### PR TITLE
Use pytidylib to clean up content HTML fragments in pelican-import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Pelican currently supports:
 * Code syntax highlighting
 * Asset management with `webassets`_ (optional)
 * Import from WordPress, Dotclear, or RSS feeds
+* Clean up imported HTML with pytidylib_ (optional)
 * Integration with external tools: Twitter, Google Analytics, etc. (optional)
 
 Have a look at the `Pelican documentation`_ for more information.
@@ -68,3 +69,4 @@ client handy, use the webchat_ for quick feedback.
 .. _webchat: http://webchat.freenode.net/?channels=pelican&uio=d4
 .. _contribute: http://docs.getpelican.com/en/latest/contribute.html
 .. _webassets: https://github.com/miracle2k/webassets
+.. _pytidylib: http://countergram.com/open-source/pytidylib

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,3 +7,4 @@ BeautifulSoup4
 lxml
 typogrify
 webassets
+pytidylib

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -19,6 +19,14 @@ from codecs import open
 from pelican.utils import slugify
 
 
+TIDYLIB = False
+try:
+    import tidylib
+    TIDYLIB = True
+except ImportError:
+    print('Install optional dependency "pytidylib" for cleaner HTML.')
+
+
 def wp2fields(xml):
     """Opens a wordpress XML file, and yield pelican fields"""
     try:
@@ -261,11 +269,14 @@ def fields2pelican(fields, out_markup, output_path, dircat=False, strip_raw=Fals
             html_filename = os.path.join(output_path, filename+'.html')
 
             with open(html_filename, 'w', encoding='utf-8') as fp:
-                # Replace newlines with paragraphs wrapped with <p> so
-                # HTML is valid before conversion
-                paragraphs = content.splitlines()
-                paragraphs = ['<p>{0}</p>'.format(p) for p in paragraphs]
-                new_content = ''.join(paragraphs)
+                if TIDYLIB:
+                    (new_content, spew) = tidylib.tidy_fragment(content, {'indent': 0})
+                else:
+                    # Replace newlines with paragraphs wrapped with <p> so
+                    # HTML is valid before conversion
+                    paragraphs = content.splitlines()
+                    paragraphs = ['<p>{0}</p>'.format(p) for p in paragraphs]
+                    new_content = ''.join(paragraphs)
 
                 fp.write(new_content)
 


### PR DESCRIPTION
Fall back to previous behavior if tidylib is unavailable.
