### PR TITLE
Modified quickstart title question so that it's more clear

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -209,7 +209,7 @@ Please answer the following questions so this script can generate the files need
     '''.format(v=__version__))
 
     CONF['basedir'] = os.path.abspath(ask('Where do you want to create your new Web site ?', answer=str, default=args.path))
-    CONF['sitename'] = ask('How will you call your Web site ?', answer=str, default=args.title)
+    CONF['sitename'] = ask('What will be the title of this Web site ?', answer=str, default=args.title)
     CONF['author'] = ask('Who will be the author of this Web site ?', answer=str, default=args.author)
     CONF['lang'] = ask('What will be the default language of this Web site ?', str, args.lang or CONF['lang'], 2)
 


### PR DESCRIPTION
I just downloaded pelican and used the quickstart tool but was confused by the question about what to call my website.  I wan't sure if it was asking me for the title or for a command that I would use to call it.  This update makes it clear for me.
