### PR TITLE
Related Post Plugin Example

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -291,7 +291,7 @@ For example::
     {% if article.related_posts %}
         <ul>
         {% for related_post in article.related_posts %}
-            <li>{{ related_post }}</li>
+            <li><a href="{{ related_post.url }}">{{ related_post.title }}</a></li>
         {% endfor %}
         </ul>
     {% endif %}


### PR DESCRIPTION
The existing related posts example doesn't show properties for the collection, this could be confusing to individuals who are not programmers, because as it was the code would render five bullet points.

I am also looking to add some type of loop control or if statement to the loop to detect duplicate, I tried t a dictionary sort filter through jinja, bu that through an error, the following is not guarantted to work then:

```
    {% set LASTARTICLE = "notset" %}
    {% if article.related_posts %}
        <ul>
        {% for related_post in article.related_posts|dictsort(false, 'url')  %}
            {% if not (LASTARTICLE == related_post.url) %}
               <li><a href="{{ related_post.url }}">{{ related_post.title }}</a></li>
            {% endif %}
            {% set LASTARTICLE = related_post.url %}
        {% endfor %}
        </ul>
    {% endif %}
```

the dicsort does not work (is this not a dict, I'm not a python guy so I'm just hacking at it.)
