### PR TITLE
Modify system path to ensure current directory is included

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -60,8 +60,14 @@ class Pelican(object):
             else:
                 raise Exception("Impossible to find the theme %s" % theme)
 
+        self.init_path()
         self.init_plugins()
         signals.initialized.send(self)
+
+    def init_path(self):
+        if not any(p in sys.path for p in ['', '.']):
+            logger.debug("Adding current directory to system path")
+            sys.path.insert(0, '')
 
     def init_plugins(self):
         self.plugins = self.settings['PLUGINS']


### PR DESCRIPTION
I've noticed on some machines, the current directory is not automatically placed in `sys.path`, which causes issues if you have an import statement in your settings file (for a plugin in that directory for example). One option is to have the user modify their `sys.path` in their settings file, as is done in [tools/templates/publishconf.py.in](https://github.com/ametaireau/pelican/blob/master/pelican/tools/templates/publishconf.py.in#L5), but this pull request just adds it automatically to avoid confusion on the part of the user.

I've modified the path in the Pelican class `__init__` method before plugin initialization, since I think the only places (that I could find) where an incorrect path could be a problem is loading the plugins and then loading the settings.
