### PR TITLE
Make sure test passes for dates formatted as utf-8

### DIFF
--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -82,7 +82,8 @@ class TestPage(TestCase):
         page_kwargs['metadata']['date'] = dt
         page = Page( **page_kwargs)
 
-        self.assertEqual(page.locale_date, dt.strftime(_DEFAULT_CONFIG['DEFAULT_DATE_FORMAT']))
+        self.assertEqual(page.locale_date,
+            unicode(dt.strftime(_DEFAULT_CONFIG['DEFAULT_DATE_FORMAT']), 'utf-8'))
 
 
         page_kwargs['settings'] = {x:_DEFAULT_CONFIG[x] for x in _DEFAULT_CONFIG}


### PR DESCRIPTION
On my system, test "If DATETIME is set to a tuple, it should be used to override LOCALE" fails:
# 

FAIL: test_datetime (tests.test_contents.TestPage)
## If DATETIME is set to a tuple, it should be used to override LOCALE

Traceback (most recent call last):
  File "/home/meir/devel/Projects/pelican/pelican/tests/test_contents.py", line 85, in test_datetime
    self.assertEqual(page.locale_date, dt.strftime(_DEFAULT_CONFIG['DEFAULT_DATE_FORMAT']))
AssertionError: u"\u05d0' 13 \u05e1\u05e4\u05d8\u05de\u05d1\u05e8 2015" != "\xd7\x90' 13 \xd7\xa1\xd7\xa4\xd7\x98\xd7\x9e\xd7\x91\xd7\xa8 2015"

---

Ran 11 tests in 0.034s

FAILED (failures=1)

They are actually the same if the utf-8 string is converted unicode (as it should, since page.locale_date is unicode by itself).
