### PR TITLE
fixed link to pelican homepage in the simple theme

### DIFF
--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -18,8 +18,8 @@
         {% endblock %}
         <footer id="contentinfo" class="body">
                 <address id="about" class="vcard body">
-                Proudly powered by <a
-                href="http://hg.lolnet.org/pelican/">pelican</a>, and obviously <a href="http://python.org">python</a>!
+                Proudly powered by <a href="http://docs.notmyidea.org/alexis/pelican/">pelican</a>,
+                and obviously <a href="http://python.org">python</a>!
                 </address><!-- /#about -->
         </footer><!-- /#contentinfo -->
 </body>


### PR DESCRIPTION
The link to the Pelican homepage in the simple theme was wrong; I fixed it.
