### PR TITLE
BUG: Typogrify not applied to pages.

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -378,7 +378,7 @@ class PagesGenerator(Generator):
                 os.path.join(self.path, self.settings['PAGE_DIR']),
                 exclude=self.settings['PAGE_EXCLUDES']):
             try:
-                content, metadata = read_file(f)
+                content, metadata = read_file(f, settings=self.settings)
             except Exception, e:
                 logger.warning(u'Could not process %s\n%s' % (f, str(e)))
                 continue


### PR DESCRIPTION
The TYPOGRIFY setting is currently ignored when reading pages. This PR fixes the bug.
