### PR TITLE
Provide slug storage option for posts during Pelican import

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Release history
 3.1 (XXXX-XX-XX)
 ================
 
+* Importer now stores slugs within files by default. This can be disabled with
+  the ``--disable-slugs`` option.
 * Improve handling of links to intra-site resources
 * Ensure WordPress import adds paragraphs in for all types of line endings
   in post content.

--- a/docs/importer.rst
+++ b/docs/importer.rst
@@ -39,29 +39,44 @@ Usage
 """""
 
 | pelican-import [-h] [--wpfile] [--dotclear] [--feed] [-o OUTPUT]
-|                [-m MARKUP][--dir-cat]
+|                [-m MARKUP] [--dir-cat] [--strip-raw] [--disable-slugs]
 |                input
+
+Positional arguments
+====================
+
+  input                 The input file to read
 
 Optional arguments
 """"""""""""""""""
 
   -h, --help            show this help message and exit
-  --wpfile              Wordpress XML export
-  --dotclear            Dotclear export
-  --feed                Feed to parse
+  --wpfile              Wordpress XML export (default: False)
+  --dotclear            Dotclear export (default: False)
+  --feed                Feed to parse (default: False)
   -o OUTPUT, --output OUTPUT
-                        Output path
-  -m MARKUP             Output markup
+                        Output path (default: output)
+  -m MARKUP, --markup MARKUP
+                        Output markup format (supports rst & markdown)
+                        (default: rst)
   --dir-cat             Put files in directories with categories name
+                        (default: False)
+  --strip-raw           Strip raw HTML code that can't be converted to markup
+                        such as flash embeds or iframes (wordpress import
+                        only) (default: False)
+  --disable-slugs       Disable storing slugs from imported posts within
+                        output. With this disabled, your Pelican URLs may not
+                        be consistent with your original posts. (default:
+                        False)
 
 Examples
 ========
 
-for WordPress::
+For WordPress::
 
     $ pelican-import --wpfile -o ~/output ~/posts.xml
 
-for Dotclear::
+For Dotclear::
 
     $ pelican-import --dotclear -o ~/output ~/backup.txt
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -48,6 +48,26 @@ class TestWordpressXmlImporter(unittest.TestCase):
                          strip_raw=True))
             self.assertFalse(any('<iframe' in rst for rst in rst_files))
 
+    def test_can_toggle_slug_storage(self):
+
+        posts = list(self.posts)
+        r = lambda f: open(f).read()
+        silent_f2p = mute(True)(fields2pelican)
+
+        with temporary_folder() as temp:
+
+            rst_files = (r(f) for f in silent_f2p(posts, 'markdown', temp))
+            self.assertTrue(all('Slug:' in rst for rst in rst_files))
+            rst_files = (r(f) for f in silent_f2p(posts, 'markdown', temp,
+                         disable_slugs=True))
+            self.assertFalse(any('Slug:' in rst for rst in rst_files))
+
+            rst_files = (r(f) for f in silent_f2p(posts, 'rst', temp))
+            self.assertTrue(all(':slug:' in rst for rst in rst_files))
+            rst_files = (r(f) for f in silent_f2p(posts, 'rst', temp,
+                         disable_slugs=True))
+            self.assertFalse(any(':slug:' in rst for rst in rst_files))
+
     def test_decode_html_entities_in_titles(self):
         posts = list(self.posts)
         test_posts = [post for post in posts if post[2] == 'html-entity-test']


### PR DESCRIPTION
This option allows the Pelican importer to store slugs as "Slug:" or ":slug:" depending on filetype - within the given imported posts.  This means the resulting files can be renamed/moved/etc and the slug remains the same as when imported (useful for consistency in URLs etc).

Also includes some updates to the import documentation.
