### PR TITLE
Install webassets & cssmin only for Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
     - pip install nose mock --use-mirrors
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors unittest2; else pip install --use-mirrors unittest2py3k; fi
     - pip install . --use-mirrors
-    - pip install Markdown
-    - pip install webassets
-    - pip install cssmin
+    - pip install --use-mirrors Markdown
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --use-mirrors webassets cssmin; fi
 script: nosetests -s pelican


### PR DESCRIPTION
webassets is not py3 compatible yet. This will avoid a failed install of
webassets for each py3 Travis build. (see https://github.com/getpelican/pelican/pull/706#issuecomment-15338366)
