### PR TITLE
Put RSS Feed as optional in brownstone template

### DIFF
--- a/pelican/themes/brownstone/templates/base.html
+++ b/pelican/themes/brownstone/templates/base.html
@@ -18,7 +18,9 @@ Released   : 20100928
 <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
 <link href="{{ SITEURL }}/theme/css/style.css" rel="stylesheet" type="text/css" media="screen" />
 <link href="{{ SITEURL }}/{{ FEED }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} ATOM Feed" />
+{% if FEED_RSS %}
 <link href="{{ SITEURL }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
+{% endif %}
 </head>
 <body>
 <div id="wrapper">


### PR DESCRIPTION
I had forgotten an %if block in base.html.

Fixed
