### PR TITLE
Fixes incompatibiity with Python 2.6 str.format

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -554,7 +554,7 @@ class StaticGenerator(Generator):
             save_as = os.path.join(self.output_path, sc.save_as)
             mkdir_p(os.path.dirname(save_as))
             shutil.copy(source_path, save_as)
-            logger.info('copying {} to {}'.format(sc.source_path, sc.save_as))
+            logger.info('copying {0} to {1}'.format(sc.source_path, sc.save_as))
 
 
 class PdfGenerator(Generator):

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -222,7 +222,7 @@ class HTMLReader(Reader):
                 self._in_body = False
                 self._in_top_level = True
             elif self._in_body:
-                self._data_buffer += '</{}>'.format(cgi.escape(tag))
+                self._data_buffer += '</{0}>'.format(cgi.escape(tag))
 
         def handle_startendtag(self, tag, attrs):
             if tag == 'meta' and self._in_head:
@@ -231,23 +231,23 @@ class HTMLReader(Reader):
                 self._data_buffer += self.build_tag(tag, attrs, True)
 
         def handle_comment(self, data):
-            self._data_buffer += '<!--{}-->'.format(data)
+            self._data_buffer += '<!--{0}-->'.format(data)
 
         def handle_data(self, data):
             self._data_buffer += data
 
         def handle_entityref(self, data):
-            self._data_buffer += '&{};'.format(data)
+            self._data_buffer += '&{0};'.format(data)
 
         def handle_charref(self, data):
-            self._data_buffer += '&#{};'.format(data)
+            self._data_buffer += '&#{0};'.format(data)
 
         def build_tag(self, tag, attrs, close_tag):
-            result = '<{}'.format(cgi.escape(tag))
+            result = '<{0}'.format(cgi.escape(tag))
             for k, v in attrs:
                 result += ' ' + cgi.escape(k)
                 if v is not None:
-                    result += '="{}"'.format(cgi.escape(v))
+                    result += '="{0}"'.format(cgi.escape(v))
             if close_tag:
                 return result + ' />'
             return result + '>'
@@ -323,7 +323,7 @@ def read_file(path, fmt=None, settings=None):
         fmt = ext[1:]
 
     if fmt not in _EXTENSIONS:
-        raise TypeError('Pelican does not know how to parse {}'.format(path))
+        raise TypeError('Pelican does not know how to parse {0}'.format(path))
 
     reader = _EXTENSIONS[fmt](settings)
     settings_key = '%s_EXTENSIONS' % fmt.upper()

--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -188,5 +188,5 @@ class LoggedTestCase(unittest.TestCase):
         actual = self._logcount_handler.count_logs(msg=msg, **kwargs)
         self.assertEqual(
             actual, count,
-            msg='expected {} occurrences of {!r}, but found {}'.format(
+            msg='expected {0} occurrences of {1!r}, but found {2}'.format(
                 count, msg, actual))

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -143,12 +143,12 @@ def deprecated_attribute(old, new, since=None, remove=None, doc=None):
     """
     def _warn():
         version = '.'.join(six.text_type(x) for x in since)
-        message = ['{} has been deprecated since {}'.format(old, version)]
+        message = ['{0} has been deprecated since {1}'.format(old, version)]
         if remove:
             version = '.'.join(six.text_type(x) for x in remove)
             message.append(
-                ' and will be removed by version {}'.format(version))
-        message.append('.  Use {} instead.'.format(new))
+                ' and will be removed by version {0}'.format(version))
+        message.append('.  Use {0} instead.'.format(new))
         logger.warning(''.join(message))
         logger.debug(''.join(
                 six.text_type(x) for x in traceback.format_stack()))
@@ -403,7 +403,7 @@ def process_translations(content_list):
         if len_ > 1:
             logger.warning('there are %s variants of "%s"' % (len_, slug))
             for x in default_lang_items:
-                logger.warning('    {}'.format(x.source_path))
+                logger.warning('    {0}'.format(x.source_path))
         elif len_ == 0:
             default_lang_items = items[:1]
 

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -62,7 +62,7 @@ class Writer(object):
         try:
             self.site_url = context.get('SITEURL', get_relative_path(path))
             self.feed_domain = context.get('FEED_DOMAIN')
-            self.feed_url = '{}/{}'.format(self.feed_domain, path)
+            self.feed_url = '{0}/{1}'.format(self.feed_domain, path)
 
             feed = self._create_new_feed(feed_type, context)
 
@@ -121,7 +121,7 @@ class Writer(object):
                 pass
             with open(path, 'w', encoding='utf-8') as f:
                 f.write(output)
-            logger.info('writing {}'.format(path))
+            logger.info('writing {0}'.format(path))
 
         localcontext = context.copy()
         if relative_urls:


### PR DESCRIPTION
Python 2.6 str.format() does not accept empty placeholders.

> > > '{}'.format('a')
> > > ValueError: zero length field name in format
