### PR TITLE
Add warnings for files skipped due to unknown status

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -284,6 +284,10 @@ class ArticlesGenerator(Generator):
                 all_articles.append(article)
             elif article.status == "draft":
                 self.drafts.append(article)
+            else:
+                logger.warning(u"Unknown status %s for file %s, skipping it." %
+                               (repr(unicode.encode(article.status, 'utf-8')),
+                                repr(f)))
 
         self.articles, self.translations = process_translations(all_articles)
 


### PR DESCRIPTION
This bit me with an export tool, I had _no idea_ why some files weren't showing up in my output dir.
