### PR TITLE
Display feed(s) in footer if no SOCIAL links

### DIFF
--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -54,7 +54,7 @@
                         </ul>
                 </div><!-- /.blogroll -->
         {% endif %}
-        {% if SOCIAL %}
+        {% if SOCIAL or FEED_ALL_ATOM or FEED_ALL_RSS %}
                 <div class="social">
                         <h2>social</h2>
                         <ul>


### PR DESCRIPTION
For sites where there are no SOCIAL links defined the FEED_ALL_ATOM and/or the FEED_ALL_RSS links are not displayed.
