### PR TITLE
Optional post attribute `id`.

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -35,11 +35,17 @@ class Writer(object):
     def _add_item_to_the_feed(self, feed, item):
 
         title = Markup(item.title).striptags()
+        if hasattr(item, 'id'):
+            unique_id = item.id
+        else:
+            unique_id = ('tag:%s,%s:%s'
+                         % (self.site_url.replace('http://', ''),
+                            item.date.date(),
+                            item.url))
         feed.add_item(
             title=title,
             link='%s/%s' % (self.site_url, item.url),
-            unique_id='tag:%s,%s:%s' % (self.site_url.replace('http://', ''),
-                                        item.date.date(), item.url),
+            unique_id=unique_id,
             description=item.get_content(self.site_url),
             categories=item.tags if hasattr(item, 'tags') else None,
             author_name=getattr(item, 'author', ''),


### PR DESCRIPTION
Implement an optional `id` attribute on posts, that can be used to
override the default feed unique-id generation. Useful if you have
an old feed with a different format of ids, or ever need to rename a
post without it showing up as a duplicate in everyones feed.
