### PR TITLE
utils: Teach mkdir_p to fail if the existing target isn't a directory

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -416,5 +416,5 @@ def mkdir_p(path):
     try:
         os.makedirs(path)
     except OSError as e:
-        if e.errno != errno.EEXIST:
+        if e.errno != errno.EEXIST or not os.path.isdir(path):
             raise


### PR DESCRIPTION
Existing symlinks to directories will still pass, because isdir() follows
symbolic links.
