### PR TITLE
Fix simple template article permalink in article page.

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -3,7 +3,7 @@
 <section id="content" class="body">
   <header>
     <h2 class="entry-title">
-      <a href="{{ article.url }}" rel="bookmark"
+      <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
          title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2>
  {% import 'translations.html' as translations with context %}
  {{ translations.translations_for(article) }}


### PR DESCRIPTION
This change modifies the simple template so that the SITEURL
prefix is added to the article permalink found within the article
page itself.
