### PR TITLE
revert #523

### DIFF
--- a/docs/fr/configuration.rst
+++ b/docs/fr/configuration.rst
@@ -163,6 +163,3 @@ SITEURL :
 
 STATIC_PATHS :
 	Les chemins statiques que vous voulez avoir accès sur le chemin de sortie "statique" ;
-
-MARKDOWN_EXTENSIONS :
-	Liste des extentions Markdown que vous souhaitez utiliser ;

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -129,8 +129,6 @@ Setting name (default value)                                            What doe
                                                                         Can be used to separate templates from the theme.
                                                                         Example: projects, resume, profile ...
                                                                         This templates need to use ``DIRECT_TEMPLATES`` setting
-
-`MARKDOWN_EXTENSIONS` (``['toc',]``)                                    A list of any Markdown extensions you want to use.
 `ASCIIDOC_OPTIONS` (``[]``)                                             A list of options to pass to asciidoc, see the `manpage
                                                                         <http://www.methods.co.nz/asciidoc/manpage.html>`_
 =====================================================================   =====================================================================

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -136,13 +136,8 @@ class MarkdownReader(Reader):
 
     def read(self, filename):
         """Parse content and metadata of markdown files"""
-        markdown_extensions = self.settings.get('MARKDOWN_EXTENSIONS', [])
-        if isinstance(markdown_extensions, (str, unicode)):
-            markdown_extensions = [m.strip() for m in
-                                   markdown_extensions.split(',')]
         text = pelican_open(filename)
-        md = Markdown(extensions=set(
-            self.extensions + markdown_extensions + ['meta']))
+        md = Markdown(extensions=set(self.extensions + ['meta']))
         content = md.convert(text)
 
         metadata = {}

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -78,7 +78,6 @@ _DEFAULT_CONFIG = {'PATH': '.',
                    'TYPOGRIFY': False,
                    'SUMMARY_MAX_LENGTH': 50,
                    'PLUGINS': [],
-                   'MARKDOWN_EXTENSIONS': ['toc', ],
                    'TEMPLATE_PAGES': {}
                    }
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -145,9 +145,9 @@ class MdReaderTest(unittest.TestCase):
     @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
     def test_article_with_markdown_markup_extension(self):
         # test to ensure the markdown markup extension is being processed as expected
-        reader = readers.MarkdownReader({})
-        reader.settings.update(dict(MARKDOWN_EXTENSIONS=['toc', ]))
-        content, metadata = reader.read(_filename('article_with_markdown_markup_extensions.md'))
+        content, metadata = readers.read_file(
+                _filename('article_with_markdown_markup_extensions.md'),
+                settings={'MD_EXTENSIONS': ['toc', 'codehilite', 'extra']})
         expected = '<div class="toc">\n'\
             '<ul>\n'\
             '<li><a href="#level1">Level1</a><ul>\n'\


### PR DESCRIPTION
we don't need a new MARKDOWN_EXTENSIONS setting because the equivalent setting
MD_EXTENSIONS already exists.
