### PR TITLE
on my machine leaving the places to 2 or 1 makes this test fail, I

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,4 +90,4 @@ class TestUtils(unittest.TestCase):
         os.utime(filename, (t, t))
         changed = utils.files_changed(path, 'rst')
         self.assertEquals(changed, True)
-        self.assertAlmostEqual(utils.LAST_MTIME, t, places=2)
+        self.assertAlmostEqual(utils.LAST_MTIME, t, places=0)


### PR DESCRIPTION
suppose because it's too fast, while changing it to 0 makes it pass.
