### PR TITLE
Optional creation of inline "read more" link in summary

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -11,7 +11,7 @@ from sys import platform, stdin
 
 
 from pelican.settings import _DEFAULT_CONFIG
-from pelican.utils import slugify, truncate_html_words, memoized
+from pelican.utils import slugify, truncate_html_words, memoized, insert_into_last_element
 from pelican import signals
 
 logger = logging.getLogger(__name__)
@@ -192,10 +192,16 @@ class Page(object):
         if hasattr(self, '_summary'):
             return self._summary
         else:
+            content = self.content
             if self.settings['SUMMARY_MAX_LENGTH']:
-                return truncate_html_words(self.content,
+                content = truncate_html_words(self.content,
                         self.settings['SUMMARY_MAX_LENGTH'])
-            return self.content
+
+            if self.settings['READ_MORE_LINK']:
+                read_more = self.settings['READ_MORE_LINK_FORMAT'] % {'url': self.url, 'text': self.settings['READ_MORE_LINK']}
+                content = insert_into_last_element(content, read_more)
+
+            return content
 
     def _set_summary(self, summary):
         """Dummy function"""

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -78,7 +78,9 @@ _DEFAULT_CONFIG = {'PATH': '.',
                    'TYPOGRIFY': False,
                    'SUMMARY_MAX_LENGTH': 50,
                    'PLUGINS': [],
-                   'TEMPLATE_PAGES': {}
+                   'TEMPLATE_PAGES': {},
+                   'READ_MORE_LINK': None,
+                   'READ_MORE_LINK_FORMAT': '<a class="read-more" href="/%(url)s">%(text)s</a>'
                    }
 
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -336,3 +336,29 @@ def mkdir_p(path):
     except OSError, e:
         if e.errno != errno.EEXIST:
             raise
+
+def insert_into_last_element(html, element):
+    """ function to insert an html element into another html fragment
+        example:
+            html = '<p>paragraph1</p><p>paragraph2...</p>'
+            element = '<a href="/read-more/">read more</a>'
+            ---> '<p>paragraph1</p><p>paragraph2...<a href="/read-more/">read more</a></p>'
+    """
+    try:
+        from lxml.html import fragment_fromstring, fragments_fromstring, tostring
+        from lxml.etree import ParserError
+    except ImportError:
+        raise Exception("Unable to find lxml. To use READ_MORE_LINK, you need lxml")
+    
+    try:
+        item = fragment_fromstring(element)
+    except ParserError, TypeError:
+        item = fragment_fromstring('<span></span>')
+    
+    try:
+        doc = fragments_fromstring(html)
+        doc[-1].append(item)
+        
+        return ''.join(tostring(e) for e in doc)
+    except ParserError, TypeError:
+        return ''


### PR DESCRIPTION
Added optional utility to insert an inline 'read more' link inside of the summary's last html element.  I documented my use case/need here: http://vuongnguyen.com/creating-inline-read-more-link-python-pelican-lxml.html.   Perhaps this is useful for others as well.  Thank you.  -Vuong
