### PR TITLE
Add -U (--upgrade) to upgrade a theme with pelican-theme

### DIFF
--- a/pelican/tools/pelican_themes.py
+++ b/pelican/tools/pelican_themes.py
@@ -64,6 +64,9 @@ def main():
 
 
     args = parser.parse_args()
+    
+    to_install = args.to_install or args.to_upgrade
+    to_sym = args.to_symlink or args.clean
 
 
     if args.action:
@@ -71,8 +74,7 @@ def main():
             list_themes(args.verbose)
         elif args.action is 'path':
             print(_THEMES_PATH)
-    elif args.to_install or args.to_remove or args.to_symlink or args.clean:
-
+    elif to_install or args.to_remove or to_sym:
         if args.to_remove:
             if args.verbose:
                 print('Removing themes...')


### PR DESCRIPTION
I disliked having to do:

$ pelican-theme -r <theme-name> -i <theme-path>

So I modified install() to handle an upgrade of an existing theme. While doing
so, I noticed that in install() and symlink() the script would error with 'no a
directory' instead of 'not a directory'. So I fixed that for you as well.
