### PR TITLE
Fix a failing test in the asciidoc reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
     - "3.2"
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq ruby-sass
+ - sudo apt-get install -qq --no-install-recommends asciidoc ruby-sass
 install:
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then ln -s /usr/share/asciidoc/asciidocapi.py ~/virtualenv/python2.7/lib/python2.7/site-packages/; fi
     - pip install nose mock --use-mirrors
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors unittest2; else pip install --use-mirrors unittest2py3k; fi
     - pip install . --use-mirrors

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -237,7 +237,7 @@ class HTMLReader(Reader):
 
         def handle_charref(self, data):
             self._data_buffer += '&#{};'.format(data)
-            
+
         def build_tag(self, tag, attrs, close_tag):
             result = '<{}'.format(cgi.escape(tag))
             for k,v in attrs:
@@ -280,7 +280,8 @@ class AsciiDocReader(Reader):
     def read(self, source_path):
         """Parse content and metadata of asciidoc files"""
         from cStringIO import StringIO
-        text = StringIO(pelican_open(source_path))
+        with pelican_open(source_path) as source:
+            text = StringIO(source)
         content = StringIO()
         ad = AsciiDocAPI()
 


### PR DESCRIPTION
and add asciidoc and pandoc to travis so that the related tests will not be skipped.
