### PR TITLE
Add a new pagination setting 'TEMPLATE_PAGINATION' which allows the user to set the number of pages used on a per-template basis.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -407,6 +407,10 @@ Setting name (default value)                        What does it do?
 `DEFAULT_PAGINATION` (``False``)                    The maximum number of articles to include on a
                                                     page, not including orphans. False to disable
                                                     pagination.
+`TEMPLATE_PAGINATION` (``{}``)                      A dictionary used to set per-template pagination,
+                                                    used when you wish different templates to have
+                                                    a specific number of articles per page.
+                                                    For example: ``{'index': 10}``
 ================================================    =====================================================
 
 Tag cloud

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -79,6 +79,7 @@ _DEFAULT_CONFIG = {'PATH': os.curdir,
                    'DATE_FORMATS': {},
                    'JINJA_EXTENSIONS': [],
                    'LOCALE': '',  # defaults to user locale
+                   'TEMPLATE_PAGINATION': {},
                    'DEFAULT_PAGINATION': False,
                    'DEFAULT_ORPHANS': 0,
                    'DEFAULT_METADATA': (),

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -142,7 +142,14 @@ class Writer(object):
             for key in paginated.keys():
                 object_list = paginated[key]
 
-                if self.settings.get('DEFAULT_PAGINATION'):
+                template_pagination = self.settings.get('TEMPLATE_PAGINATION')
+                if template_pagination:
+                    per_page = template_pagination.get(template.name.strip('.html'))
+
+                if per_page:
+                    paginators[key] = Paginator(object_list,
+                        per_page, self.settings.get('DEFAULT_ORPHANS'))
+                elif self.settings.get('DEFAULT_PAGINATION'):
                     paginators[key] = Paginator(object_list,
                         self.settings.get('DEFAULT_PAGINATION'),
                         self.settings.get('DEFAULT_ORPHANS'))


### PR DESCRIPTION
This change adds a new setting 'TEMPLATE_PAGINATION', which may be used when
you want a specific page to have a different pagination value than the default.

For example, you want an index page with 10 articles per page, but category
pages should have 3 articles per page.

(This change includes update to docs/settings.rst which explains how to use the setting)
