### PR TITLE
Correctly use the right variable for webassets

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -505,7 +505,7 @@ Another example for Javascript:
 .. code-block:: jinja
 
     {% assets filters="uglifyjs,gzip", output="js/packed.js", "js/jquery.js", "js/base.js", "js/widgets.js" %}
-        <script src="{{ ASSETS_URL }}"></script>
+        <script src="{{ ASSET_URL }}"></script>
     {% endassets %}
 
 The above will produce a minified and gzipped JS file:


### PR DESCRIPTION
According to [the webasset docs](http://webassets.readthedocs.org/en/latest/integration/jinja2.html#using-the-tag)
the variable should be `ASSET_URL` instead of `ASSETS_URL`.
