### PR TITLE
Year and month in URL. Issue #145

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -61,12 +61,18 @@ Setting name (default value)                        what does it do?
                                                     on the output path "static". By default,
                                                     pelican will copy the 'images' folder to the
                                                     output folder.
-`ARTICLE_PERMALINK_STRUCTURE` (``'/%Y/%m/'``)       Allows to render URLs for articles sorted by date, 
-                                                    in case you specify a format as specified in the 
-                                                    example. It follows the python datetime directives:
+`ARTICLE_PERMALINK_STRUCTURE` (``''``)              Empty by default. Allows to render URLs for 
+                                                    articles sorted by date, in case you specify a 
+                                                    format as specified in the example.
+                                                    It follows the python datetime directives:
                                                      * %Y: Year with century as a decimal number.
                                                      * %m: Month as a decimal number [01,12].
                                                      * %d: Day of the month as a decimal number [01,31].
+
+                                                     Note: if you specify a datetime directive, it will
+                                                     be substituted using the date metadata field into 
+                                                     the rest file. if the date is not specified, pelican
+                                                     will rely on the mtime of your file.
 
                                                      Check the python datetime documentation 
                                                      at http://bit.ly/cNcJUC for more information.
@@ -77,6 +83,12 @@ Setting name (default value)                        what does it do?
                                                      * author: '%(author)s'
                                                      * tags: '%(tags)s'
                                                      * date: '%(date)s'
+
+                                                    Example usage:
+                                                     * '/%Y/%m/' it will be something like 
+                                                       '/2011/07/sample-post.html'.
+                                                     * '/%Y/%(category)s/' it will be something like
+                                                       '/2011/life/sample-post.html'.
 ================================================    =====================================================
 
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -162,14 +162,13 @@ class ArticlesGenerator(Generator):
         article_template = self.get_template('article')
         for article in chain(self.translations, self.articles):
             add_to_url = u''
-            if self.settings.has_key('ARTICLE_PERMALINK_STRUCTURE'):
-                article_permalink_structure = self.settings.get('ARTICLE_PERMALINK_STRUCTURE')
+            if 'ARTICLE_PERMALINK_STRUCTURE' in self.settings:
+                article_permalink_structure = self.settings['ARTICLE_PERMALINK_STRUCTURE']
                 article_permalink_structure = article_permalink_structure.lstrip('/')
-                try:
-                    add_to_url = article.date.strftime(article_permalink_structure)
-                except:
-                    pass
 
+                # try to substitute any python datetime directive
+                add_to_url = article.date.strftime(article_permalink_structure)
+                # try to substitute any article metadata in rest file
                 add_to_url = add_to_url % article.__dict__
                 add_to_url = [slugify(i) for i in add_to_url.split('/')]
                 add_to_url = os.path.join(*add_to_url)

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -42,7 +42,7 @@ _DEFAULT_CONFIG = {'PATH': None,
                    'DEFAULT_METADATA': (),
                    'FILES_TO_COPY': (),
                    'DEFAULT_STATUS': 'published',
-                   'ARTICLE_PERMALINK_STRUCTURE': '/%Y/%m/'
+                   'ARTICLE_PERMALINK_STRUCTURE': ''
                    }
 
 def read_settings(filename):

--- a/samples/pelican.conf.py
+++ b/samples/pelican.conf.py
@@ -9,9 +9,6 @@ PDF_GENERATOR = False
 REVERSE_CATEGORY_ORDER = True
 LOCALE = ""
 DEFAULT_PAGINATION = 2
-# Allows to construct an url like /2011/07/sample-post.html
-# See documentation for more info.
-ARTICLE_PERMALINK_STRUCTURE = ''
 
 FEED_RSS = 'feeds/all.rss.xml'
 CATEGORY_FEED_RSS = 'feeds/%s.rss.xml'


### PR DESCRIPTION
Hello Alexis,

I have been developing the year and month in url and it seems all is working fine.

I have added a new option into the settings file called 'PERMALINK_STRUCTURE'. This option is intended to take a value like '/%Y/%m/' that it will be translated to year and month for every article. Also, the PERMALINK_STRUCTURE option can take any other string like '/blog/', '/articles/', etc.

This value will be added into the url in generators.py file. I have used generators.py and not writers.py because in writers.py i didn't find the way to move only the articles with this new structure. The archives.html, tags.html, etc; were moved in too.

My intention is to use this structure with articles. See the following tree directory:

output/
├── 2010
│   ├── 10
│   │   ├── oh-yeah.html
│   │   └── unbelievable.html
│   └── 12
│       └── this-is-a-super-article.html
├── 2011
│   ├── 02
│   │   ├── article-1.html
│   │   ├── article-2.html
│   │   └── article-3.html
│   ├── 04
│   │   └── a-markdown-powered-article.html
│   └── 07
│       └── oh-yeah-fr.html
├── archives.html
├── author
│   └── Alexis M\303\251taireau.html
├── categories.html
├── category
│   ├── bar.html
...

Also, I have modified the article.html template, changing the article.url variable to pagename that is a Jinja2 variable that takes the url for the actual page.

Thanks in advance and best regards,
Manuel Viera.
