### PR TITLE
Fix for issue #219: tags should list only main articles, not translations

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -417,9 +417,6 @@ class ArticlesGenerator(Generator):
             self.add_source_path(article)
 
             if article.status == "published":
-                if hasattr(article, 'tags'):
-                    for tag in article.tags:
-                        self.tags[tag].append(article)
                 all_articles.append(article)
             elif article.status == "draft":
                 self.drafts.append(article)
@@ -431,11 +428,16 @@ class ArticlesGenerator(Generator):
         self.articles, self.translations = process_translations(all_articles)
 
         for article in self.articles:
-            # only main articles are listed in categories, not translations
+            # only main articles are listed in categories and tags
+            # not translations
             self.categories[article.category].append(article)
+            if hasattr(article, 'tags'):
+                for tag in article.tags:
+                    self.tags[tag].append(article)
             # ignore blank authors as well as undefined
             if hasattr(article, 'author') and article.author.name != '':
                 self.authors[article.author].append(article)
+
 
         # sort the articles by date
         self.articles.sort(key=attrgetter('date'), reverse=True)

--- a/pelican/tests/output/basic/tag/bar.html
+++ b/pelican/tests/output/basic/tag/bar.html
@@ -35,34 +35,8 @@
 
                             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../second-article-fr.html">Deuxième article</a></h1> 
+                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1> 
                     <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-        <p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
-            <a href="../second-article.html">en</a>
-    
-</footer><!-- /.post-info --><p>Ceci est un article, en français.</p>
-                </article>
-                            </aside><!-- /#featured -->
-                            <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-                                                
-
-                 
-                        <li><article class="hentry">    
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-                
-                <div class="entry-content">
-                <footer class="post-info">
         <abbr class="published" title="2012-02-29T00:00:00">
                 Wed 29 February 2012
         </abbr>
@@ -71,12 +45,14 @@
 <p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
             <a href="../second-article-fr.html">fr</a>
     
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-                                </div><!-- /.entry-content -->
-            </article></li>
-                            
+</footer><!-- /.post-info --><p>This is some article, in english</p>
+                </article>
+                            </aside><!-- /#featured -->
+                            <section id="content" class="body">
+                    <h1>Other articles</h1>
+                    <hr />
+                    <ol id="posts-list" class="hfeed">
+                                                
 
                  
                         <li><article class="hentry">    

--- a/pelican/tests/output/basic/tag/baz.html
+++ b/pelican/tests/output/basic/tag/baz.html
@@ -35,34 +35,8 @@
 
                             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../second-article-fr.html">Deuxième article</a></h1> 
+                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1> 
                     <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-        <p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
-            <a href="../second-article.html">en</a>
-    
-</footer><!-- /.post-info --><p>Ceci est un article, en français.</p>
-                </article>
-                            </aside><!-- /#featured -->
-                            <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-                                                
-
-                 
-                        <li><article class="hentry">    
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-                
-                <div class="entry-content">
-                <footer class="post-info">
         <abbr class="published" title="2012-02-29T00:00:00">
                 Wed 29 February 2012
         </abbr>
@@ -71,13 +45,11 @@
 <p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
             <a href="../second-article-fr.html">fr</a>
     
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-                                </div><!-- /.entry-content -->
-            </article></li>
-                            </ol><!-- /#posts-list -->
-                                                    </section><!-- /#content -->
+</footer><!-- /.post-info --><p>This is some article, in english</p>
+                </article>
+                                                                </aside><!-- /#featured -->
+                                                </ol><!-- /#posts-list -->
+                        </section><!-- /#content -->
                     <section id="extras" class="body">
                                 <div class="social">
                         <h2>social</h2>

--- a/pelican/tests/output/basic/tag/foo.html
+++ b/pelican/tests/output/basic/tag/foo.html
@@ -35,34 +35,8 @@
 
                             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../second-article-fr.html">Deuxième article</a></h1> 
+                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1> 
                     <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-        <p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
-            <a href="../second-article.html">en</a>
-    
-</footer><!-- /.post-info --><p>Ceci est un article, en français.</p>
-                </article>
-                            </aside><!-- /#featured -->
-                            <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-                                                
-
-                 
-                        <li><article class="hentry">    
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-                
-                <div class="entry-content">
-                <footer class="post-info">
         <abbr class="published" title="2012-02-29T00:00:00">
                 Wed 29 February 2012
         </abbr>
@@ -71,12 +45,14 @@
 <p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
             <a href="../second-article-fr.html">fr</a>
     
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-                                </div><!-- /.entry-content -->
-            </article></li>
-                            
+</footer><!-- /.post-info --><p>This is some article, in english</p>
+                </article>
+                            </aside><!-- /#featured -->
+                            <section id="content" class="body">
+                    <h1>Other articles</h1>
+                    <hr />
+                    <ol id="posts-list" class="hfeed">
+                                                
 
                  
                         <li><article class="hentry">    

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -39,37 +39,8 @@
 
                             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../second-article-fr.html">Deuxième article</a></h1> 
+                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1> 
                     <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-                <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-        <p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
-            <a href="../second-article.html">en</a>
-    
-</footer><!-- /.post-info --><p>Ceci est un article, en français.</p>
-<p>There are <a href="../second-article-fr.html#disqus_thread">comments</a>.</p>                </article>
-                            </aside><!-- /#featured -->
-                            <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-                                                
-
-                 
-                        <li><article class="hentry">    
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-                
-                <div class="entry-content">
-                <footer class="post-info">
         <abbr class="published" title="2012-02-29T00:00:00">
                 Wed 29 February 2012
         </abbr>
@@ -81,12 +52,14 @@
 <p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
             <a href="../second-article-fr.html">fr</a>
     
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-                <p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                            
+</footer><!-- /.post-info --><p>This is some article, in english</p>
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </article>
+                            </aside><!-- /#featured -->
+                            <section id="content" class="body">
+                    <h1>Other articles</h1>
+                    <hr />
+                    <ol id="posts-list" class="hfeed">
+                                                
 
                  
                         <li><article class="hentry">    

--- a/pelican/tests/output/custom/tag/baz.html
+++ b/pelican/tests/output/custom/tag/baz.html
@@ -39,37 +39,8 @@
 
                             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../second-article-fr.html">Deuxième article</a></h1> 
+                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1> 
                     <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-                <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-        <p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
-            <a href="../second-article.html">en</a>
-    
-</footer><!-- /.post-info --><p>Ceci est un article, en français.</p>
-<p>There are <a href="../second-article-fr.html#disqus_thread">comments</a>.</p>                </article>
-                            </aside><!-- /#featured -->
-                            <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-                                                
-
-                 
-                        <li><article class="hentry">    
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-                
-                <div class="entry-content">
-                <footer class="post-info">
         <abbr class="published" title="2012-02-29T00:00:00">
                 Wed 29 February 2012
         </abbr>
@@ -81,15 +52,13 @@
 <p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
             <a href="../second-article-fr.html">fr</a>
     
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-                <p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                            </ol><!-- /#posts-list -->
-                            <p class="paginator">
+</footer><!-- /.post-info --><p>This is some article, in english</p>
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </article>
+                                    <p class="paginator">
         Page 1 / 1
     </p>
+                            </aside><!-- /#featured -->
+                                                </ol><!-- /#posts-list -->
                         </section><!-- /#content -->
                     <section id="extras" class="body">
                         <div class="blogroll">

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -39,37 +39,8 @@
 
                             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../second-article-fr.html">Deuxième article</a></h1> 
+                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1> 
                     <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-                <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-        <p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
-            <a href="../second-article.html">en</a>
-    
-</footer><!-- /.post-info --><p>Ceci est un article, en français.</p>
-<p>There are <a href="../second-article-fr.html#disqus_thread">comments</a>.</p>                </article>
-                            </aside><!-- /#featured -->
-                            <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-                                                
-
-                 
-                        <li><article class="hentry">    
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-                
-                <div class="entry-content">
-                <footer class="post-info">
         <abbr class="published" title="2012-02-29T00:00:00">
                 Wed 29 February 2012
         </abbr>
@@ -81,12 +52,14 @@
 <p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations: 
             <a href="../second-article-fr.html">fr</a>
     
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-                <p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                            
+</footer><!-- /.post-info --><p>This is some article, in english</p>
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </article>
+                            </aside><!-- /#featured -->
+                            <section id="content" class="body">
+                    <h1>Other articles</h1>
+                    <hr />
+                    <ol id="posts-list" class="hfeed">
+                                                
 
                  
                         <li><article class="hentry">    


### PR DESCRIPTION
This fixes the issue #219 and updates the expected outputs accordingly.

Previously, all articles were listed in a tag (and related places, e.g. `tags` in templates). This resulted in articles with translations listed multiple times in `tag.html` created pages. Now, only articles in the default language are listed.
