### PR TITLE
change the way logging is done, using the standard log tree instead of

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -1,19 +1,23 @@
-import argparse
 import os
-import sys
 import re
+import sys
 import time
+import logging
+import argparse
 
 from pelican.generators import (ArticlesGenerator, PagesGenerator,
         StaticGenerator, PdfGenerator)
+from pelican.log import init
 from pelican.settings import read_settings, _DEFAULT_CONFIG
 from pelican.utils import clean_output_dir, files_changed
 from pelican.writers import Writer
-from pelican import log
 
 __major__ = 3
 __minor__ = 0
 __version__ = "{0}.{1}".format(__major__, __minor__)
+
+
+logger = logging.getLogger(__name__)
 
 
 class Pelican(object):
@@ -57,7 +61,7 @@ class Pelican(object):
     def _handle_deprecation(self):
 
         if self.settings.get('CLEAN_URLS', False):
-            log.warning('Found deprecated `CLEAN_URLS` in settings. Modifing'
+            logger.warning('Found deprecated `CLEAN_URLS` in settings. Modifing'
                         ' the following settings for the same behaviour.')
 
             self.settings['ARTICLE_URL'] = '{slug}/'
@@ -67,10 +71,10 @@ class Pelican(object):
 
             for setting in ('ARTICLE_URL', 'ARTICLE_LANG_URL', 'PAGE_URL',
                             'PAGE_LANG_URL'):
-                log.warning("%s = '%s'" % (setting, self.settings[setting]))
+                logger.warning("%s = '%s'" % (setting, self.settings[setting]))
 
         if self.settings.get('ARTICLE_PERMALINK_STRUCTURE', False):
-            log.warning('Found deprecated `ARTICLE_PERMALINK_STRUCTURE` in'
+            logger.warning('Found deprecated `ARTICLE_PERMALINK_STRUCTURE` in'
                         ' settings.  Modifing the following settings for'
                         ' the same behaviour.')
 
@@ -91,7 +95,7 @@ class Pelican(object):
                             'PAGE_LANG_SAVE_AS'):
                 self.settings[setting] = os.path.join(structure,
                                                       self.settings[setting])
-                log.warning("%s = '%s'" % (setting, self.settings[setting]))
+                logger.warning("%s = '%s'" % (setting, self.settings[setting]))
 
     def run(self):
         """Run the generators and return"""
@@ -157,13 +161,13 @@ def main():
                         dest='delete_outputdir',
         action='store_true', help='Delete the output directory.')
     parser.add_argument('-v', '--verbose', action='store_const',
-                        const=log.INFO, dest='verbosity',
+                        const=logging.INFO, dest='verbosity',
                         help='Show all messages.')
     parser.add_argument('-q', '--quiet', action='store_const',
-                        const=log.CRITICAL, dest='verbosity',
+                        const=logging.CRITICAL, dest='verbosity',
                         help='Show only critical errors.')
     parser.add_argument('-D', '--debug', action='store_const',
-                        const=log.DEBUG, dest='verbosity',
+                        const=logging.DEBUG, dest='verbosity',
                         help='Show all message, including debug messages.')
     parser.add_argument('--version', action='version', version=__version__,
             help='Print the pelican version and exit.')
@@ -173,7 +177,7 @@ def main():
                              " on the content files.")
     args = parser.parse_args()
 
-    log.init(args.verbosity)
+    init(args.verbosity)
     # Split the markup languages only if some have been given. Otherwise,
     # populate the variable with None.
     markup = [a.strip().lower() for a in args.markup.split(',')]\
@@ -207,9 +211,9 @@ def main():
         else:
             pelican.run()
     except Exception, e:
-        log.critical(unicode(e))
+        logger.critical(unicode(e))
 
-        if (args.verbosity == log.DEBUG):
+        if (args.verbosity == logging.DEBUG):
             raise
         else:
             sys.exit(getattr(e, 'exitcode', 1))

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
+import locale
+import logging
+import functools
+
 from datetime import datetime
 from os import getenv
 from sys import platform, stdin
-import functools
-import locale
 
-from pelican.log import warning, error
+
 from pelican.settings import _DEFAULT_CONFIG
 from pelican.utils import slugify, truncate_html_words
 
+
+logger = logging.getLogger(__name__)
 
 class Page(object):
     """Represents a page
@@ -44,7 +48,7 @@ class Page(object):
             else:
                 title = filename.decode('utf-8') if filename else self.title
                 self.author = Author(getenv('USER', 'John Doe'), settings)
-                warning(u"Author of `{0}' unknown, assuming that his name is "
+                logger.warning(u"Author of `{0}' unknown, assuming that his name is "
                          "`{1}'".format(title, self.author))
 
         # manage languages
@@ -200,6 +204,6 @@ def is_valid_content(content, f):
         content.check_properties()
         return True
     except NameError, e:
-        error(u"Skipping %s: impossible to find informations about '%s'"\
+        logger.error(u"Skipping %s: impossible to find informations about '%s'"\
                 % (f, e))
         return False

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-import datetime
 import math
 import random
+import logging
+import datetime
 
 from collections import defaultdict
 from functools import partial
@@ -13,9 +14,11 @@ from jinja2 import Environment, FileSystemLoader, PrefixLoader, ChoiceLoader
 from jinja2.exceptions import TemplateNotFound
 
 from pelican.contents import Article, Page, Category, is_valid_content
-from pelican.log import warning, error, debug, info
 from pelican.readers import read_file
 from pelican.utils import copy, process_translations, open
+
+
+logger = logging.getLogger(__name__)
 
 
 class Generator(object):
@@ -47,7 +50,7 @@ class Generator(object):
             extensions=self.settings.get('JINJA_EXTENSIONS', []),
         )
 
-        debug('template list: {0}'.format(self._env.list_templates()))
+        logger.debug('template list: {0}'.format(self._env.list_templates()))
 
         # get custom Jinja filters from user settings
         custom_filters = self.settings.get('JINJA_FILTERS', {})
@@ -223,7 +226,7 @@ class ArticlesGenerator(Generator):
             try:
                 content, metadata = read_file(f, settings=self.settings)
             except Exception, e:
-                warning(u'Could not process %s\n%s' % (f, str(e)))
+                logger.warning(u'Could not process %s\n%s' % (f, str(e)))
                 continue
 
             # if no category is set, use the name of the path as a category
@@ -326,7 +329,7 @@ class PagesGenerator(Generator):
             try:
                 content, metadata = read_file(f)
             except Exception, e:
-                error(u'Could not process %s\n%s' % (f, str(e)))
+                logger.error(u'Could not process %s\n%s' % (f, str(e)))
                 continue
             page = Page(content, metadata, settings=self.settings,
                         filename=f)
@@ -388,7 +391,7 @@ class PdfGenerator(Generator):
             # print "Generating pdf for", obj.filename, " in ", output_pdf
             with open(obj.filename) as f:
                 self.pdfcreator.createPdf(text=f, output=output_pdf)
-            info(u' [ok] writing %s' % output_pdf)
+            logger.info(u' [ok] writing %s' % output_pdf)
 
     def generate_context(self):
         pass
@@ -396,13 +399,13 @@ class PdfGenerator(Generator):
     def generate_output(self, writer=None):
         # we don't use the writer passed as argument here
         # since we write our own files
-        info(u' Generating PDF files...')
+        logger.info(u' Generating PDF files...')
         pdf_path = os.path.join(self.output_path, 'pdf')
         if not os.path.exists(pdf_path):
             try:
                 os.mkdir(pdf_path)
             except OSError:
-                error("Couldn't create the pdf output folder in " + pdf_path)
+                logger.error("Couldn't create the pdf output folder in " + pdf_path)
                 pass
 
         for article in self.context['articles']:

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -1,8 +1,12 @@
+__all__ = [
+    'init'
+]
+
 import os
 import sys
-from logging import CRITICAL, ERROR, WARN, INFO, DEBUG
-from logging import critical, error, info, warning, warn, debug
-from logging import Formatter, getLogger, StreamHandler
+import logging
+
+from logging import Formatter, getLogger, StreamHandler, DEBUG
 
 
 RESET_TERM = u'\033[0;m'
@@ -78,32 +82,21 @@ class DummyFormatter(object):
 
 
 def init(level=None, logger=getLogger(), handler=StreamHandler()):
+    logger = logging.getLogger()
     fmt = DummyFormatter()
     handler.setFormatter(fmt)
     logger.addHandler(handler)
+
     if level:
         logger.setLevel(level)
 
 
 if __name__ == '__main__':
     init(level=DEBUG)
-    debug('debug')
-    info('info')
-    warning('warning')
-    error('error')
-    critical('critical')
 
-
-__all__ = [
-    "debug",
-    "info",
-    "warn",
-    "warning",
-    "error",
-    "critical",
-    "DEBUG",
-    "INFO",
-    "WARN",
-    "ERROR",
-    "CRITICAL"
-]
+    root_logger = logging.getLogger()
+    root_logger.debug('debug')
+    root_logger.info('info')
+    root_logger.warning('warning')
+    root_logger.error('error')
+    root_logger.critical('critical')

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
-from os.path import isabs
 import locale
+import logging
 
-from pelican import log
+from os.path import isabs
+
+
+logger = logging.getLogger(__name__)
+
 
 DEFAULT_THEME = os.sep.join([os.path.dirname(os.path.abspath(__file__)),
                               "themes/notmyidea"])
@@ -102,10 +106,10 @@ def read_settings(filename=None):
         except locale.Error:
             pass
     else:
-        log.warn("LOCALE option doesn't contain a correct value")
+        logger.warn("LOCALE option doesn't contain a correct value")
 
     if not 'TIMEZONE' in context:
-        log.warn("No timezone information specified in the settings. Assuming"
+        logger.warn("No timezone information specified in the settings. Assuming"
                  " your timezone is UTC for feed generation. Check "
                  "http://docs.notmyidea.org/alexis/pelican/settings.html#timezone "
                  "for more information")

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 import os
-import pytz
 import re
+import pytz
 import shutil
+import logging
 
 from codecs import open as _open
 from datetime import datetime
 from itertools import groupby
 from operator import attrgetter
-from pelican.log import warning, info
+
+logger = logging.getLogger(__name__)
 
 
 def get_date(string):
@@ -71,16 +73,16 @@ def copy(path, source, destination, destination_path=None, overwrite=False):
     if os.path.isdir(source_):
         try:
             shutil.copytree(source_, destination_)
-            info('copying %s to %s' % (source_, destination_))
+            logger.info('copying %s to %s' % (source_, destination_))
         except OSError:
             if overwrite:
                 shutil.rmtree(destination_)
                 shutil.copytree(source_, destination_)
-                info('replacement of %s with %s' % (source_, destination_))
+                logger.info('replacement of %s with %s' % (source_, destination_))
 
     elif os.path.isfile(source_):
         shutil.copy(source_, destination_)
-        info('copying %s to %s' % (source_, destination_))
+        logger.info('copying %s to %s' % (source_, destination_))
 
 
 def clean_output_dir(path):
@@ -186,14 +188,14 @@ def process_translations(content_list):
         default_lang_items = filter(attrgetter('in_default_lang'), items)
         len_ = len(default_lang_items)
         if len_ > 1:
-            warning(u'there are %s variants of "%s"' % (len_, slug))
+            logger.warning(u'there are %s variants of "%s"' % (len_, slug))
             for x in default_lang_items:
-                warning('    %s' % x.filename)
+                logger.warning('    %s' % x.filename)
         elif len_ == 0:
             default_lang_items = items[:1]
 
         if not slug:
-            warning('empty slug for %r' % (default_lang_items[0].filename,))
+            logger.warning('empty slug for %r' % (default_lang_items[0].filename,))
         index.extend(default_lang_items)
         translations.extend(filter(
             lambda x: x not in default_lang_items,

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
+
 import os
+import re
+import locale
+import logging
+
 from codecs import open
 from functools import partial
-import locale
-import re
 
 from feedgenerator import Atom1Feed, Rss201rev2Feed
 from pelican.paginator import Paginator
-from pelican.log import info
 from pelican.utils import get_relative_path, set_date_tzinfo
+
+logger = logging.getLogger(__name__)
 
 
 class Writer(object):
@@ -73,7 +77,7 @@ class Writer(object):
                     pass
                 fp = open(complete_path, 'w')
                 feed.write(fp, 'utf-8')
-                info('writing %s' % complete_path)
+                logger.info('writing %s' % complete_path)
 
                 fp.close()
             return feed
@@ -108,7 +112,7 @@ class Writer(object):
                 pass
             with open(filename, 'w', encoding='utf-8') as f:
                 f.write(output)
-            info(u'writing %s' % filename)
+            logger.info(u'writing %s' % filename)
 
         localcontext = context.copy()
         if relative_urls:


### PR DESCRIPTION
calling the module-level functions on an unitialised logging object.

This allows to
- simplify log.py
- use one logger object for each file

This is about Issue #272, I created the pull request already because it seems to work nicely and I don't see any drawback from this approach..
