### PR TITLE
settings: Fix abspath existence check for path settings

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -91,7 +91,7 @@ def read_settings(filename=None, override=None):
                     and not isabs(local_settings[p]):
                 absp = os.path.abspath(os.path.normpath(os.path.join(
                             os.path.dirname(filename), local_settings[p])))
-                if p != 'THEME' or os.path.exists(p):
+                if p != 'THEME' or os.path.exists(absp):
                     local_settings[p] = absp
     else:
         local_settings = copy.deepcopy(_DEFAULT_CONFIG)


### PR DESCRIPTION
The path to check is `absp`.  `p` is the setting name.
