### PR TITLE
Add help directly to publishconf.py

### DIFF
--- a/pelican/tools/templates/publishconf.py.in
+++ b/pelican/tools/templates/publishconf.py.in
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*- #
 
+# This file is only used if you use `make publish` or
+# explicitly specify it as your config file.
+
 import sys
 sys.path.append('.')
 from pelicanconf import *


### PR DESCRIPTION
Confusion about this was the result of a question in #pelican, figure we can prevent confusion in the future.
