### PR TITLE
Fixed a typo

### DIFF
--- a/docs/importer.rst
+++ b/docs/importer.rst
@@ -24,10 +24,10 @@ Dependencies
 
 ``pelican-import`` has two dependencies not required by the rest of pelican:
 
-- BeautifulSoup
+- Beautiful Soup
 - pandoc
 
-BeatifulSoup can be installed like any other Python package::
+Beautiful Soup can be installed like any other Python package::
 
     $ pip install BeautifulSoup
 


### PR DESCRIPTION
Was reading through the documentation and noticed a typo in `BeatifulSoup`. I also discovered that in general the name is written with a space, so I changed it to `Beautiful Soup`. I left the codeblock unchanged.
