### PR TITLE
Allow explicit setting of markdown extensions

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -50,6 +50,7 @@ class Reader(object):
 
     def __init__(self, settings):
         self.settings = settings
+        self.mdextensions = self.settings.get('MARKDOWNEXTENSIONS', ['codehilite', 'extra'])
 
     def process_metadata(self, name, value):
         if name in _METADATA_PROCESSORS:
@@ -142,7 +143,7 @@ class RstReader(Reader):
 class MarkdownReader(Reader):
     enabled = bool(Markdown)
     file_extensions = ['md', 'markdown', 'mkd']
-    extensions = ['codehilite', 'extra']
+    extensions = self.mdextensions
 
     def _parse_metadata(self, meta):
         """Return the dict containing document metadata"""


### PR DESCRIPTION
These additions are to make it easier to disable pygments or any other extension the user may not want. In the previous version, these plugins are hardcoded, but by making it a variable in the config, it is possible to not use pygments or easily load extra markdown plugins if needed; you can have multiple plugins in one virtual environment and have different configs load them as needed.

In my `pelicanconf.py` I then have the following:

```
MARKDOWNEXTENSIONS = ['extra', 'syntaxhighlighter']
```

where `syntaxhighlighter` is a custom markdown extension I am working on to use syntax highlighter instead of pygments for code highlighting.  However, if its not set in the config file, it will fall back to the current settings there by default.

If someone knows better, is is possible to get the settings read in the MarkdownReader class instead, that might be more clean.
