### PR TITLE
Unbound property "summary" results in problems

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -58,7 +58,7 @@ class Page(object):
             self.locale_date = self.date.strftime(self.date_format.encode('ascii','xmlcharrefreplace')).decode('utf')
 
         if not hasattr(self, 'summary'):
-            self.summary = property(lambda self: truncate_html_words(self.content, 50))
+            self.summary = property(lambda self: truncate_html_words(self.content, 50)).__get__(self, Page)
 
         # store the settings ref.
         self._settings = settings


### PR DESCRIPTION
The commit ec06e6ed9590f0d7dbaff9a5f4b58cf94136a1fb moves the summary property from being defined at the class-level to being defined at instance-level.

This introduces a "subtle" bug as the property object never gets bound to the Page instance, which prevents it from dispatching the intended function. Instead, it will just [return itself](http://users.rcn.com/python/download/Descriptor.htm#properties) from its `__get__` method.

My commit makes sure that the summary-property gets bound properly.

Cheers! :)
