### PR TITLE
Make devserver ignore temporary files

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -289,7 +289,8 @@ def files_changed(path, extensions):
         for root, dirs, files in os.walk(path):
             dirs[:] = [x for x in dirs if x[0] != '.']
             for f in files:
-                if any(f.endswith(ext) for ext in extensions):
+                if not f.startswith('.') \ # ignore hidden files
+                and any(f.endswith(ext) for ext in extensions):
                     yield os.stat(os.path.join(root, f)).st_mtime
 
     global LAST_MTIME


### PR DESCRIPTION
Some editors (such as emacs) automatically save 
open files in temporary files, usually as hidden
files. 

The result is that the devserver is continually
building as soon as I open some file in emacs. 
This solves the problem by ignoring hidden files.
