### PR TITLE
Install from git repository

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,7 +6,7 @@ Installing
 
 You're ready? Let's go! You can install Pelican via several different methods. The simplest is via `pip <http://pip.openplans.org/>`_::
 
-    $ pip install pelican
+    $ pip install git+git://github.com/ametaireau/pelican.git
 
 If you have the project source, you can install Pelican using the distutils 
 method. I recommend doing so in a virtualenv::


### PR DESCRIPTION
I propose changing the install method from Pypi to the Github repository; this has the benefit of keeping users on the latest released version, which also keeps them in sync to the available documentation.

The main problem users seem to have is not being able to use all the options described in the documentation (for example the ARTICLE_URL and ARTICLE_SAVE_AS) because the version of Pelican on Pypi is older than the one for which the docs apply.
