### PR TITLE
Fixed pagination link error when <DIRECT_TEMPLATE_NAME>_SAVE_AS used

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -254,8 +254,8 @@ class ArticlesGenerator(Generator):
                 continue
 
             write(save_as, self.get_template(template),
-                  self.context, blog=True, paginated=paginated,
-                  page_name=template)
+                self.context, blog=True, paginated=paginated,
+                page_name=os.path.splitext(save_as)[0])
 
     def generate_tags(self, write):
         """Generate Tags pages."""

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -133,7 +133,7 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_direct_templates(write)
         write.assert_called_with("archives/index.html",
             generator.get_template("archives"), settings,
-            blog=True, paginated={}, page_name='archives')
+            blog=True, paginated={}, page_name='archives/index')
 
     def test_direct_templates_save_as_false(self):
 


### PR DESCRIPTION
Pagination links are broken when {DIRECT_TEMPLATE_NAME}_SAVE_AS setting is used. For example, setting INDEX_SAVE_AS to 'blog/index.html' will result in pagination links pointing to index2.html, index3.html, .... Instead they should point to blog/index2.html, blog/index3.html, ....

The unit test for this scenario was passing as it was testing for an incorrect 'page_name' variable being set.
