### PR TITLE
Fix stopserver command

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -56,9 +56,9 @@ devserver:
 	$$(BASEDIR)/develop_server.sh restart
 
 stopserver:
-_   kill -9 `cat pelican.pid`
-_   kill -9 `cat srv.pid`
-_   @echo 'Stopped Pelican and SimpleHTTPServer processes running in background.
+	kill -9 `cat pelican.pid`
+	kill -9 `cat srv.pid`
+	@echo 'Stopped Pelican and SimpleHTTPServer processes running in background.'
 
 publish:
 	$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(PUBLISHCONF) $$(PELICANOPTS)


### PR DESCRIPTION
Commit a13e31a7 of 21st February adds a "stopserver" command to the makefile but doesn't include leading tabs, which causes all newly-created makefiles to be invalid. It also doesn't close quotes on the final line of that block. This patch fixes both problems.
