### PR TITLE
make develop_server.sh notify/cleanup when pelican or server don't start

### DIFF
--- a/pelican/tools/templates/develop_server.sh.in
+++ b/pelican/tools/templates/develop_server.sh.in
@@ -26,11 +26,14 @@ function usage(){
   exit 3
 }
 
+function alive() {
+  kill -0 $$1 >/dev/null 2>&1
+}
+
 function shut_down(){
-  if [[ -f $$SRV_PID ]]; then
-    PID=$$(cat $$SRV_PID)
-    PROCESS=$$(ps -p $$PID | tail -n 1 | awk '{print $$4}')
-    if [[ $$PROCESS != "" ]]; then
+  PID=$$(cat $$SRV_PID)
+  if [[ $$? -eq 0 ]]; then
+    if alive $PID; then
       echo "Killing pelican.server"
       kill $$PID
     else
@@ -41,10 +44,9 @@ function shut_down(){
     echo "pelican.server PIDFile not found"
   fi
 
-  if [[ -f $$PELICAN_PID ]]; then
-    PID=$$(cat $$PELICAN_PID)
-    PROCESS=$$(ps -p $$PID | tail -n 1 | awk '{print $$4}')
-    if [[ $$PROCESS != "" ]]; then
+  PID=$$(cat $$PELICAN_PID)
+  if [[ $$? -eq 0 ]]; then
+    if alive $$PID; then
       echo "Killing Pelican"
       kill $$PID
     else
@@ -60,12 +62,22 @@ function start_up(){
   echo "Starting up Pelican and pelican.server"
   shift
   $$PELICAN --debug --autoreload -r $$INPUTDIR -o $$OUTPUTDIR -s $$CONFFILE $$PELICANOPTS &
-  echo $$! > $$PELICAN_PID
+  pelican_pid=$$!
+  echo $$pelican_pid > $$PELICAN_PID
   cd $$OUTPUTDIR
   python -m pelican.server &
-  echo $$! > $$SRV_PID
+  srv_pid=$$!
+  echo $$srv_pid > $$SRV_PID
   cd $$BASEDIR
-  sleep 1 && echo 'Pelican and pelican.server processes now running in background.'
+  sleep 1
+  if ! alive $$pelican_pid ; then
+    echo "Pelican didn't start. Is the pelican package installed?"
+    return 1
+  elif ! alive $$srv_pid ; then
+    echo "pelican.server didn't start. Is the pelican package installed?"
+    return 1
+  fi
+  echo 'Pelican and pelican.server processes now running in background.'
 }
 
 ###
@@ -78,7 +90,9 @@ elif [[ $$1 == "restart" ]]; then
   shut_down
   start_up
 elif [[ $$1 == "start" ]]; then
-  start_up
+  if ! start_up; then
+    shut_down
+  fi
 else
   usage
 fi


### PR DESCRIPTION
After waiting for pelican and server to come up, if either one has died then give a more helpful message and clean up. Previously did not check for this, so script informed user that everything was running even if one or both parts failed for whatever reason.

This is meant to provide a little more user-friendliness in those cases where user has a develop_server.sh in project directory but forgot to (re)install pelican, activate relevant virtualenv, etc. as well as other unforeseen situations where one of the processes does not start.
