### PR TITLE
Getting an explicit error message on server creation

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -22,4 +22,8 @@ except OSError as e:
 
 
 print("serving at port", PORT)
-httpd.serve_forever()
+try:
+    httpd.serve_forever()
+except KeyboardInterrupt as e:
+    print("shutting down server")
+    httpd.socket.close()


### PR DESCRIPTION
When using `make serve` and the port is already in used you get this message :

```
$ make serve
cd /home/felix/Work/sites/mysite/output && python -m pelican.server
Traceback (most recent call last):/.virtualenvs/pelican/lib/python3.3/site-packages/pelican-3.2-py3.3.egg/pelican/server.py", line 16, in <module>
    httpd = socketserver.TCPServer(("", PORT), Handler)
  File "/usr/lib64/python3.3/socketserver.py", line 430, in __init__
    self.server_bind()
  File "/usr/lib64/python3.3/socketserver.py", line 441, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 98] Address already in use
make: *** [serve] Error 1
```

This kind of message is probably more readable :

```
$ make serve
cd /home/felix/Work/sites/mysite/output && python -m pelican.server
Could not listen on port 8000
make: *** [serve] Error 1
```
