### PR TITLE
Fixed hardcoded category url in base.html in default themes

### DIFF
--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -35,7 +35,7 @@
                 {% endfor %}
                 {% endif %}
                 {% for cat, null in categories %}
-                    <li {% if cat == category %}class="active"{% endif %}><a href="{{ SITEURL }}/category/{{ cat }}.html">{{ cat }}</a></li>
+                    <li {% if cat == category %}class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
                 {% endfor %}
                 </ul></nav>
         </header><!-- /#banner -->


### PR DESCRIPTION
Currently the category url is hardcoded in base.html, so eventough I changed the CATEGORY_URL from the settings, the link generated in base.html is still category/{name}.html. This fixes that problem.
