### PR TITLE
Double-quote HTML attribute

### DIFF
--- a/pelican/themes/notmyidea/templates/archives.html
+++ b/pelican/themes/notmyidea/templates/archives.html
@@ -6,7 +6,7 @@
 <dl>
 {% for article in dates %}
     <dt>{{ article.locale_date }}</dt>
-    <dd><a href='{{ article.url }}'>{{ article.title }}</a></dd>
+    <dd><a href="{{ article.url }}">{{ article.title }}</a></dd>
 {% endfor %}
 </dl>
 </section>

--- a/pelican/themes/simple/templates/archives.html
+++ b/pelican/themes/simple/templates/archives.html
@@ -5,7 +5,7 @@
 <dl>
 {% for article in dates %}
     <dt>{{ article.locale_date }}</dt>
-    <dd><a href='{{ article.url }}'>{{ article.title }}</a></dd>
+    <dd><a href="{{ article.url }}">{{ article.title }}</a></dd>
 {% endfor %}
 </dl>
 {% endblock %}


### PR DESCRIPTION
Double-quote HTML attribute in archives page in themes, so that style matches rest of the pages in themes.
