### PR TITLE
Fix markup for single-paragraph summary in reST metadata

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -43,6 +43,10 @@ class Reader(object):
 
 class _FieldBodyTranslator(HTMLTranslator):
 
+    def __init__(self, document):
+        HTMLTranslator.__init__(self, document)
+        self.compact_p = None
+
     def astext(self):
         return ''.join(self.body)
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -23,8 +23,9 @@ class RstReaderTest(unittest.TestCase):
             'category': 'yeah',
             'author': u'Alexis Métaireau',
             'title': 'This is a super article !',
-            'summary': 'Multi-line metadata should be supported\nas well as'\
-                       ' <strong>inline markup</strong>.',
+            'summary': u'<p class="first last">Multi-line metadata should be'\
+                       u' supported\nas well as <strong>inline'\
+                       u' markup</strong>.</p>\n',
             'date': datetime.datetime(2010, 12, 2, 10, 14),
             'tags': ['foo', 'bar', 'foobar'],
             'custom_field': 'http://notmyidea.org',


### PR DESCRIPTION
If summary in reST metadata contains a single paragraph, it is not wrapped within a `<p>` tag. But if it contains two or more paragraphs, they are.

This pull request fixes this behavior.
