### PR TITLE
Clean up tox testing configuration

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,10 +1,8 @@
-Jinja2>=2.4
-Pygments
-docutils
-feedgenerator
+# Tests
 unittest2
-pytz
 mock
+# Optional Packages
 Markdown
-blinker
 BeautifulSoup
+typogrify
+webassets

--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,5 @@ deps =
     mock
     Markdown
     BeautifulSoup
+    typogrify
+    webassets


### PR DESCRIPTION
Add the unit2 tests to tox and remove unnecessary dependencies
These dependencies are installed when tox runs setup.py
