### PR TITLE
improvements for importers

### DIFF
--- a/docs/importer.rst
+++ b/docs/importer.rst
@@ -1,0 +1,56 @@
+=================================
+ Import from other blog software
+=================================
+
+Description
+===========
+
+``importer.py`` is a command line tool for converting articles from other
+software to ReStructuredText. The supported formats are:
+
+- Wordpress XML export
+- Dotclear export
+- RSS/ATOM feed
+
+The conversion from HTML to ReStructuredText relies on `pandoc
+<http://johnmacfarlane.net/pandoc/>`_. For Dotclear, if the source posts are
+written with Markdown syntax, they will not be converted (as Pelican also
+supports Markdown).
+
+Usage
+"""""
+
+| importer.py [-h] [--wpfile] [--dotclear] [--feed] [-o OUTPUT]
+|                    [--dir-cat]
+|                    input
+
+Optional arguments:
+"""""""""""""""""""
+
+  -h, --help            show this help message and exit
+  --wpfile              Wordpress XML export
+  --dotclear            Dotclear export
+  --feed                Feed to parse
+  -o OUTPUT, --output OUTPUT
+                        Output path
+  --dir-cat             Put files in directories with categories name
+
+Examples
+========
+
+for Wordpress::
+
+    $ python2 tools/importer.py --wpfile -o ~/output ~/posts.xml
+
+for Dotclear::
+
+    $ python2 tools/importer.py --dotclear -o ~/output ~/backup.txt
+
+
+Tests
+=====
+
+To test the module, one can use sample files:
+
+- for Wordpress: http://wpcandy.com/made/the-sample-post-collection
+- for Dotclear: http://themes.dotaddict.org/files/public/downloads/lorem-backup.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,8 +42,8 @@ If you want to see new features in Pelican, dont hesitate to tell me, to clone
 the repository, etc. That's open source, dude!
 
 Contact me at "alexis at notmyidea dot org" for any request/feedback! You can
-also join the team at `#pelican on irc.freenode.org 
-<irc://irc.freenode.net/pelican>`_ 
+also join the team at `#pelican on irc.freenode.org
+<irc://irc.freenode.net/pelican>`_
 (or if you don't have any IRC client, using `the webchat
 <http://webchat.freenode.net/?channels=pelican&uio=d4>`_)
 for quick feedback.
@@ -55,11 +55,12 @@ A french version of the documentation is available at :doc:`fr/index`.
 
 .. toctree::
    :maxdepth: 2
-   
+
    getting_started
    settings
    themes
    internals
    pelican-themes
+   importer
    faq
    contribute

--- a/tools/importer.py
+++ b/tools/importer.py
@@ -214,8 +214,8 @@ def main(input_type, input, output_path, dircat=False):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-            description="Transform even feed or XML files to rst files."
-                    "Be sure to have pandoc installed")
+            description="Transform feed, Wordpress or Dotclear files to rst files."
+                        "Be sure to have pandoc installed")
 
     parser.add_argument(dest='input', help='The input file to read')
     parser.add_argument('--wpfile', action='store_true', dest='wpfile',
@@ -223,7 +223,7 @@ if __name__ == '__main__':
     parser.add_argument('--dotclear', action='store_true', dest='dotclear',
             help='Dotclear export')
     parser.add_argument('--feed', action='store_true', dest='feed',
-            help='feed to parse')
+            help='Feed to parse')
     parser.add_argument('-o', '--output', dest='output', default='output',
             help='Output path')
     parser.add_argument('--dir-cat', action='store_true', dest='dircat',
@@ -238,6 +238,6 @@ if __name__ == '__main__':
     elif args.feed:
         input_type = 'feed'
     else:
-        print "you must provide either --wpfile or --feed options"
+        print "you must provide either --wpfile, --dotclear or --feed options"
         exit()
     main(input_type, args.input, args.output, dircat=args.dircat)


### PR DESCRIPTION
following the merge of the dotclear importer https://github.com/ametaireau/pelican/commit/d77f657aa757644e30d7e1f26af9d61692b6de23#commitcomment-490886 , here are some improvements :
- for dotclear: remove seconds in date, remove additionnal \\n
- fix categories for wordpress (categories is a list a string)
- refactor a bit the code between markdown and rst
- add an option to put files in directories with category names 
- add documentation
