### PR TITLE
fix for #783

### DIFF
--- a/pelican/plugins/summary.py
+++ b/pelican/plugins/summary.py
@@ -31,7 +31,7 @@ def content_object_init(instance):
     instance._get_content = types.MethodType(_get_content, instance)
 
     # extract out our summary
-    if not hasattr(instance, '_summary'):
+    if not hasattr(instance, '_summary') and instance._content is not None:
         content = instance._content
         begin_summary = -1
         end_summary = -1


### PR DESCRIPTION
fix for:

`AttributeError: 'NoneType' object has no attribute 'find'`

when using summary plugin with static files
