### PR TITLE
contents: Add URLWrapper.__repr__

### DIFF
--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -41,6 +41,9 @@ class URLWrapper(object):
     def __str__(self):
         return self.name
 
+    def __repr__(self):
+        return '<{} {}>'.format(type(self).__name__, str(self))
+
     def _from_settings(self, key, get_page_name=False):
         """Returns URL information as defined in settings.
 


### PR DESCRIPTION
This makes it easier to troubleshoot collections of URLWrappers, because
printing the collection will give you something you can actually read ;).

This pulls commit 2c007b1 (the 8th) off the bottom of #671.  You may
want to apply it after #768 to preserve #671's ordering.
