### PR TITLE
add disqus_url to comment js block

### DIFF
--- a/pelican/themes/notmyidea/templates/article.html
+++ b/pelican/themes/notmyidea/templates/article.html
@@ -14,17 +14,13 @@
       {% include 'article_infos.html' %}
       {{ article.content }}
     </div><!-- /.entry-content -->
-    {% if DISQUS_SITENAME %}
+    {% if DISQUS_SITENAME and SITEURL and article.status != "draft" %}
     <div class="comments">
       <h2>Comments !</h2>
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "{{ article.url }}";
-        {% if not RELATIVE_URLS %}
         var disqus_url = "{{ SITEURL }}/{{ article.url }}";
-        {% elif FEED_DOMAIN %}
-        var disqus_url = "{{ FEED_DOMAIN }}/{{ article.url }}";
-        {% endif %}
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';

--- a/tests/output/custom/a-markdown-powered-article.html
+++ b/tests/output/custom/a-markdown-powered-article.html
@@ -61,8 +61,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "a-markdown-powered-article.html";
-                var disqus_url = "http://blog.notmyidea.org/a-markdown-powered-article.html";
-                (function() {
+        var disqus_url = "./a-markdown-powered-article.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/article-1.html
+++ b/tests/output/custom/article-1.html
@@ -60,8 +60,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "article-1.html";
-                var disqus_url = "http://blog.notmyidea.org/article-1.html";
-                (function() {
+        var disqus_url = "./article-1.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/article-2.html
+++ b/tests/output/custom/article-2.html
@@ -60,8 +60,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "article-2.html";
-                var disqus_url = "http://blog.notmyidea.org/article-2.html";
-                (function() {
+        var disqus_url = "./article-2.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/article-3.html
+++ b/tests/output/custom/article-3.html
@@ -60,8 +60,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "article-3.html";
-                var disqus_url = "http://blog.notmyidea.org/article-3.html";
-                (function() {
+        var disqus_url = "./article-3.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/drafts/a-draft-article.html
+++ b/tests/output/custom/drafts/a-draft-article.html
@@ -56,19 +56,6 @@
 listed anywhere else.</p>
 
     </div><!-- /.entry-content -->
-        <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_identifier = "a-draft-article.html";
-                var disqus_url = "http://blog.notmyidea.org/a-draft-article.html";
-                (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-    </div>
     
   </article>
 </section>

--- a/tests/output/custom/filename_metadata-example.html
+++ b/tests/output/custom/filename_metadata-example.html
@@ -60,8 +60,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "filename_metadata-example.html";
-                var disqus_url = "http://blog.notmyidea.org/filename_metadata-example.html";
-                (function() {
+        var disqus_url = "./filename_metadata-example.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/oh-yeah-fr.html
+++ b/tests/output/custom/oh-yeah-fr.html
@@ -62,8 +62,8 @@ Translations:
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "oh-yeah-fr.html";
-                var disqus_url = "http://blog.notmyidea.org/oh-yeah-fr.html";
-                (function() {
+        var disqus_url = "./oh-yeah-fr.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/oh-yeah.html
+++ b/tests/output/custom/oh-yeah.html
@@ -67,8 +67,8 @@ YEAH !</p>
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "oh-yeah.html";
-                var disqus_url = "http://blog.notmyidea.org/oh-yeah.html";
-                (function() {
+        var disqus_url = "./oh-yeah.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/second-article-fr.html
+++ b/tests/output/custom/second-article-fr.html
@@ -62,8 +62,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "second-article-fr.html";
-                var disqus_url = "http://blog.notmyidea.org/second-article-fr.html";
-                (function() {
+        var disqus_url = "./second-article-fr.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/second-article.html
+++ b/tests/output/custom/second-article.html
@@ -62,8 +62,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "second-article.html";
-                var disqus_url = "http://blog.notmyidea.org/second-article.html";
-                (function() {
+        var disqus_url = "./second-article.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/this-is-a-super-article.html
+++ b/tests/output/custom/this-is-a-super-article.html
@@ -71,8 +71,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "this-is-a-super-article.html";
-                var disqus_url = "http://blog.notmyidea.org/this-is-a-super-article.html";
-                (function() {
+        var disqus_url = "./this-is-a-super-article.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);

--- a/tests/output/custom/unbelievable.html
+++ b/tests/output/custom/unbelievable.html
@@ -62,8 +62,8 @@
       <div id="disqus_thread"></div>
       <script type="text/javascript">
         var disqus_identifier = "unbelievable.html";
-                var disqus_url = "http://blog.notmyidea.org/unbelievable.html";
-                (function() {
+        var disqus_url = "./unbelievable.html";
+        (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = 'http://blog-notmyidea.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);


### PR DESCRIPTION
By default, the `disqus_url` is not set in the `disqus_thread` block, which is suggested to be set in the [disqus official docs](http://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables).

With `disqus_url` not set, if I opened my article in the browser in a dev environment before publishing, the page is rendered with url such as `http://localhost:8000/your-slug/`, and disqus will use that url as the `disqus_url`(explained in the [doc](http://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables)). 

Once set, the thread will use that `disqus_url` to generate links to the comments, that is, every comment, no matter put on product environment or dev env, will be set with the `localhost:8000` started url. What's more, the `disqus_url` [**cannot** be updated](http://help.disqus.com/customer/portal/articles/735170-how-can-i-update-discussion-urls) once set, you'll have the change the identifier(slug) to get rid of that `localhost:8000` url.

So, I change the `article` template of `not my idea` theme, and I recommend other theme maker to add the `disqus_url` settings, too.
