### PR TITLE
Correct the meta-data infomation in the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -75,7 +75,7 @@ include the following at the top of the article::
 
     Modified: 2012-08-08
 
-In a reStructuredText post, this is how the meta-data would be enterend::
+In a reStructuredText post, the meta-data would be entered like this::
 
     :Modified: 2012-08-08
 


### PR DESCRIPTION
Meta-data have to be entered as reStructuredText Field Lists, which start with a colon. See http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists
