### PR TITLE
Updated 'notmyidea' theme, to be 'link post' capable.

### DIFF
--- a/pelican/themes/notmyidea/static/css/main.css
+++ b/pelican/themes/notmyidea/static/css/main.css
@@ -255,9 +255,6 @@ img.left, figure.left {float: left; margin: 0 2em 2em 0;}
 	-moz-border-radius: 10px;
 	-webkit-border-radius: 10px;
 }
-a.permalinkpost {
-	color: #C86E50;
-}
 
 /*
 	Extras

--- a/pelican/themes/notmyidea/templates/article.html
+++ b/pelican/themes/notmyidea/templates/article.html
@@ -5,9 +5,8 @@
   <article>
     <header>
       <h1 class="entry-title">
-        <a href="{% if article.link %}{{ article.link }}{% else %}{{ SITEURL }}/{{ article.url }}{% endif %}" rel="bookmark"{% if not article.link %}
-           title="Permalink to {{ article.title|striptags }}"{% endif %}>{{ article.title}}</a>
-           {% if article.link %}<a href="{{ SITEURL }}/{{ article.url }}" class="permalinkpost" title="Permalink to {{ article.title|striptags }}">&#9733;</a>{% endif %}</h1>
+        <a href="{% if article.link %}{{ article.link }}{% else %}{{ SITEURL }}/{{ article.url }}{% endif %}" rel="bookmark"
+           {% if not article.link %}title="Permalink to {{ article.title|striptags }}"{% endif %}>{{ article.title}}</a>{% if article.link %}<a href="{{ SITEURL }}/{{ article.url }}" class="permalinkpost" title="Permalink to {{ article.title|striptags }}">&#9733;</a>{% endif %}</h1>
       {% include 'twitter.html' %}
     </header>
 

--- a/pelican/themes/notmyidea/templates/index.html
+++ b/pelican/themes/notmyidea/templates/index.html
@@ -8,7 +8,7 @@
         {% if loop.first and not articles_page.has_previous() %}
             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="{% if article.link %}{{ article.link }}{% else %}{{ SITEURL }}/{{ article.url }}{% endif %}">{{ article.title }}</a>{% if article.link %} <a href="{{ SITEURL }}/{{ article.url }}" class="permalinkpost">&#9733;</a>{% endif %}</h1>
+                    <h1 class="entry-title"><a href="{% if article.link %}{{ article.link }}{% else %}{{ SITEURL }}/{{ article.url }}{% endif %}">{{ article.title }}</a>{% if article.link %} <a href="{{ SITEURL }}/{{ article.url }}" class="permalinkpost">&#9733;</a>{% endif %}</h1> 
                     {% include 'article_infos.html' %}{{ article.content }}{% include 'comments.html' %}
                 </article>
                 {% if loop.length == 1 %}
@@ -27,9 +27,10 @@
                 <section id="content" class="body">
                     <ol id="posts-list" class="hfeed" start="{{ articles_paginator.per_page -1 }}">
             {% endif %}
-            <li><article class="hentry{% if article.link %} linkpost{% endif %}">
+            <li><article class="hentry{% if article.link %} linkpost{% endif %}">    
                 <header>
-                    <h1><a href="{% if article.link %}{{ article.link }}{% else %}{{ SITEURL }}/{{ article.url }}{% endif %}" rel="bookmark">{{ article.title }}</a>{% if article.link %} <a href="{{ SITEURL }}/{{ article.url }}" class="permalinkpost">&#9733;</a>{% endif %}</h1>
+                    <h1><a href="{% if article.link %}{{ article.link }}{% else %}{{ SITEURL }}/{{ article.url }}{% endif %}" rel="bookmark"
+                           {% if not article.link %}title="Permalink to {{ article.title|striptags }}"{% endif %}>{{ article.title }}</a>{% if article.link %} <a href="{{ SITEURL }}/{{ article.url }}" class="permalinkpost">&#9733;</a>{% endif %}</h1>
                 </header>
                 
                 <div class="entry-content">


### PR DESCRIPTION
Link posts seem to be the most requested feature. Since Pelican can support it by default, 'notmyidea' theme is updated to support it out of the box for an example.

This addresses issue #565

See an example of the output visit: http://pelicantests.site44.com/

**This is not ready to be merged.** 

Please review and provide feedback as well as were to document this capability. Since it is a 'requested feature' that Pelican supports out of the box, I was thinking the _FAQ_.  Sound ok?
