### PR TITLE
page_name variable now takes user's settings in consideration.

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -198,7 +198,7 @@ class ArticlesGenerator(Generator):
             write(tag.save_as, tag_template, self.context, tag=tag,
                 articles=articles, dates=dates,
                 paginated={'articles': articles, 'dates': dates},
-                page_name=u'tag/%s' % tag)
+                page_name=self.settings.get('TAG_URL', u'tag/%s') % tag)
 
     def generate_categories(self, write):
         """Generate category pages."""
@@ -208,7 +208,7 @@ class ArticlesGenerator(Generator):
             write(cat.save_as, category_template, self.context,
                 category=cat, articles=articles, dates=dates,
                 paginated={'articles': articles, 'dates': dates},
-                page_name=u'category/%s' % cat)
+                page_name=self.settings.get('CATEGORY_URL', u'category/%s') % cat)
 
     def generate_authors(self, write):
         """Generate Author pages."""
@@ -218,7 +218,7 @@ class ArticlesGenerator(Generator):
             write(aut.save_as, author_template, self.context,
                 author=aut, articles=articles, dates=dates,
                 paginated={'articles': articles, 'dates': dates},
-                page_name=u'author/%s' % aut)
+                page_name=self.settings.get('AUTHOR_URL', u'author/%s') % aut)
 
     def generate_drafts(self, write):
         """Generate drafts pages."""


### PR DESCRIPTION
page_name variable now tries to get the URL the user has set.
So now the settings TAG_URL, CATEGORY_URL, AUTHOR_URL are in effect always if they are set.
right now it uses just one variable to format the string, but we might add more variables to each URL depending on the object, i.e. AUTHOR_URL="%lastname/%firstname".
It can easily be implemented by giving the variables in those lines I changed. 
Fixes issue #385
