### PR TITLE
Add <guid> to RSS xml.

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -34,6 +34,7 @@ class Writer(object):
         feed.add_item(
             title=item.title,
             link='%s/%s' % (self.site_url, item.url),
+            unique_id='%s/%s' % (self.site_url, item.url),
             description=item.content,
             categories=item.tags if hasattr(item, 'tags') else None,
             author_name=getattr(item, 'author', 'John Doe'),


### PR DESCRIPTION
Hello, this is the patch for https://github.com/ametaireau/pelican/issues/189, I think it might help other users.

Reason:

```
Without <guid> tag in RSS XML, some RSS reader will show all
items in RSS as unread item.
```
