### PR TITLE
Fix misspelling of ssh_target_dir in quickstart

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -231,7 +231,7 @@ Please answer the following questions so this script can generate the files need
         if ask('Do you want to upload your website using SSH ?', answer=bool, default=False):
             CONF['ssh_host'] = ask('What is the hostname of your SSH server ?', str, CONF['ssh_host'])
             CONF['ssh_user'] = ask('What is your username on this server ?', str, CONF['ssh_user'])
-            CONF['ssh_traget_dir'] = ask('Where do you want to put your website on this server ?', str, CONF['ssh_target_dir'])
+            CONF['ssh_target_dir'] = ask('Where do you want to put your website on this server ?', str, CONF['ssh_target_dir'])
 
         if ask('Do you want to upload your website using Dropbox ?', answer=bool, default=False):
             CONF['dropbox_dir'] = ask('Where is your Dropbox directory ?', str, CONF['dropbox_dir'])


### PR DESCRIPTION
Easy fix!
