### PR TITLE
Allow to customize the name of the static folder

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -504,7 +504,7 @@ class StaticGenerator(Generator):
                     os.path.join(self.path, static_path), extensions=False):
                 f_rel = os.path.relpath(f, self.path)
                 # TODO remove this hardcoded 'static' subdirectory
-                sc = StaticContent(f_rel, os.path.join(self.settings['STATIC_FOLDER'], f_rel),
+                sc = StaticContent(f_rel, os.path.join(self.settings['OUTPUT_STATIC_DIR'], f_rel),
                         settings=self.settings)
                 self.staticfiles.append(sc)
                 self.context['filenames'][f_rel] = sc

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -79,7 +79,7 @@ _DEFAULT_CONFIG = {'PATH': '.',
                    'SUMMARY_MAX_LENGTH': 50,
                    'PLUGINS': [],
                    'TEMPLATE_PAGES': {},
-                   'STATIC_FOLDER': 'static'
+                   'OUTPUT_STATIC_DIR': 'static'
                    }
 
 


### PR DESCRIPTION
This simple hack allows you to change the name of the static folder via a setting in pelicanonf.py. This is a extreme case but sometimes you will need to change the name of the folder.

The commit keeps the default configuration unless the user specifies the following in the settings:

STATIC_URL = 'assets'

Then, the user in its code can do the following. For example in base.html:

<img src="{{SITEURL}}/{{STATIC_URL}}/images/logo.png"/>
