### PR TITLE
custom jinja2 blocks as metadata

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     asciidoc = False
 
+from jinja2 import Template
 from pelican.contents import Category, Tag, Author
 from pelican.utils import get_date, pelican_open
 
@@ -231,6 +232,13 @@ def read_file(filename, fmt=None, settings=None):
         raise ValueError("Missing dependencies for %s" % fmt)
 
     content, metadata = reader.read(filename)
+    #use content as Template to extract any Jinja2 blocks defined in it
+    templ = Template(content)
+    for name,function in templ.blocks.iteritems():
+        metadata[name] =  function(templ.new_context()).next()
+    #replace content with rendered template to remove the block definitions
+    content = templ.render()
+
 
     # eventually filter the content with typogrify if asked so
     if settings and settings.get('TYPOGRIFY'):


### PR DESCRIPTION
This allows to define jinja2 blocks in the text and have them accessible as metadata.

Example

```
date: 2013-01-10
title: title

{%block summary %}
Here goes the summary

{% endblock summary %}

more text
{% block conclusion %}
Nothing

{% endblock conclusion %}
```

Now one can use e.g. `article.summary` and `article.conclusion` and the theme templates.

Fixes #358

Knwown Caveat: does not play well with the Markdown 'attr_list' extension (which gets loaded by 'extra' per default). Just take care that the markdown parsers does not mess up the block definition (newlines help)

I will update the docs etc... after the discussion of the proposed solution is over.
