### PR TITLE
`MD_EXTENSIONS` should be a list not a tuple.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -46,7 +46,7 @@ Setting name (default value)                        What does it do?
 `MARKUP` (``('rst', 'md')``)                        A list of available markup languages you want
                                                     to use. For the moment, the only available values
                                                     are `rst` and `md`.
-`MD_EXTENSIONS` (``('codehilite','extra')``)        A list of the extensions that the Markdown processor
+`MD_EXTENSIONS` (``['codehilite','extra']``)        A list of the extensions that the Markdown processor
                                                     will use. Refer to the extensions chapter in the
                                                     Python-Markdown documentation for a complete list of
                                                     supported extensions.


### PR DESCRIPTION
If you set `MD_EXTENSIONS` in your config file as a tuple, it throws an error, eg:

``` python
MD_EXTENSIONS = (
    'codehilite',
    'toc',
    'extra',
)
```

It should be a list:

``` python
MD_EXTENSIONS = 
    'codehilite',
    'toc',
    'extra',
]
```

Updated docs to reflect that.
