### PR TITLE
Fix for issue #392

### DIFF
--- a/pelican/tests/__init__.py
+++ b/pelican/tests/__init__.py
@@ -1,0 +1,2 @@
+import logging
+logging.getLogger().addHandler(logging.NullHandler())


### PR DESCRIPTION
This adds a `NullHandler` as default handler for loggers in tests so that while testing, components that log stuff won't complain about handlers 

i.e. no more pesky `No handlers could be found for logger "pelican.contents"` messages when running tests (issue #392).

Tests that care about logging install their own handlers and use that without a problem.
