### PR TITLE
Adding a missing space in one error message

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -344,6 +344,6 @@ def is_valid_content(content, f):
         content.check_properties()
         return True
     except NameError as e:
-        logger.error("Skipping %s: impossible to find informations about"
+        logger.error("Skipping %s: impossible to find informations about "
                       "'%s'" % (f, e))
         return False


### PR DESCRIPTION
Put a space in error message to not concatain word 'about' and the missing tag
