### PR TITLE
Allow to load custom readers with new dict setting: READERS.

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -35,6 +35,8 @@ The logic is separated into different classes and concepts:
   syntax is `Jinja2 <http://jinja.pocoo.org/>`_ and is very easy to learn, so
   don't hesitate to jump in and build your own theme.
 
+.. _implement-reader:
+
 How to implement a new reader?
 ==============================
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -500,6 +500,27 @@ adding the following to your configuration::
 
     CSS_FILE = "wide.css"
 
+Custom readers
+==============
+
+Creating Pelican custom readers is addressed in a dedicated section
+(see :ref:`implement-reader`). To load them, use the settings described below.
+
+=======================   =======================================================
+Setting name              What does it do ?
+=======================   =======================================================
+`READERS`                 Additional file extensions -> reader mapping
+                          allowing to redefine the readers used by pelican, or
+                          add oneself readers.
+=======================   =======================================================
+
+For example, if you redefined the reStructuredText reader in
+``mypelican.RstReader``, you can use it with the following in your
+configuration::
+
+    import mypelican.RstReader
+    READERS = {'rst': mypelican.RstReader, }
+
 Example settings
 ================
 

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -322,10 +322,14 @@ def read_file(path, fmt=None, settings=None):
     if not fmt:
         fmt = ext[1:]
 
+    extensions = dict(_EXTENSIONS)
+    if settings and settings.get('READERS'):
+        extensions.update(settings.get('READERS'))
+
     if fmt not in _EXTENSIONS:
         raise TypeError('Pelican does not know how to parse {}'.format(path))
 
-    reader = _EXTENSIONS[fmt](settings)
+    reader = extensions[fmt](settings)
     settings_key = '%s_EXTENSIONS' % fmt.upper()
 
     if settings and settings_key in settings:

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -84,7 +84,8 @@ _DEFAULT_CONFIG = {'PATH': '.',
                    'SUMMARY_MAX_LENGTH': 50,
                    'PLUGINS': [],
                    'TEMPLATE_PAGES': {},
-                   'IGNORE_FILES': []
+                   'IGNORE_FILES': [],
+                   'READERS': {},
                    }
 
 


### PR DESCRIPTION
This adds a new dict setting, READERS, containing extensions -> Reader class, allowing to load custom readers. I do not know if there was another way to load readers.

My use case is that I need another RstReader, that do not rely on html4css1 (mostly because I do not like the output, so not html5). so I created a mypelican.RstReader and loaded it this way:

```
import mypelican.RstReader
READERS = {'rst': mypelican.RstReader,}
```
