### PR TITLE
make HtmlReader work

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -163,8 +163,9 @@ class HtmlReader(Reader):
 
     def read(self, filename):
         """Parse content and metadata of (x)HTML files"""
-        with open(filename) as content:
+        with open(filename) as text:
             metadata = {'title': 'unnamed'}
+            content = text.read()
             for i in self._re.findall(content):
                 key = i.split(':')[0][5:].strip()
                 value = i.split(':')[-1][:-3].strip()


### PR DESCRIPTION
found that the HtmlReader not work because re.findall needs a string as argument but a file object is sent.
it is fixed just by reading the file content and then sending the content string to re.findall 
