### PR TITLE
Check output directory exists before doing a clean

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -43,7 +43,7 @@ $$(OUTPUTDIR)/%.html:
 	$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)
 
 clean:
-	find $$(OUTPUTDIR) -mindepth 1 -delete
+	[ ! -d $$(OUTPUTDIR) ] || find $$(OUTPUTDIR) -mindepth 1 -delete
 
 regenerate: clean
 	$$(PELICAN) -r $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)


### PR DESCRIPTION
If the output directory does not exist the 'make clean' command fails, which also means that the 'make html' command which would otherwise create the output directory also fails without generating the output.

This a slightly more succinct version of pull request #733 but I couldn't figure out how to attach this commit to that pull request.
