### PR TITLE
Update webassets plugin to allow user to pass configuration settings to webassets

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -183,10 +183,19 @@ The above will produce a minified and gzipped JS file:
     <script src="http://{SITEURL}/theme/js/packed.js?00703b9d"></script>
 
 Pelican's debug mode is propagated to Webassets to disable asset packaging
-and instead work with the uncompressed assets. However, this also means that
-the LESS and SASS files are not compiled. This should be fixed in a future
-version of Webassets (cf. the related `bug report
-<https://github.com/getpelican/pelican/issues/481>`_).
+and instead work with the uncompressed assets.
+
+Many of Webasset's available compilers have additional configuration options
+(i.e. 'Less', 'Sass', 'Stylus', 'Closure_js').  You can pass these options to
+Webassets using the ``ASSET_CONFIG`` in your settings file.
+
+The following will handle Google Closure's compilation level and locate
+LessCSS's binary:
+
+.. code-block:: python
+
+    ASSET_CONFIG = (('closure_compressor_optimization', 'WHITESPACE_ONLY'),
+                    ('less_bin', 'lessc.cmd'), )
 
 .. _Webassets: https://github.com/miracle2k/webassets
 .. _Webassets documentation: http://webassets.readthedocs.org/en/latest/builtin_filters.html

--- a/pelican/plugins/assets.py
+++ b/pelican/plugins/assets.py
@@ -36,6 +36,10 @@ def create_assets_env(generator):
     assets_src = os.path.join(generator.output_path, 'theme')
     generator.env.assets_environment = Environment(assets_src, assets_url)
 
+    if 'ASSET_CONFIG' in generator.settings:
+        for item in generator.settings['ASSET_CONFIG']:
+            generator.env.assets_environment.config[item[0]] = item[1]
+
     logger = logging.getLogger(__name__)
     if logging.getLevelName(logger.getEffectiveLevel()) == "DEBUG":
         generator.env.assets_environment.debug = True


### PR DESCRIPTION
Found that the webassets plugin didn't allow the user to modify any of the configuration settings. This is important for instance, on Windows in order to call NodeJS tools you have to call it like: `lessc.cmd` or `stylus.cmd` or it won't run.  

But it's more than that, because if you are using other tools you can alter the settings as well. This allows for a `ASSET_CONFIG` setting that you can add these items.

Plugin Documentation is updated.

Also removed language about DEBUG not compiling CSS for Less and Sass since as of at least webassets 0.8 this is no longer an issue.
