### PR TITLE
[1 line change] check only paths (i.e. not None) for being absolute when reading the settings

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -77,7 +77,7 @@ def read_settings(filename):
     # Make the paths relative to the settings file
     for path in ['PATH', 'OUTPUT_PATH']:
         if path in context:
-            if path is not None and not os.path.isabs(context[path]):
+            if context[path] is not None and not os.path.isabs(context[path]):
                 context[path] = os.path.abspath(os.path.normpath(os.path.join(os.path.dirname(filename), context[path])))
 
     # set the locale


### PR DESCRIPTION
A user on the irc at #pelican, SpaceAviator, had a problem with invoking pelican because during the process of reading the config file the default value None for path caused trouble: He got the following traceback: http://paste2.org/p/1466889. So from now on, the path is checked if it's None before it is normalized or anything else happens with it.
