### PR TITLE
Small modifications on the Mardkown reader

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -99,12 +99,12 @@ class RstReader(Reader):
 class MarkdownReader(Reader):
     enabled = bool(Markdown)
     extension = "md"
-    extensions = ['codehilite', 'extra']
+    extensions = ['codehilite', 'extra', 'meta']
 
     def read(self, filename):
         """Parse content and metadata of markdown files"""
         text = open(filename)
-        md = Markdown(extensions=set(self.extensions + ['meta']))
+        md = Markdown(extensions=self.extensions)
         content = md.convert(text)
 
         metadata = {}


### PR DESCRIPTION
Hello,

I've planned to modify the Markdown reader to make it get the title from the Markdown source if not found in metadatas…

Sadly, it seems to be impossible to do without re-parsing the output of the Markdown parser with an HTML parser, and that would be too heavy...

Anyway, i've made a small modification of the Markdown reader to simplify a bit the code :-)
