### PR TITLE
Tag Cloud example code did not work

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -386,7 +386,7 @@ The default theme does not support tag clouds, but it is pretty easy to add::
 
     <ul>
         {% for tag in tag_cloud %}
-            <li class="tag-{{ tag.1 }}"><a href="/tag/{{ tag.0 }}.html">{{ tag.0 }}</a></li>
+            <li class="tag-{{ tag.1 }}"><a href="/tag/{{ tag.0|string|replace(" ", "-" ) }}.html">{{ tag.0 }}</a></li>
         {% endfor %}
     </ul>
 


### PR DESCRIPTION
In the current version of Pelican, tag pages are generated at /tag/[keyword].html not /tag/[keyword]/

I had used this sample code and noted that the links were not rendering (giving me 404s). I looked at the template for "notmyidea" and noted that the links worked and were in a different format. I have not used older versions of pelican so I am not sure if previously this code was correct.
