### PR TITLE
Documentation doesn't clearly outline what is required for each plugin in the settings

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -100,16 +100,16 @@ request if you need them!
 List of plugins
 ===============
 
-The following plugins are currently included with Pelican under ``pelican.plugins``:
+The following plugins are currently included with Pelican:
 
-* `Asset management`_
-* `GitHub activity`_
-* `Global license`_
-* `Gravatar`_
-* `Gzip cache`_
-* `HTML tags for reStructuredText`_
-* `Related posts`_
-* `Sitemap`_
+* `Asset management`_ ``pelican.plugins.assets``
+* `GitHub activity`_ ``pelican.plugins.github_activity``
+* `Global license`_ ``pelican.plugins.global_license``
+* `Gravatar`_ ``pelican.plugins.gravatar``
+* `Gzip cache`_ ``pelican.plugins.gzip_cache``
+* `HTML tags for reStructuredText`_ ``pelican.plugins.html_rst_directive``
+* `Related posts`_ ``pelican.plugins.related_posts``
+* `Sitemap`_ ``pelican.plugins.sitemap``
 
 Ideas for plugins that haven't been written yet:
 


### PR DESCRIPTION
Updated the Plugins documentation to explicitly call out what each "callable" plugin is named. The documentation covers the details of each of the included plugins, but doesn't actually say what to put in your settings file for each specific plugin. 

Where plugins like **Gravatar** `gravatar` and **Related Posts** `related_posts`, follow a simple naming convention--plugins like **Asset management** `assets` and **HTML tags for reStructuredText** `html_rst_directive` do not.

This makes it clear to someone not digging through the code and directory structure what the (explicit) plugin names are. This also allows for future included plugins to not be required to follow a well-defined naming structure, and simply remain well documented--including if sub-categorization if ever required.
