### PR TITLE
Changing LOCALE according to lang of current page in DATE_FORMAT

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -5,6 +5,7 @@ from pelican.settings import _DEFAULT_CONFIG
 from datetime import datetime
 from os import getenv
 from sys import platform, stdin
+import locale
 
 class Page(object):
     """Represents a page
@@ -85,6 +86,10 @@ class Page(object):
             else:
                 self.date_format = settings['DEFAULT_DATE_FORMAT']
 
+	if isinstance(self.date_format, tuple):
+		locale.setlocale(locale.LC_ALL, self.date_format[0])
+		self.date_format = self.date_format[1]
+	
         if hasattr(self, 'date'):
             if platform == 'win32':
                 self.locale_date = self.date.strftime(self.date_format.encode('ascii','xmlcharrefreplace')).decode(stdin.encoding)


### PR DESCRIPTION
As I wrote in #213

If self.data_format is a tuple, then it will override current locale using self.data_format[0] . This fix should not break any existing configure file.

My settings now:

``` python
DATE_FORMATS = {
    'en':('usa','%a, %d %b %Y'),
    'zh':('chs','%Y-%m-%d, %a'),
    'jp':('jpn','%Y/%m/%d (%a)'),
}
```

Which generate a date like this in English page:
    Fri, 24 Feb 2012
And like this in Japanese page:
    2012/02/24 (金)
