### PR TITLE
Docs: Added missing link to issue tracker.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -21,7 +21,7 @@ How can I help?
 ================
 
 There are several ways to help out. First, you can use Pelican and report any
-suggestions or problems you might have via IRC or the issue tracker.
+suggestions or problems you might have via IRC or the `issue tracker <https://github.com/getpelican/pelican/issues>`_.
 
 If you want to contribute, please fork `the git repository
 <https://github.com/getpelican/pelican/>`_, create a new feature branch, make


### PR DESCRIPTION
In the 'How can I help' section, the issue tracker was mentioned but not linked. This commit turns it into a link.
