### PR TITLE
Enable Markdown Extra by default in Pelican.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -103,7 +103,7 @@ class MarkdownReader(Reader):
     def read(self, filename):
         """Parse content and metadata of markdown files"""
         text = open(filename)
-        md = Markdown(extensions = ['meta', 'codehilite'])
+        md = Markdown(extensions = ['meta', 'codehilite', 'extra'])
         content = md.convert(text)
 
         metadata = {}


### PR DESCRIPTION
It is a very useful extension for those who work with Markdown instead of reStructuredText. Supports tables, abbreviations, footnotes, Inline HTML ... 
