### PR TITLE
Lowercase PAGES variable in templates

### DIFF
--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -32,8 +32,8 @@
                     <li><a href="{{ link }}">{{ title }}</a></li>
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU %}
-                {% for page in PAGES %}
-                    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
+                {% for pg in pages %}
+                    <li><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
                 {% endfor %}
                 {% endif %}
                 {% for cat, null in categories %}

--- a/pelican/themes/notmyidea/templates/index.html
+++ b/pelican/themes/notmyidea/templates/index.html
@@ -53,8 +53,8 @@
 {% else %}
 <section id="content" class="body">    
 <h2>Pages</h2>
-    {% for page in PAGES %}
-        <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
+    {% for pg in pages %}
+        <li><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
     {% endfor %}
 </section>
 {% endif %}

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -34,8 +34,8 @@
             <li><a href="{{ link }}">{{ title }}</a></li>
         {% endfor %}
         {% if DISPLAY_PAGES_ON_MENU %}
-          {% for p in PAGES %}
-            <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
+          {% for pg in pages %}
+            <li{% if pg == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
           {% endfor %}
         {% else %}
           {% for cat, null in categories %}


### PR DESCRIPTION
The PAGES variable in templates, can be confused with a settings variable, where they are always uppercase. So I made it lowercase and also I iterate pages with 'pg' instead of 'page', because 'page' can be confused with 'pages'.

I hope you agree :)
Thanks
