### PR TITLE
Python 3 unicode issue in pelican_quickstart.py

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -47,7 +47,7 @@ else:
 def decoding_strings(f):
     def wrapper(*args, **kwargs):
         out = f(*args, **kwargs)
-        if isinstance(out, six.string_types):
+        if isinstance(out, six.string_types) and not six.PY3:
             # todo: make encoding configurable?
             return out.decode(sys.stdin.encoding)
         return out


### PR DESCRIPTION
Re the issue I made: https://github.com/getpelican/pelican/issues/724
Although this might also be fixed by https://github.com/getpelican/pelican/pull/706 which looks like it fixes more.
So perhaps reject this and take that one instead.
