### PR TITLE
Fix internal linkref for allow TOC

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -201,7 +201,7 @@ class Writer(object):
             """
             content = input._content
 
-            hrefs = re.compile(r'<\s*[^\>]*href\s*=\s*(["\'])(.*?)\1')
+            hrefs = re.compile(r'<\s*[^\>]*href\s*=(^!#)\s*(["\'])(.*?)\1')
             srcs = re.compile(r'<\s*[^\>]*src\s*=\s*(["\'])(.*?)\1')
 
             matches = hrefs.findall(content)


### PR DESCRIPTION
Allow use of **.. contents::** directive in yours articles without break link
