### PR TITLE
Fix bug with docutils' code directive.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -110,7 +110,8 @@ class RstReader(Reader):
         return output
 
     def _get_publisher(self, source_path):
-        extra_params = {'initial_header_level': '2'}
+        extra_params = {'initial_header_level': '2',
+                        'syntax_highlight': 'short'}
         pub = docutils.core.Publisher(
             destination_class=docutils.io.StringOutput)
         pub.set_components('standalone', 'restructuredtext', 'html')


### PR DESCRIPTION
Since version 0.9 `docutils` supports `code` directive. But this directive
can generate fullname classes for the `pygments` style classes.

For example, the following code

``` reStructuredText
.. code:: c++

    GetFoo()->do_something();
```

generate the following output

``` html
<pre class="code c++ literal-block">
  <span class="name">GetFoo</span>
  <span class="punctuation">()</span>
  <span class="operator">-&gt;</span>
  <span class="name">do_something</span>
  <span class="punctuation">();</span>
</pre>
```

Note, that fullname classes were used, when we need a short one

``` html
<pre class="code c++ literal-block">
  <span class="n">GetFoo</span>
  <span class="p">()</span>
  <span class="o">-&gt;</span>
  <span class="n">do_something</span>
  <span class="p">();</span>
</pre>
```
