### PR TITLE
Added settings to allow supression of Authors, Tags, and Categories pages.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -129,6 +129,12 @@ Setting name (default value)                                            What doe
                                                                         These templates need to use ``DIRECT_TEMPLATES`` setting.
 `ASCIIDOC_OPTIONS` (``[]``)                                             A list of options to pass to AsciiDoc. See the `manpage
                                                                         <http://www.methods.co.nz/asciidoc/manpage.html>`_
+`GENERATE_AUTHORS` (``True``)											If set to ``False``, Pelican will not generate separate files for
+																		each author.
+`GENERATE_TAGS` (``True``)												If set to ``False``, Pelican will not generate separate files for
+																		each tag.
+`GENERATE_CATEGORIES` (``True``)										If set to ``False``, Pelican will not generate separate files for
+																		each category.																		
 =====================================================================   =====================================================================
 
 .. [#] Default is the system locale.

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -259,34 +259,37 @@ class ArticlesGenerator(Generator):
 
     def generate_tags(self, write):
         """Generate Tags pages."""
-        tag_template = self.get_template('tag')
-        for tag, articles in self.tags.items():
-            articles.sort(key=attrgetter('date'), reverse=True)
-            dates = [article for article in self.dates if article in articles]
-            write(tag.save_as, tag_template, self.context, tag=tag,
-                articles=articles, dates=dates,
-                paginated={'articles': articles, 'dates': dates},
-                page_name=tag.page_name)
+        if self.settings.get('GENERATE_TAGS'):
+            tag_template = self.get_template('tag')
+            for tag, articles in self.tags.items():
+                articles.sort(key=attrgetter('date'), reverse=True)
+                dates = [article for article in self.dates if article in articles]
+                write(tag.save_as, tag_template, self.context, tag=tag,
+                    articles=articles, dates=dates,
+                    paginated={'articles': articles, 'dates': dates},
+                    page_name=tag.page_name)
 
     def generate_categories(self, write):
         """Generate category pages."""
-        category_template = self.get_template('category')
-        for cat, articles in self.categories:
-            dates = [article for article in self.dates if article in articles]
-            write(cat.save_as, category_template, self.context,
-                category=cat, articles=articles, dates=dates,
-                paginated={'articles': articles, 'dates': dates},
-                page_name=cat.page_name)
+        if self.settings.get('GENERATE_CATEGORIES'):
+            category_template = self.get_template('category')
+            for cat, articles in self.categories:
+                dates = [article for article in self.dates if article in articles]
+                write(cat.save_as, category_template, self.context,
+                    category=cat, articles=articles, dates=dates,
+                    paginated={'articles': articles, 'dates': dates},
+                    page_name=cat.page_name)
 
     def generate_authors(self, write):
         """Generate Author pages."""
-        author_template = self.get_template('author')
-        for aut, articles in self.authors:
-            dates = [article for article in self.dates if article in articles]
-            write(aut.save_as, author_template, self.context,
-                author=aut, articles=articles, dates=dates,
-                paginated={'articles': articles, 'dates': dates},
-                page_name=aut.page_name)
+        if self.settings.get('GENERATE_AUTHORS'):
+            author_template = self.get_template('author')
+            for aut, articles in self.authors:
+                dates = [article for article in self.dates if article in articles]
+                write(aut.save_as, author_template, self.context,
+                    author=aut, articles=articles, dates=dates,
+                    paginated={'articles': articles, 'dates': dates},
+                    page_name=aut.page_name)
 
     def generate_drafts(self, write):
         """Generate drafts pages."""

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -81,7 +81,10 @@ _DEFAULT_CONFIG = {'PATH': '.',
                    'SUMMARY_MAX_LENGTH': 50,
                    'PLUGINS': [],
                    'TEMPLATE_PAGES': {},
-                   'IGNORE_FILES': []
+                   'IGNORE_FILES': [],
+                   'GENERATE_AUTHORS': True,
+                   'GENERATE_TAGS': True,
+                   'GENERATE_CATEGORIES': True,
                    }
 
 


### PR DESCRIPTION
This was a side effect of my porting the zh2 theme to pelican. I didn't want any special pages for tags and categories, and since it's a single-author blog I didn't really need a set of authors pages either.

To disable the generation of these pages, just set the following to false in your config file:

GENERATE_AUTHORS = False
GENERATE_TAGS = False
GENERATE_CATEGORIES = False

The default values for these settings mimic existing behavior.

Note that this doesn't stop the default template generation of these pages, just the pages themselves. 

For example if you have an article with the "general" tag, the following is generated by default:

...
tags.html (contains link to ./tags/general.html)
tags/
   general.html

Setting GENERATE_TAGS = false will disable the creation of tags/*.html and the tags folder. However tags.html (and authors.html and categories.html) is controlled by the existing DIRECT_TEMPLATES setting.

If you don't want authors.html, categories.htm, and tags.html to be generated, you have to disable them by removing them from the DIRECT_TEMPLATES setting:

DIRECT_TEMPLATES = (('index'),)

It seems like it might be better if both of these things were handled in a single setting, but I didn't want to break existing functionality by changing how DIRECT_TEMPLATES worked.
