### PR TITLE
Fixing URLs relativization in summary (done the right way)

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -84,10 +84,6 @@ class Page(object):
             else:
                 self.locale_date = self.date.strftime(self.date_format.encode('ascii','xmlcharrefreplace')).decode('utf')
         
-        # manage summary
-        if not hasattr(self, 'summary'):
-            self.summary = property(lambda self: truncate_html_words(self.content, 50)).__get__(self, Page)
-
         # manage status
         if not hasattr(self, 'status'):
             self.status = settings['DEFAULT_STATUS']
@@ -106,6 +102,9 @@ class Page(object):
             content = self._content
         return content
 
+    @property
+    def summary(self):
+        return truncate_html_words(self.content, 50)
 
 class Article(Page):
     mandatory_properties = ('title', 'date', 'category')


### PR DESCRIPTION
URLs in summary where not relativized. 

This impacted for instance the index page where the "Other articles" summaries contain broken URLs.

The previous fix was complex and broken. Now I've chosen to make summary a property so that (if I understand correctly the internals of pelican) the access to article content is deferred to the moment in which the writer has already relativized the URLs.
