### PR TITLE
Trailing slashes removed to avoid category bug

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -245,7 +245,9 @@ class ArticlesGenerator(Generator):
     def generate_context(self):
         """change the context"""
 
-        article_path = os.path.join(self.path, self.settings['ARTICLE_DIR'])
+        article_path = os.path.normpath(  # we have to remove trailing slashes
+            os.path.join(self.path, self.settings['ARTICLE_DIR'])
+        )
         all_articles = []
         for f in self.get_files(
                 article_path,
@@ -259,8 +261,8 @@ class ArticlesGenerator(Generator):
             # if no category is set, use the name of the path as a category
             if 'category' not in metadata:
 
-                if os.path.dirname(f) == article_path:
-                    category = self.settings['DEFAULT_CATEGORY']
+                if os.path.dirname(f) == article_path:  # if the article is not in a subdirectory
+                    category = self.settings['DEFAULT_CATEGORY'] 
                 else:
                     category = os.path.basename(os.path.dirname(f))\
                                 .decode('utf-8')


### PR DESCRIPTION
Hello,

There was a bug with the category names: 
When there was articles in the `ARTICLE_DIR`, those article wasn't put in the  `DEFAULT_CATEGORY` but in a category whose the name was the `dirname()` of the `ARTICLE_DIR`.

For example , `content/foo/bar.md` was in the `foo` category but `content/bar.md` was in the `content` category instead of the `DEFAULT_CATEGORY` ...

The reason was at [`pelican/generators.py`, line 264](https://github.com/m-r-r/pelican/blob/trailing-slashes/pelican/generators.py#L264):  
The test was always false, because there was trailing slashes in the `self.settings['ARTICLE_DIR']` variable…  
I used `os.path.normpath` to remove the slashes and added a comment to avoid someone remove `normpath` by error, so now it shoud works :-)
