### PR TITLE
Remove trailing slash from SITEURL if present. Fixes #275.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -65,10 +65,11 @@ Setting name (default value)                        What does it do?
 `SITEURL`                                           Base URL of your website. Not defined by default,
                                                     which means the base URL is assumed to be "/" with a
                                                     root-relative URL structure. If `SITEURL` is specified
-                                                    explicitly, URLs will be generated with an absolute
-                                                    URL structure (including the domain). If you want to
-                                                    use relative URLs instead of root-relative or absolute
-                                                    URLs, you should instead use the `RELATIVE_URL` setting.
+                                                    explicitly, there should be no trailing slash at the end,
+                                                    and URLs will be generated with an absolute URL structure
+                                                    (including the domain). If you want to use relative URLs
+                                                    instead of root-relative or absolute URLs, you should
+                                                    instead use the `RELATIVE_URL` setting.
 `STATIC_PATHS` (``['images']``)                     The static paths you want to have accessible
                                                     on the output path "static". By default,
                                                     Pelican will copy the 'images' folder to the

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -128,9 +128,15 @@ def configure_settings(settings, default_settings=None, filename=None):
     else:
         logger.warn("LOCALE option doesn't contain a correct value")
 
-    # If SITEURL is defined but FEED_DOMAIN isn't, set FEED_DOMAIN = SITEURL
-    if ('SITEURL' in settings) and (not 'FEED_DOMAIN' in settings):
-        settings['FEED_DOMAIN'] = settings['SITEURL']
+    if ('SITEURL' in settings):
+        # If SITEURL has a trailing slash, remove it and provide a warning
+        siteurl = settings['SITEURL']
+        if (siteurl[len(siteurl) - 1:] == '/'):
+            settings['SITEURL'] = siteurl[:-1]
+            logger.warn("Removed extraneous trailing slash from SITEURL.")
+        # If SITEURL is defined but FEED_DOMAIN isn't, set FEED_DOMAIN = SITEURL
+        if not 'FEED_DOMAIN' in settings:
+            settings['FEED_DOMAIN'] = settings['SITEURL']
 
     # Warn if feeds are generated with both SITEURL & FEED_DOMAIN undefined
     if (('FEED' in settings) or ('FEED_RSS' in settings)) and (not 'FEED_DOMAIN' in settings):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -36,6 +36,11 @@ class TestSettingsConfiguration(unittest.TestCase):
     def test_configure_settings(self):
         """Manipulations to settings should be applied correctly."""
 
+        # SITEURL should not have a trailing slash
+        settings = {'SITEURL': 'http://blog.notmyidea.org/', 'LOCALE': ''}
+        configure_settings(settings)
+        self.assertEqual(settings['SITEURL'], 'http://blog.notmyidea.org')
+
         # FEED_DOMAIN, if undefined, should default to SITEURL
         settings = {'SITEURL': 'http://blog.notmyidea.org', 'LOCALE': ''}
         configure_settings(settings)


### PR DESCRIPTION
Added code to remove trailing slash if present in SITEURL, replete with a corresponding test. Amended SITEURL docs, explaining that there shouldn't be a trailing slash.
