### PR TITLE
Fix Null Attributes in New HTML Parser

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -240,7 +240,10 @@ class HTMLReader(Reader):
             
         def build_tag(self, tag, attrs, close_tag):
             result = '<{}'.format(cgi.escape(tag))
-            result += ''.join((' {}="{}"'.format(cgi.escape(k), cgi.escape(v)) for k,v in attrs))
+            for k,v in attrs:
+                result += ' ' + cgi.escape(k)
+                if v is not None:
+                    result += '="{}"'.format(cgi.escape(v))
             if close_tag:
                 return result + ' />'
             return result + '>'

--- a/tests/content/article_with_null_attributes.html
+++ b/tests/content/article_with_null_attributes.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+    </head>
+    <body>
+        Ensure that empty attributes are copied properly.
+        <input name="test" disabled style="" />
+    </body>
+</html>

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -298,9 +298,19 @@ class HTMLReaderTest(unittest.TestCase):
             self.assertEquals(value, metadata[key], key)
 
 
+    def test_article_with_null_attributes(self):
+        reader = readers.HTMLReader({})
+        content, metadata = reader.read(_path('article_with_null_attributes.html'))
+
+        self.assertEquals('''
+        Ensure that empty attributes are copied properly.
+        <input name="test" disabled style="" />
+    ''', content)
+
     def test_article_metadata_key_lowercase(self):
         """Keys of metadata should be lowercase."""
         reader = readers.HTMLReader({})
         content, metadata = reader.read(_path('article_with_uppercase_metadata.html'))
         self.assertIn('category', metadata, "Key should be lowercase.")
         self.assertEquals('Yeah', metadata.get('category'), "Value keeps cases.")
+


### PR DESCRIPTION
Ran into one small bug with the recently accepted HTML Parser that this addresses. Simply put, the following HTML would not parse correctly:

```
<tag attr />
```

Currently, it has to be specifed as:

```
<tag attr="attr" />
```

This change addresses the issue and adds a test for it.
