### PR TITLE
Allow overriding reader extensions.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,6 +46,10 @@ Setting name (default value)                        what does it do?
 `MARKUP` (``('rst', 'md')``)                        A list of available markup languages you want
                                                     to use. For the moment, only available values
                                                     are `rst` and `md`.
+`MD_EXTENSIONS` (``('codehilite','extra')``)        A list of the extensions that the markdown processor
+                                                    will use. Refer to the extensions chapter in the
+                                                    Python-Markdown documentation for a complete list of
+                                                    supported extensions.
 `OUTPUT_PATH` (``'output/'``)                       Where to output the generated files.
 `PATH` (``None``)                                   path to look at for input files.
 `PDF_GENERATOR` (``False``)                         Set to True if you want to have PDF versions

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -211,7 +211,7 @@ class ArticlesGenerator(Generator):
         files = self.get_files(self.path, exclude=['pages',])
         all_articles = []
         for f in files:
-            content, metadata = read_file(f)
+            content, metadata = read_file(f, settings=self.settings)
 
             # if no category is set, use the name of the path as a category
             if 'category' not in metadata.keys():


### PR DESCRIPTION
The promised redo of pull request #148.

> This adds an extensions setting all readers in the style of `[ext]_EXTENSIONS`. So for the MarkdownReader, who's extension is "md", the setting read is `MD_EXTENSIONS`.
> 
> The settings allow overriding the default options passed through the readers. In the case of Markdown the default values are `['codehilite','extra']`, but user may change this through the setting:
> 
> `MD_EXTENSIONS = ['footnotes','abbr','codehilite']`

In addition to fixing the issues with the earlier pull, I have changed this to only affect Markdown. This is because the Rst reader doesn't actually have any extensions, but Markdown has _extra params_ (as the settings `output_format` and `extension_configs`). We should add support for altering these at some point but I didn't wan't to confuse the two. It would cause trouble later on if we were mixing settings and extensions for readers when we hit a case where we want both.
