### PR TITLE
Dev req

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,0 @@
-unittest2
-mock

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
-#!/usr/bin/env python
+import sys
+
 from setuptools import setup
 
 requires = ['feedgenerator', 'Jinja2', 'Pygments', 'docutils', 'pytz']
 
-try:
-    import argparse
-except ImportError:
-    requires.append('argparse')
+tests_require = ['mock', 'nose']
+
+if sys.version < '2.7':
+    tests_require.append('unittest2')
 
 entry_points = {
     'console_scripts': [
@@ -28,6 +29,8 @@ setup(
     packages = ['pelican', 'pelican.tools'],
     include_package_data = True,
     install_requires = requires,
+    tests_require = tests_require,
+    test_suite = 'nose.collector',
     entry_points = entry_points,
     classifiers = ['Development Status :: 5 - Production/Stable',
                    'Environment :: Console',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,7 +8,7 @@ from os.path import dirname, abspath, join
 from pelican.settings import read_settings, _DEFAULT_CONFIG
 
 
-class TestSettingsFromFile(unittest2.TestCase):
+class TestSettingsFromFile(unittest.TestCase):
     """Providing a file, it should read it, replace the default values and
     append new values to the settings, if any
     """


### PR DESCRIPTION
I've tried to move more knowledge in setup.py removing the dev_requirements file..
Now we can set up a virtualenv and then running
_python setup.py develop_ will install all the needed dependencies.

Running _python setup.py test_ will also install nose, mock and unittest2 if needed.

I didn't really find a solution for the
try:
   import unittest2

thing yet, not sure if we can avoid it..

Let me know if it makes sense,
cheers!
