### PR TITLE
Add unidecode for translating slugs in asian languages

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -49,6 +49,8 @@ def slugify(value):
     value = Markup(value).striptags()
     if type(value) == unicode:
         import unicodedata
+        from unidecode import unidecode
+        value = unicode(unidecode(value))
         value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
     value = unicode(re.sub('[^\w\s-]', '', value).strip().lower())
     return re.sub('[-\s]+', '-', value)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-requires = ['feedgenerator', 'jinja2 >= 2.4', 'pygments', 'docutils', 'pytz', 'blinker']
+requires = ['feedgenerator', 'jinja2 >= 2.4', 'pygments', 'docutils', 'pytz', 'blinker', 'unidecode']
 
 try:
     import argparse

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,9 @@ class TestUtils(unittest.TestCase):
         samples = (('this is a test', 'this-is-a-test'),
                    ('this        is a test', 'this-is-a-test'),
                    (u'this → is ← a ↑ test', 'this-is-a-test'),
-                   ('this--is---a test', 'this-is-a-test'))
+                   ('this--is---a test', 'this-is-a-test'),
+                   (u'unicode測試許功蓋，你看到了嗎？', 'unicodece-shi-xu-gong-gai-ni-kan-dao-liao-ma'),
+                   (u'大飯原発４号機、１８日夜起動へ', 'da-fan-yuan-fa-4hao-ji-18ri-ye-qi-dong-he'),)
 
         for value, expected in samples:
             self.assertEquals(utils.slugify(value), expected)


### PR DESCRIPTION
I've added unidecode function for translating slugs in asian languages.
Test passed.

It should work with European languages as well. Though not tested.

This method is used by Askbot, too.
http://stackoverflow.com/questions/702337/how-to-make-django-slugify-work-properly-with-unicode-strings?lq=1
