### PR TITLE
refactor the check of executable for unit tests

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -114,7 +114,6 @@ def mute(returns_output=False):
     return decorator
 
 
-
 def get_article(title, slug, content, lang, extra_metadata=None):
     metadata = {'slug': slug, 'title': title, 'lang': lang}
     if extra_metadata is not None:
@@ -122,19 +121,20 @@ def get_article(title, slug, content, lang, extra_metadata=None):
     return Article(content, metadata=metadata)
 
 
-def skipIfNoExecutable(executable, valid_exit_code=1):
-    """Tries to run an executable to make sure it's in the path, Skips the tests
-    if not found.
+def skipIfNoExecutable(executable):
+    """Skip test if `executable` is not found
+
+    Tries to run `executable` with subprocess to make sure it's in the path,
+    and skips the tests if not found (if subprocess raises a `OSError`).
     """
 
-    # calling with no params the command should exit with 1
     with open(os.devnull, 'w') as fnull:
         try:
             res = subprocess.call(executable, stdout=fnull, stderr=fnull)
         except OSError:
             res = None
 
-    if res != valid_exit_code:
-        return unittest.skip('{0} compiler not found'.format(executable))
+    if res is None:
+        return unittest.skip('{0} executable not found'.format(executable))
 
     return lambda func: func

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -3,25 +3,24 @@
 import os
 
 from pelican.tools.pelican_import import wp2fields, fields2pelican
-from .support import unittest, temporary_folder, mute
+from .support import unittest, temporary_folder, mute, skipIfNoExecutable
 
 CUR_DIR = os.path.dirname(__file__)
 WORDPRESS_XML_SAMPLE = os.path.join(CUR_DIR, 'content', 'wordpressexport.xml')
 
-PANDOC = os.system('pandoc --version') == 0
 try:
     import BeautifulSoup
 except ImportError:
     BeautifulSoup = False  # NOQA
 
 
+@skipIfNoExecutable(['pandoc', '--version'])
+@unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')
 class TestWordpressXmlImporter(unittest.TestCase):
 
     def setUp(self):
         self.posts = wp2fields(WORDPRESS_XML_SAMPLE)
 
-    @unittest.skipUnless(PANDOC and BeautifulSoup,
-                         'Needs Pandoc and BeautifulSoup')
     def test_ignore_empty_posts(self):
 
         posts = list(self.posts)
@@ -29,8 +28,6 @@ class TestWordpressXmlImporter(unittest.TestCase):
         for title, content, fname, date, author, categ, tags, format in posts:
             self.assertTrue(title.strip())
 
-    @unittest.skipUnless(PANDOC and BeautifulSoup,
-                         'Needs Pandoc and BeautifulSoup')
     def test_can_toggle_raw_html_code_parsing(self):
 
         posts = list(self.posts)


### PR DESCRIPTION
pandoc was checked directly with a `os.system` call, and the output with version
and copyright of pandoc was displayed when running tests.
- replace the pandoc check with the `skipIfNoExecutable` function.
- in `skipIfNoExecutable`, the `valid_exit_code` is not needed, the executable
  is not found if an `OSError` exception is catched.
