### PR TITLE
fix TypeError: endswith first arg must be str, unicode, or tuple, not list

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -95,7 +95,7 @@ class Generator(object):
         if extensions is None:
             extensions = self.markup
         basename = os.path.basename(path)
-        if extensions is False or basename.endswith(extensions):
+        if extensions is False or basename.endswith(tuple(extensions)):
             return True
         return False
 


### PR DESCRIPTION
when extensions is passed in as a list, the intention is clear but endswith
will not accept this.
