### PR TITLE
checks if pdf_path exists before trying to create pdf_path

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -392,11 +392,12 @@ class PdfGenerator(Generator):
         # since we write our own files
         info(u' Generating PDF files...')
         pdf_path = os.path.join(self.output_path, 'pdf')
-        try:
-            os.mkdir(pdf_path)
-        except OSError:
-            error("Couldn't create the pdf output folder in " + pdf_path)
-            pass
+        if not os.path.exists(pdf_path):
+            try:
+                os.mkdir(pdf_path)
+            except OSError:
+                error("Couldn't create the pdf output folder in " + pdf_path)
+                pass
 
         for article in self.context['articles']:
             self._create_pdf(article, pdf_path)


### PR DESCRIPTION
Updated it to check if the pdf_path already exists before trying to create it. It will always generate an OSError if the folder already exists after running it the first time, even if it has the appropriate permissions.
