### PR TITLE
Do not create feeds when their filenames are set to None.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -199,7 +199,6 @@ Pelican generates category feeds as well as feeds for all your articles. It does
 not generate feeds for tags by default, but it is possible to do so using
 the ``TAG_FEED`` and ``TAG_FEED_RSS`` settings:
 
-
 ================================================    =====================================================
 Setting name (default value)                        What does it do?
 ================================================    =====================================================
@@ -213,6 +212,9 @@ Setting name (default value)                        What does it do?
 `FEED_MAX_ITEMS`                                    Maximum number of items allowed in a feed. Feed item
                                                     quantity is unrestricted by default.
 ================================================    =====================================================
+
+If you don't want to generate some of these feeds, set ``None`` to the
+variables above.
 
 .. [2] %s is the name of the category.
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -118,41 +118,46 @@ class ArticlesGenerator(Generator):
     def generate_feeds(self, writer):
         """Generate the feeds from the current context, and output files."""
 
-        writer.write_feed(self.articles, self.context, self.settings['FEED'])
-
-        if 'FEED_RSS' in self.settings:
+        if self.settings.get('FEED'):
             writer.write_feed(self.articles, self.context,
-                    self.settings['FEED_RSS'], feed_type='rss')
+                              self.settings['FEED'])
+
+        if self.settings.get('FEED_RSS'):
+            writer.write_feed(self.articles, self.context,
+                              self.settings['FEED_RSS'], feed_type='rss')
 
         for cat, arts in self.categories:
             arts.sort(key=attrgetter('date'), reverse=True)
-            writer.write_feed(arts, self.context,
-                              self.settings['CATEGORY_FEED'] % cat)
-
-            if 'CATEGORY_FEED_RSS' in self.settings:
+            if self.settings.get('CATEGORY_FEED'):
                 writer.write_feed(arts, self.context,
-                        self.settings['CATEGORY_FEED_RSS'] % cat,
-                        feed_type='rss')
+                                  self.settings['CATEGORY_FEED'] % cat)
 
-        if 'TAG_FEED' in self.settings:
+            if self.settings.get('CATEGORY_FEED_RSS'):
+                writer.write_feed(arts, self.context,
+                                  self.settings['CATEGORY_FEED_RSS'] % cat,
+                                  feed_type='rss')
+
+        if self.settings.get('TAG_FEED') or self.settings.get('TAG_FEED_RSS'):
             for tag, arts in self.tags.items():
                 arts.sort(key=attrgetter('date'), reverse=True)
-                writer.write_feed(arts, self.context,
-                        self.settings['TAG_FEED'] % tag)
+                if self.settings.get('TAG_FEED'):
+                    writer.write_feed(arts, self.context,
+                                      self.settings['TAG_FEED'] % tag)
 
-                if 'TAG_FEED_RSS' in self.settings:
+                if self.settings.get('TAG_FEED_RSS'):
                     writer.write_feed(arts, self.context,
                                       self.settings['TAG_FEED_RSS'] % tag,
                                       feed_type='rss')
 
-        translations_feeds = defaultdict(list)
-        for article in chain(self.articles, self.translations):
-            translations_feeds[article.lang].append(article)
+        if self.settings.get('TRANSLATION_FEED'):
+            translations_feeds = defaultdict(list)
+            for article in chain(self.articles, self.translations):
+                translations_feeds[article.lang].append(article)
 
-        for lang, items in translations_feeds.items():
-            items.sort(key=attrgetter('date'), reverse=True)
-            writer.write_feed(items, self.context,
-                              self.settings['TRANSLATION_FEED'] % lang)
+            for lang, items in translations_feeds.items():
+                items.sort(key=attrgetter('date'), reverse=True)
+                writer.write_feed(items, self.context,
+                                  self.settings['TRANSLATION_FEED'] % lang)
 
     def generate_pages(self, writer):
         """Generate the pages on the disk"""

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import with_statement
+try:
+    from unittest2 import TestCase
+except ImportError, e:
+    from unittest import TestCase
+
+from pelican.generators import ArticlesGenerator
+from pelican.settings import _DEFAULT_CONFIG
+
+class TestArticlesGenerator(TestCase):
+
+    def test_generate_feeds(self):
+
+        class FakeWriter(object):
+            def __init__(self):
+                self.called = False
+
+            def write_feed(self, *args, **kwargs):
+                self.called = True
+
+        generator = ArticlesGenerator(None, {'FEED': _DEFAULT_CONFIG['FEED']},
+                                      None, _DEFAULT_CONFIG['THEME'], None,
+                                      None)
+        writer = FakeWriter()
+        generator.generate_feeds(writer)
+        assert writer.called, ("The feed should be written, "
+                               "if settings['FEED'] is specified.")
+
+        generator = ArticlesGenerator(None, {'FEED': None}, None,
+                                      _DEFAULT_CONFIG['THEME'], None, None)
+        writer = FakeWriter()
+        generator.generate_feeds(writer)
+        assert not writer.called, ("If settings['FEED'] is None, "
+                                   "the feed should not be generated.")
+


### PR DESCRIPTION
Feed generation fails when CATEGORY_FEED is None.

I can see that [the document](http://pelican.notmyidea.org/en/latest/settings.html#feed-settings) says feeds are not generated if you write `CATEGORY_FEED = None` in your settings. But when I do so, pelican command fails and says `CRITICAL: unsupported operand type(s) for %: 'NoneType' and 'Category'`. This commit will fix that.
