### PR TITLE
Ignore Emacs write lock files.

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -257,7 +257,8 @@ def files_changed(path, extensions):
         for root, dirs, files in os.walk(path):
             dirs[:] = [x for x in dirs if x[0] != '.']
             for f in files:
-                if any(f.endswith(ext) for ext in extensions):
+                if any(f.endswith(ext) for ext in extensions) \
+                        and not f.startswith(".#"):
                     yield os.stat(os.path.join(root, f)).st_mtime
 
     global LAST_MTIME


### PR DESCRIPTION
Whenever a user edits a file, GNU Emacs creates symlinks prefixed with
.#, for example, ".#article.rst".  These symlinks are picked up by
Pelican when autoreload is enabled, causing many errors to be logged
until the edited file is saved in Emacs.  This change ignores files
starting with ".#" when determining whether the content has changed.

See
http://www.gnu.org/software/emacs/manual/html_node/emacs/Interlocking.html#Interlocking
for more on Emacs interlocking files.
