### PR TITLE
Updated pull request for the 'static' url issue in #327 without the extra changeset of #357

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -199,7 +199,7 @@ class Writer(object):
             def replacer(m):
                 relative_path = m.group('path')
                 dest_path = os.path.normpath(
-                                os.sep.join((get_relative_path(name), "static",
+                                os.sep.join((get_relative_path(name),
                                 relative_path)))
 
                 return m.group('markup') + m.group('quote') + dest_path \


### PR DESCRIPTION
This is the changeset to fix the 'static' url problem referenced in ametaireau/pelican#327 without the utf-8 problem that I tried to fix in my tree (reference in ametaireau/pelican#357).

The changeset simply removes the word 'static' from the path building code.
