### PR TITLE
Fix: hashlib.md5 funcition only accepts bytes as input

### DIFF
--- a/pelican/plugins/gravatar.py
+++ b/pelican/plugins/gravatar.py
@@ -1,4 +1,5 @@
 import hashlib
+import six
 
 from pelican import signals
 """
@@ -33,8 +34,9 @@ def add_gravatar(generator, metadata):
 
     #then add gravatar url
     if 'email' in metadata.keys():
+        email_bytes = six.b(metadata['email']).lower()
         gravatar_url = "http://www.gravatar.com/avatar/" + \
-                        hashlib.md5(metadata['email'].lower()).hexdigest()
+                        hashlib.md5(email_bytes).hexdigest()
         metadata["author_gravatar"] = gravatar_url
 
 


### PR DESCRIPTION
This is a fix for the gravatar plugin issue mentioned at https://github.com/getpelican/pelican/issues/264#issuecomment-13644229

The `six.b` function will convert the supplied argument into `bytes` but using `latin-1` encoding, which I think is fine since we are dealing with email address.
