### PR TITLE
- remove default=None with argparse is redundant since it's the

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -135,7 +135,8 @@ class Pelican(object):
 
 def main():
     parser = argparse.ArgumentParser(description="""A tool to generate a
-    static blog, with restructured text input files.""")
+    static blog, with restructured text input files.""",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument(dest='path', nargs='?',
         help='Path where to find the content files.')
@@ -145,11 +146,11 @@ def main():
     parser.add_argument('-o', '--output', dest='output',
         help='Where to output the generated files. If not specified, a '
              'directory will be created, named "output" in the current path.')
-    parser.add_argument('-m', '--markup', default=None, dest='markup',
+    parser.add_argument('-m', '--markup', dest='markup',
         help='The list of markup language to use (rst or md). Please indicate '
              'them separated by commas.')
-    parser.add_argument('-s', '--settings', dest='settings', default='',
-        help='The settings of the application. Default to False.')
+    parser.add_argument('-s', '--settings', dest='settings',
+        help='The settings of the application.')
     parser.add_argument('-d', '--delete-output-directory',
                         dest='delete_outputdir',
         action='store_true', help='Delete the output directory.')

--- a/tools/pelican_import.py
+++ b/tools/pelican_import.py
@@ -234,7 +234,8 @@ def fields2pelican(fields, out_markup, output_path, dircat=False):
 def main():
     parser = argparse.ArgumentParser(
         description="Transform feed, Wordpress or Dotclear files to rst files."
-            "Be sure to have pandoc installed")
+            "Be sure to have pandoc installed",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument(dest='input', help='The input file to read')
     parser.add_argument('--wpfile', action='store_true', dest='wpfile',

--- a/tools/pelican_quickstart.py
+++ b/tools/pelican_quickstart.py
@@ -193,14 +193,16 @@ def ask(question, answer=str, default=None, l=None):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="A kickstarter for pelican")
+    parser = argparse.ArgumentParser(
+        description="A kickstarter for pelican",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-p', '--path', default=".",
             help="The path to generate the blog into")
-    parser.add_argument('-t', '--title', default=None, metavar="title",
+    parser.add_argument('-t', '--title', metavar="title",
             help='Set the title of the website')
-    parser.add_argument('-a', '--author', default=None, metavar="author",
+    parser.add_argument('-a', '--author', metavar="author",
             help='Set the author name of the website')
-    parser.add_argument('-l', '--lang', default=None, metavar="lang",
+    parser.add_argument('-l', '--lang', metavar="lang",
             help='Set the default lang of the website')
 
     args = parser.parse_args()


### PR DESCRIPTION
default value already.
- use the argparse.ArgumentDefaultsHelpFormatter as the
  formatter_class, to print out automatically the default values

I'm not 100% sure that the helpformatter was also in 2.6, downloading now to check, otherwise I think
there aren't any problems and the output is much nicer.

Something like this:
   -d, --delete-output-directory
                        Delete the output directory. (default: False)
  -v, --verbose         Show all messages. (default: None)
