### PR TITLE
Disable images in excerpt

### DIFF
--- a/pelican/themes/notmyidea/static/css/main.css
+++ b/pelican/themes/notmyidea/static/css/main.css
@@ -355,7 +355,7 @@ img.left, figure.left {float: right; margin: 0 0 2em 2em;}
 }
 li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 #content > .hentry {padding: 1em 0;}
-
+.hentry img{display : none ;}
 .entry-title {font-size: 3em; margin-bottom: 10px; margin-top: 0;}
 .entry-title a:link, .entry-title a:visited {text-decoration: none; color: #333;}
 .entry-title a:visited {background-color: #fff;}


### PR DESCRIPTION
I found a problem with images with onmyidea theme. I didn't modify my theme to let you see.

On my homepage : http://freeculture.homelinux.com, in the excerpt zone, you can the than one image is larger than the excerpt, and comes on the following excerpt area.

I think the best thing to do is to disable them. I didn't modified my theme to let you see the problem.
