### PR TITLE
Raise exceptions from the autoreload loop if debug is enabled

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Release history
 ================
 
 * Support for Python 3!
+* Ensure exceptions are raised if they take place during processing
+  with autoreload enabled with debug enabled.
 
 3.1 (2012-12-04)
 ================

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -326,6 +326,9 @@ def main():
                         files_found_error = False
                     time.sleep(1)  # sleep to avoid cpu load
                 except Exception as e:
+                    if (args.verbosity == logging.DEBUG):
+                        logger.critical(e.args)
+                        raise
                     logger.warning(
                             'Caught exception "{0}". Reloading.'.format(e))
                     continue


### PR DESCRIPTION
At present, these exceptions get effectively swallowed as only the explanation is shown, not the traceback or the cause.  This logs the exception arguments and re-raises the exception.
