### PR TITLE
Clean up testing modules

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -1,8 +1,19 @@
+__all__ = [
+    'temporary_folder',
+    'get_article',
+    'unittest',
+]
+
 from contextlib import contextmanager
 from tempfile import mkdtemp
 from shutil import rmtree
 
 from pelican.contents import Article
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 @contextmanager

--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
-try:
-    from unittest2 import TestCase, skip
-except ImportError, e:
-    from unittest import TestCase, skip  # NOQA
+
+from .support import unittest
 
 from pelican.contents import Page
 from pelican.settings import _DEFAULT_CONFIG
@@ -14,7 +11,8 @@ from jinja2.utils import generate_lorem_ipsum
 TEST_CONTENT = str(generate_lorem_ipsum(n=1))
 TEST_SUMMARY = generate_lorem_ipsum(n=1, html=False)
 
-class TestPage(TestCase):
+
+class TestPage(unittest.TestCase):
 
     def setUp(self):
         super(TestPage, self).setUp()
@@ -117,7 +115,6 @@ class TestPage(TestCase):
         try:
             page = Page(**page_kwargs)
             self.assertEqual(page.locale_date, u'2015-09-13(\u65e5)')
-            # above is unicode in Japanese: 2015-09-13(“ú)
         except locale_module.Error:
             # The constructor of ``Page`` will try to set the locale to
             # ``ja_JP.utf8``. But this attempt will failed when there is no
@@ -126,4 +123,4 @@ class TestPage(TestCase):
             #
             # Until we find some other method to test this functionality, we
             # will simply skip this test.
-            skip("There is no locale %s in this system." % locale)
+            unittest.skip("There is no locale %s in this system." % locale)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError, e:
-    import unittest  # NOQA
+
+from mock import MagicMock
 
 from pelican.generators import ArticlesGenerator
 from pelican.settings import _DEFAULT_CONFIG
-
-from mock import MagicMock
+from .support import unittest
 
 
 class TestArticlesGenerator(unittest.TestCase):

--- a/tests/test_pelican.py
+++ b/tests/test_pelican.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from support import temporary_folder
+from .support import temporary_folder
 
 from pelican import Pelican
 from pelican.settings import read_settings

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,13 +1,10 @@
 # coding: utf-8
-try:
-    import unittest2 as unittest
-except ImportError, e:
-    import unittest
 
 import datetime
 import os
 
 from pelican import readers
+from .support import unittest
 
 CUR_DIR = os.path.dirname(__file__)
 CONTENT_PATH = os.path.join(CUR_DIR, 'content')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,14 +1,10 @@
-try:
-    import unittest2
-except ImportError, e:
-    import unittest as unittest2
-
 from os.path import dirname, abspath, join
 
 from pelican.settings import read_settings, _DEFAULT_CONFIG
+from .support import unittest
 
 
-class TestSettingsFromFile(unittest2.TestCase):
+class TestSettingsFromFile(unittest.TestCase):
     """Providing a file, it should read it, replace the default values and
     append new values to the settings, if any
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,10 @@
 # -*- coding: utf-8 -*-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest  # NOQA
-
 import os
 import datetime
 import time
 
 from pelican import utils
-from support import get_article
+from .support import get_article, unittest
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
- move the try/except dance in support.py
- use relative . imports in test files
- remove the "future with import", since python < 2.6 is not supported
