### PR TITLE
docs/contribute.rst: Update tests/output generation for moved tests

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -54,9 +54,9 @@ If you have made changes that affect the output of a Pelican-generated weblog,
 then you should update the output used by functional tests.
 To do so, you can use the following two commands::
 
-    $ LC_ALL="C" pelican -o tests/output/custom/ -s samples/pelican.conf.py \
+    $ LC_ALL="C" pelican -o pelican/tests/output/custom/ -s samples/pelican.conf.py \
         samples/content/
-    $ LC_ALL="C" pelican -o tests/output/basic/ samples/content/
+    $ LC_ALL="C" pelican -o pelican/tests/output/basic/ samples/content/
 
 testing for python3
 -------------------


### PR DESCRIPTION
This brings the docs back up to date after 547f8d2 (Move the tests into
pelican. Fix #500, 2013-04-06).
