### PR TITLE
Makefile - clean should check if output dir exists

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -43,7 +43,7 @@ $$(OUTPUTDIR)/%.html:
 	$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)
 
 clean:
-	find $$(OUTPUTDIR) -mindepth 1 -delete
+    if [ -d $(OUTPUTDIR) ]; then find $(OUTPUTDIR) -mindepth 1 -delete; fi
 
 regenerate: clean
 	$$(PELICAN) -r $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)


### PR DESCRIPTION
Hi. Thats my first git pull request so be clement ;)

A small change in the Makefile for the pelican-quickstart. Clean function should check if the output dir exists.

Small error handling. I use pelican with git together and the output dir is not tracked. On the server make html will create the output dir without a error thrown.
