### PR TITLE
Kill SimpleHTTPServer also on OS X

### DIFF
--- a/pelican/tools/templates/develop_server.sh.in
+++ b/pelican/tools/templates/develop_server.sh.in
@@ -30,7 +30,7 @@ function shut_down(){
   if [[ -f $$SRV_PID ]]; then
     PID=$$(cat $$SRV_PID)
     PROCESS=$$(ps -p $$PID | tail -n 1 | awk '{print $$4}')
-    if [[ $$PROCESS == python ]]; then
+    if [[ $$PROCESS != "" ]]; then
       echo "Killing SimpleHTTPServer"
       kill $$PID
     else


### PR DESCRIPTION
The old check fails when the Python process is for example /opt/local/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
