### PR TITLE
Nitpicking - tempdir naming, also backslashes are bad

### DIFF
--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -8,8 +8,8 @@ from codecs import open
 from tempfile import mkdtemp
 from shutil import rmtree
 
-from pelican.generators import ArticlesGenerator, PagesGenerator, \
-    TemplatePagesGenerator
+from pelican.generators import (ArticlesGenerator, PagesGenerator,
+                                TemplatePagesGenerator)
 from pelican.writers import Writer
 from pelican.settings import _DEFAULT_CONFIG
 from pelican.tests.support import unittest, get_settings
@@ -219,8 +219,8 @@ class TestTemplatePagesGenerator(unittest.TestCase):
     TEMPLATE_CONTENT = "foo: {{ foo }}"
 
     def setUp(self):
-        self.temp_content = mkdtemp()
-        self.temp_output = mkdtemp()
+        self.temp_content = mkdtemp(prefix='pelicantests.')
+        self.temp_output = mkdtemp(prefix='pelicantests.')
 
     def tearDown(self):
         rmtree(self.temp_content)

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -42,7 +42,7 @@ class TestPelican(LoggedTestCase):
 
     def setUp(self):
         super(TestPelican, self).setUp()
-        self.temp_path = mkdtemp()
+        self.temp_path = mkdtemp(prefix='pelicantests.')
         self.old_locale = locale.setlocale(locale.LC_ALL)
         self.maxDiff = None
         locale.setlocale(locale.LC_ALL, str('C'))
@@ -53,12 +53,12 @@ class TestPelican(LoggedTestCase):
         super(TestPelican, self).tearDown()
 
     def assertFilesEqual(self, diff):
-        msg = "some generated files differ from the expected functional " \
-              "tests output.\n" \
-              "This is probably because the HTML generated files " \
-              "changed. If these changes are normal, please refer " \
-              "to docs/contribute.rst to update the expected " \
-              "output of the functional tests."
+        msg = ("some generated files differ from the expected functional "
+               "tests output.\n"
+               "This is probably because the HTML generated files "
+               "changed. If these changes are normal, please refer "
+               "to docs/contribute.rst to update the expected "
+               "output of the functional tests.")
 
         self.assertEqual(diff['left_only'], [], msg=msg)
         self.assertEqual(diff['right_only'], [], msg=msg)

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -94,9 +94,9 @@ class RstReaderTest(unittest.TestCase):
         # unmodified
         content, _ = readers.read_file(_path('article.rst'))
         expected = ('<p>This is some content. With some stuff to '
-                   '&quot;typogrify&quot;.</p>\n<p>Now with added '
-                   'support for <abbr title="three letter acronym">'
-                   'TLA</abbr>.</p>\n')
+                    '&quot;typogrify&quot;.</p>\n<p>Now with added '
+                    'support for <abbr title="three letter acronym">'
+                    'TLA</abbr>.</p>\n')
 
         self.assertEqual(content, expected)
 
@@ -138,25 +138,26 @@ class MdReaderTest(unittest.TestCase):
         # correct reader
         content, metadata = reader.read(
             _path('article_with_md_extension.md'))
-        expected = "<h1>Test Markdown File Header</h1>\n"\
-                "<h2>Used for pelican test</h2>\n"\
-                "<p>The quick brown fox jumped over the lazy dog's back.</p>"
+        expected = (
+                "<h1>Test Markdown File Header</h1>\n"
+                "<h2>Used for pelican test</h2>\n"
+                "<p>The quick brown fox jumped over the lazy dog's back.</p>")
         self.assertEqual(content, expected)
         # test to ensure the mkd file extension is being processed by the
         # correct reader
         content, metadata = reader.read(
             _path('article_with_mkd_extension.mkd'))
-        expected = "<h1>Test Markdown File Header</h1>\n<h2>Used for pelican"\
-                   " test</h2>\n<p>This is another markdown test file.  Uses"\
-                   " the mkd extension.</p>"
+        expected = ("<h1>Test Markdown File Header</h1>\n<h2>Used for pelican"
+                    " test</h2>\n<p>This is another markdown test file.  Uses"
+                    " the mkd extension.</p>")
         self.assertEqual(content, expected)
         # test to ensure the markdown file extension is being processed by the
         # correct reader
         content, metadata = reader.read(
             _path('article_with_markdown_extension.markdown'))
-        expected = "<h1>Test Markdown File Header</h1>\n<h2>Used for pelican"\
-                   " test</h2>\n<p>This is another markdown test file.  Uses"\
-                   " the markdown extension.</p>"
+        expected = ("<h1>Test Markdown File Header</h1>\n<h2>Used for pelican"
+                    " test</h2>\n<p>This is another markdown test file.  Uses"
+                    " the markdown extension.</p>")
         self.assertEqual(content, expected)
 
     @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
@@ -166,16 +167,16 @@ class MdReaderTest(unittest.TestCase):
         content, metadata = readers.read_file(
                 _path('article_with_markdown_markup_extensions.md'),
                 settings={'MD_EXTENSIONS': ['toc', 'codehilite', 'extra']})
-        expected = '<div class="toc">\n'\
-            '<ul>\n'\
-            '<li><a href="#level1">Level1</a><ul>\n'\
-            '<li><a href="#level2">Level2</a></li>\n'\
-            '</ul>\n'\
-            '</li>\n'\
-            '</ul>\n'\
-            '</div>\n'\
-            '<h2 id="level1">Level1</h2>\n'\
-            '<h3 id="level2">Level2</h3>'
+        expected = ('<div class="toc">\n'
+                    '<ul>\n'
+                    '<li><a href="#level1">Level1</a><ul>\n'
+                    '<li><a href="#level2">Level2</a></li>\n'
+                    '</ul>\n'
+                    '</li>\n'
+                    '</ul>\n'
+                    '</div>\n'
+                    '<h2 id="level1">Level1</h2>\n'
+                    '<h3 id="level2">Level2</h3>')
 
         self.assertEqual(content, expected)
 
@@ -231,9 +232,9 @@ class AdReaderTest(unittest.TestCase):
         content, metadata = reader.read(
                                 _path('article_with_asc_extension.asc'))
         expected = ('<hr>\n<h2><a name="_used_for_pelican_test">'
-                   '</a>Used for pelican test</h2>\n'
-                   '<p>The quick brown fox jumped over'
-                   ' the lazy dog&#8217;s back.</p>\n')
+                    '</a>Used for pelican test</h2>\n'
+                    '<p>The quick brown fox jumped over'
+                    ' the lazy dog&#8217;s back.</p>\n')
         self.assertEqual(content, expected)
         expected = {
             'category': 'Blog',

--- a/pelican/tests/test_webassets.py
+++ b/pelican/tests/test_webassets.py
@@ -25,7 +25,7 @@ class TestWebAssets(unittest.TestCase):
     """Base class for testing webassets."""
 
     def setUp(self, override=None):
-        self.temp_path = mkdtemp()
+        self.temp_path = mkdtemp(prefix='pelicantests.')
         settings = {
             'PATH': os.path.join(CUR_DIR, 'content', 'TestCategory'),
             'OUTPUT_PATH': self.temp_path,


### PR DESCRIPTION
Minor tests refactoring for clarity and easier debugging.

Tempdirs should have useful prefixes to aid in collecting information
    about failed tests.
Implicit concatenation is better than backslash line continuation.
