### PR TITLE
Fixing a typo in pelican/__init__.py on logger call for debug

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -68,10 +68,10 @@ class Pelican(object):
         for plugin in self.plugins:
             # if it's a string, then import it
             if isinstance(plugin, basestring):
-                log.debug("Loading plugin `{0}' ...".format(plugin))
+                logger.debug("Loading plugin `{0}' ...".format(plugin))
                 plugin = __import__(plugin, globals(), locals(), 'module')
 
-            log.debug("Registering plugin `{0}' ...".format(plugin.__name__))
+            logger.debug("Registering plugin `{0}' ...".format(plugin.__name__))
             plugin.register()
 
     def _handle_deprecation(self):


### PR DESCRIPTION
Trying to enable html_rst_directive I got :

``` python
Traceback (most recent call last):
  File "/usr/local/bin/pelican", line 9, in <module>
    load_entry_point('pelican==3.0', 'console_scripts', 'pelican')()
  File "/home/mandraxe/pelican_venv/src/pelican/pelican/__init__.py", line 237, in main
    pelican = get_instance(args)
  File "/home/mandraxe/pelican_venv/src/pelican/pelican/__init__.py", line 229, in get_instance
    args.delete_outputdir)
  File "/home/mandraxe/pelican_venv/src/pelican/pelican/__init__.py", line 63, in __init__
    self.init_plugins()
  File "/home/mandraxe/pelican_venv/src/pelican/pelican/__init__.py", line 71, in init_plugins
    log.debug("Loading plugin `{0}' ...".format(plugin))
AttributeError: 'module' object has no attribute 'debug'
```

I'm not sure how other people were able to use plugins with this bug, I might have missed something.
