### PR TITLE
Removed small errors in pelican-quickstart

### DIFF
--- a/tools/pelican_quickstart.py
+++ b/tools/pelican_quickstart.py
@@ -40,7 +40,7 @@ html: clean $$(OUTPUTDIR)/index.html
 \t@echo 'Done'
 
 $$(OUTPUTDIR)/%.html:
-\t$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE)
+\t$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)
 
 clean:
 \trm -fr $$(OUTPUTDIR)
@@ -94,7 +94,7 @@ DEFAULT_PAGINATION = $default_pagination
 
 CONF = {
     'pelican' : 'pelican',
-    'pelicanopts' : None,
+    'pelicanopts' : '',
     'basedir': '.',
     'ftp_host': 'localhost',
     'ftp_user': 'anonymous',
@@ -103,7 +103,7 @@ CONF = {
     'ssh_user': 'root',
     'ssh_target_dir': '/var/www',
     'dropbox_dir' : '~/Dropbox/Public/',
-    'default_pagination' : 7,
+    'default_pagination' : 10,
     'lang': 'en'
 }
 


### PR DESCRIPTION
Hello,

I've fixed a small bug in `pelican-quickstart`: the `PELICANOPTS` variable was set to `"None"` instead of an empty string and was not used
