### PR TITLE
Add support for a Markdown 'references' file

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -75,6 +75,9 @@ Setting name (default value)                                            What doe
 `MD_EXTENSIONS` (``['codehilite','extra']``)                            A list of the extensions that the Markdown processor
                                                                         will use. Refer to the extensions chapter in the
                                                                         Python-Markdown documentation for a complete list of
+
+`MD_REFERENCES` (````)                                                  A file containing Markdown links which is added to
+                                                                        the end of each posting before being processed by Markdown.
                                                                         supported extensions.
 `OUTPUT_PATH` (``'output/'``)                                           Where to output the generated files.
 `PATH` (``None``)                                                       Path to content directory to be processed by Pelican.

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -138,8 +138,12 @@ class MarkdownReader(Reader):
         """Parse content and metadata of markdown files"""
         text = pelican_open(filename)
         md = Markdown(extensions=set(self.extensions + ['meta']))
-        content = md.convert(text)
 
+        if self.settings.get('MD_REFERENCES', None):
+            refs = pelican_open(self.settings['MD_REFERENCES'])
+            text = text + "\n" + refs
+
+        content = md.convert(text)
         metadata = {}
         for name, value in md.Meta.items():
             name = name.lower()

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -78,7 +78,8 @@ _DEFAULT_CONFIG = {'PATH': '.',
                    'TYPOGRIFY': False,
                    'SUMMARY_MAX_LENGTH': 50,
                    'PLUGINS': [],
-                   'TEMPLATE_PAGES': {}
+                   'TEMPLATE_PAGES': {},
+                   'MD_REFERENCES': None
                    }
 
 


### PR DESCRIPTION
This adds support for what I call a 'references' file -- basically a set of links I use in Markdown posts. The input file looks like this:

```
    [json]: http://json.org
    [vbox]: http://www.virtualbox.org/
    [yaml]: http://yaml.org
    ...
```

By setting `MD_REFERENCES = 'myfile.md'` in _pelicanconf.py_, I can use those links within posts without having to explicitly write them into individual postings. So, for example, a blog post as

```
title: Something

If you use [JSON] (or [YAML][yaml] for that matter), lorem ipsum dolor...
```

will have links for `[json]` and `[yaml]` expanded automatically. 

I considered creating a Markdown extension with which to do that, but haven't been able to "encourage" Markdown to Preprocess those ...
