### PR TITLE
Fixes #630

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -162,7 +162,7 @@ def clean_output_dir(path):
 
 def get_relative_path(filename):
     """Return the relative path from the given filename to the root path."""
-    nslashes = filename.count('/')
+    nslashes = filename.lstrip('/').count('/')
     if nslashes == 0:
         return '.'
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,9 +51,9 @@ class TestUtils(unittest.TestCase):
 
     def test_get_relative_path(self):
 
-        samples = (('test/test.html', '..'),
-                   ('test/test/test.html', '../..'),
-                   ('test.html', '.'))
+        samples = (('/test/test.html', '..'),
+                   ('/test/test/test.html', '../..'),
+                   ('/test.html', '.'))
 
         for value, expected in samples:
             self.assertEquals(utils.get_relative_path(value), expected)


### PR DESCRIPTION
Test cases had a bug too. Actual _filename_ passed to `get_relative_path` starts with a slash.
