### PR TITLE
add unicode handling for logging

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -152,7 +152,7 @@ def main():
         else:
             pelican.run()
     except Exception, e:
-        log.critical(str(e))
+        log.critical(unicode(e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I simply changed the str(e) to unicode(e)

Found this error reported in #pelican:
src/zahlen.rst:2: (WARNING/2) Duplicate explicit target name: "tagesthemen.de".
src/vollig-unkontrolliert.rst:8: (ERROR/3) Unexpected indentation.
src/um-die-geforderte-anfrage-durchzufuhren-sind-informationen-zu-ihrer-verbindung-erforderlich.rst:3: (WARNING/2) Cannot extract compound bibliographic field "date".
Traceback (most recent call last):
  File "/usr/local/bin/pelican", line 5, in <module>
    pkg_resources.run_script('pelican==2.7.1', 'pelican')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 467, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 1200, in run_script
    execfile(script_filename, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/pelican-2.7.1-py2.7.egg/EGG-INFO/scripts/pelican", line 3, in <module>
    main()
  File "/usr/local/lib/python2.7/dist-packages/pelican-2.7.1-py2.7.egg/pelican/**init**.py", line 155, in main
    log.critical(str(e))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 82: ordinal not in range(128)
