### PR TITLE
Fix issue #175

### DIFF
--- a/pelican/tools/pelican_themes.py
+++ b/pelican/tools/pelican_themes.py
@@ -181,18 +181,19 @@ def install(path, v=False, u=False):
             try:
                 shutil.copytree(path, theme_path)
 
-                if os.name == 'posix':
-                    for root, dirs, files in os.walk(theme_path):
-                        for d in dirs:
-                            dname = os.path.join(root, d)
-                            os.chmod(dname, 0755)
-                        for f in files:
-                            fname = os.path.join(root, f)
-                            os.chmod(fname, 0644)
-            except shutil.Error, e:
+                try:
+                    if os.name == 'posix':
+                        for root, dirs, files in os.walk(theme_path):
+                            for d in dirs:
+                                dname = os.path.join(root, d)
+                                os.chmod(dname, 0755)
+                            for f in files:
+                                fname = os.path.join(root, f)
+                                os.chmod(fname, 0644)
+                except OSError, e:
+                    err("Cannot change permissions of files or directory in `{r}':\n{e}".format(r=theme_path, e=str(e)), die=False)
+            except Exception, e:
                 err("Cannot copy `{p}' to `{t}':\n{e}".format(p=path, t=theme_path, e=str(e)))
-            except OSError, e:
-                err("Cannot change permissions of files or directory in `{r}':\n{e}".format(r=theme_path, e=str(e)), die=False)
 
 
 def symlink(path, v=False):


### PR DESCRIPTION
Force world-readable permission on files and directory of the themes installed by pelican-themes.

Rationale:
If the theme's files have only -rw------- permissions, once installed  system wide and owned by root, they will not be accessible to any user but only root.

Only on posix system i.e. mostly non Windows
I have added a test on the system name to avoid an error being printed on Windows.

May need some test to check any bad side effect ? Works fine here
