### PR TITLE
Fix for page_name usage to follow AUTHOR_URL, TAG_URL, and CATEGORY_URL definition.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -152,12 +152,12 @@ Setting name (default value)                        what does it do?
                                                     use the default language.
 `PAGE_LANG_SAVE_AS` ('pages/{slug}-{lang}.html')    The location we will save the page which doesn't
                                                     use the default language.
-`AUTHOR_URL` ('author/{name}.html')                 The URL to use for an author.
-`AUTHOR_SAVE_AS` ('author/{name}.html')             The location to save an author.
-`CATEGORY_URL` ('category/{name}.html')             The URL to use for a category.
-`CATEGORY_SAVE_AS` ('category/{name}.html')         The location to save a category.
-`TAG_URL` ('tag/{name}.html')                       The URL to use for a tag.
-`TAG_SAVE_AS` ('tag/{name}.html')                   The location to save the tag page.
+`AUTHOR_URL` ('author/{slug}.html')                 The URL to use for an author.
+`AUTHOR_SAVE_AS` ('author/{slug}.html')             The location to save an author.
+`CATEGORY_URL` ('category/{slug}.html')             The URL to use for a category.
+`CATEGORY_SAVE_AS` ('category/{slug}.html')         The location to save a category.
+`TAG_URL` ('tag/{slug}.html')                       The URL to use for a tag.
+`TAG_SAVE_AS` ('tag/{slug}.html')                   The location to save the tag page.
 `<DIRECT_TEMPLATE_NAME>_SAVE_AS`                    The location to save content generated from direct
                                                     templates. Where <DIRECT_TEMPLATE_NAME> is the
                                                     upper case template name.

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -93,8 +93,8 @@ author.html
 This template will be processed for each of the existing authors, with
 output generated at output/author/`author_name`.html.
 
-If pagination is active, subsequent pages will reside at
-output/author/`author_name``n`.html.
+If pagination is active, subsequent pages will reside as defined by setting
+AUTHOR_SAVE_AS (`Default:` output/author/`author_name'n'`.html).
 
 ===================     ===================================================
 Variable                Description
@@ -109,8 +109,8 @@ dates_paginator         A paginator object for the article list, ordered by
                         date, ascending.
 dates_page              The current page of articles, ordered by date,
                         ascending.
-page_name               'author/`author_name`' -- useful for pagination
-                        links
+page_name               AUTHOR_URL where everything after `{slug}` is 
+                        removed -- useful for pagination links
 ===================     ===================================================
 
 category.html
@@ -119,8 +119,8 @@ category.html
 This template will be processed for each of the existing categories, with
 output generated at output/category/`category_name`.html.
 
-If pagination is active, subsequent pages will reside at
-output/category/`category_name``n`.html.
+If pagination is active, subsequent pages will reside as defined by setting
+CATEGORY_SAVE_AS (`Default:` output/category/`category_name'n'`.html).
 
 ===================     ===================================================
 Variable                Description
@@ -135,8 +135,8 @@ dates_paginator         A paginator object for the list of articles,
                         ordered by date, ascending
 dates_page              The current page of articles, ordered by date,
                         ascending
-page_name               'category/`category_name`' -- useful for pagination
-                        links
+page_name               CATEGORY_URL where everything after `{slug}` is 
+                        removed -- useful for pagination links
 ===================     ===================================================
 
 article.html
@@ -171,8 +171,8 @@ tag.html
 This template will be processed for each tag, with corresponding .html files
 saved as output/tag/`tag_name`.html.
 
-If pagination is active, subsequent pages will reside at
-output/tag/`tag_name``n`.html.
+If pagination is active, subsequent pages will reside as defined in setting
+TAG_SAVE_AS (`Default:` output/tag/`tag_name'n'`.html).
 
 ===================     ===================================================
 Variable                Description
@@ -187,7 +187,8 @@ dates_paginator         A paginator object for the list of articles,
                         ordered by date, ascending
 dates_page              The current page of articles, ordered by date,
                         ascending
-page_name               'tag/`tag_name`' -- useful for pagination links
+page_name               TAG_URL where everything after `{slug}` is removed
+                        -- useful for pagination links
 ===================     ===================================================
 
 Inheritance

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -183,15 +183,23 @@ class URLWrapper(object):
     def __unicode__(self):
         return self.name
 
-    def _from_settings(self, key):
+    def _from_settings(self, key, get_page_name=False):
+        """Returns URL information as defined in settings. 
+        When get_page_name=True returns URL without anything after {slug}
+        e.g. if in settings: CATEGORY_URL="cat/{slug}.html" this returns "cat/{slug}"
+        Useful for pagination."""
         setting = "%s_%s" % (self.__class__.__name__.upper(), key)
         value = self.settings[setting]
         if not isinstance(value, basestring):
             logger.warning(u'%s is set to %s' % (setting, value))
             return value
         else:
-            return unicode(value).format(**self.as_dict())
+            if get_page_name:
+                return unicode(value[:value.find('{slug}') + len('{slug}')]).format(**self.as_dict())
+            else:
+                return unicode(value).format(**self.as_dict())
 
+    page_name = property(functools.partial(_from_settings, key='URL', get_page_name=True))
     url = property(functools.partial(_from_settings, key='URL'))
     save_as = property(functools.partial(_from_settings, key='SAVE_AS'))
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -198,7 +198,7 @@ class ArticlesGenerator(Generator):
             write(tag.save_as, tag_template, self.context, tag=tag,
                 articles=articles, dates=dates,
                 paginated={'articles': articles, 'dates': dates},
-                page_name=u'tag/%s' % tag)
+                page_name=tag.page_name)
 
     def generate_categories(self, write):
         """Generate category pages."""
@@ -208,7 +208,7 @@ class ArticlesGenerator(Generator):
             write(cat.save_as, category_template, self.context,
                 category=cat, articles=articles, dates=dates,
                 paginated={'articles': articles, 'dates': dates},
-                page_name=u'category/%s' % cat)
+                page_name=cat.page_name)
 
     def generate_authors(self, write):
         """Generate Author pages."""
@@ -218,7 +218,7 @@ class ArticlesGenerator(Generator):
             write(aut.save_as, author_template, self.context,
                 author=aut, articles=articles, dates=dates,
                 paginated={'articles': articles, 'dates': dates},
-                page_name=u'author/%s' % aut)
+                page_name=aut.page_name)
 
     def generate_drafts(self, write):
         """Generate drafts pages."""


### PR DESCRIPTION
First, it includes documentation changes as outlined in #387.

Now. This fixes issue #385.

Behavior:
Following @justinmayer 's flow the current master results are:

``` html
<a href=".././author/Alexis Métaireau2.html">&raquo;</a>
```

My page_name-fix branch results:

``` html
<a href=".././author/alexis-metaireau2.html">&raquo;</a>
```

So I claim this fixes a bug in the current master in which `Alexis Métaireau2.html` doesn't exist and therefore yields a 404. `alexis-metaireau2.html` is actually what the link should point to.

Now if you add different item page_name yields everything before the {slug}:

```
When:
CATEGORY_URL = 'cat/{slug}.html'
Results:
<a href=".././cat/cat12.html">&raquo;</a>
```

So what this did is take the .html (or if anything else like: .htm | .asp | / | /?q=funnyquery) off the end. So just like before, it requires the pagination.html template to re-add the .html. Just like what is currently required in the Master. Therefore the change doesn't break any current pagination template (to my knowledge), except fix the Author "bug" I previously explained.

So I think this gives you the same logic and behavior as what is currently implied in the Master branch, but honors the URL that the settings file may change.

Finally, looking through this I also changed the documentation's settings.rst. I found that in settings.py the default used `{slug}` for all the _URL items, yet the documentation says you should use `{name}`. I felt this was inconsistent and should all follow the same convention. They should follow the `{slug}` as that's what is used everywhere else and still easy to understand. This could cause some heartache for people that are currently using `{name}` and upgrading as there might be some odd behavior.

I will close #387 as it's included here.
