### PR TITLE
Fix DELETE_OUTPUT_DIRECTORY crash when no output dir

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -97,6 +97,17 @@ def copy(path, source, destination, destination_path=None, overwrite=False):
 def clean_output_dir(path):
     """Remove all the files from the output directory"""
 
+    if not os.path.exists(path):
+        logger.debug("Directory already removed: %s" % path)
+        return
+
+    if not os.path.isdir(path):
+        try:
+            os.remove(path)
+        except Exception, e:
+            logger.error("Unable to delete file %s; %e" % path, e)
+        return
+
     # remove all the existing content from the output folder
     for filename in os.listdir(path):
         file = os.path.join(path, filename)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,3 +112,16 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(os.path.isdir(test_directory))
         self.assertListEqual([], os.listdir(test_directory))
         shutil.rmtree(test_directory)
+
+    def test_clean_output_dir_not_there(self):
+        test_directory = os.path.join(os.path.dirname(__file__), 'does_not_exist')
+        utils.clean_output_dir(test_directory)
+        self.assertTrue(not os.path.exists(test_directory))
+
+    def test_clean_output_dir_is_file(self):
+        test_directory = os.path.join(os.path.dirname(__file__), 'this_is_a_file')
+        f = open(test_directory, 'w')
+        f.write('')
+        f.close()
+        utils.clean_output_dir(test_directory)
+        self.assertTrue(not os.path.exists(test_directory))


### PR DESCRIPTION
This fixes #528.
