### PR TITLE
unify css class for pygments

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -44,7 +44,7 @@ I'm creating my own theme. How do I use Pygments for syntax highlighting?
 
 Pygments adds some classes to the generated content. These classes are used by
 themes to style code syntax highlighting via CSS. Specifically, you can
-customize the appearance of your syntax highlighting via the ``.codehilite pre``
+customize the appearance of your syntax highlighting via the ``.highlight pre``
 class in your theme's CSS file. To see how various styles can be used to render
 Django code, for example, you can use the demo `on the project website
 <http://pygments.org/demo/15101/>`_.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -84,10 +84,15 @@ Setting name (default value)                                            What doe
 `IGNORE_FILES` (``[]``)                                                 A list of file globbing patterns to match against the
                                                                         source files to be ignored by the processor. For example
                                                                         ``['.#*']`` will ignore emacs temporary files.
-`MD_EXTENSIONS` (``['codehilite','extra']``)                            A list of the extensions that the Markdown processor
-                                                                        will use. Refer to the extensions chapter in the
-                                                                        Python-Markdown documentation for a complete list of
-                                                                        supported extensions.
+`MD_EXTENSIONS` (``['codehilite(css_class=highlight)','extra']``)       A list of the extensions that the Markdown processor
+                                                                        will use. Refer to the Python Markdown documentation's
+                                                                        `Extensions section <http://pythonhosted.org/Markdown/extensions/>`_
+                                                                        for a complete list of supported extensions. (Note that
+                                                                        defining this in your settings file will override and
+                                                                        replace the default values. If your goal is to *add*
+                                                                        to the default values for this setting, you'll need to
+                                                                        include them explicitly and enumerate the full list of
+                                                                        desired Markdown extensions.)
 `OUTPUT_PATH` (``'output/'``)                                           Where to output the generated files.
 `PATH` (``None``)                                                       Path to content directory to be processed by Pelican.
 `PAGE_DIR` (``'pages'``)                                                Directory to look at for pages, relative to `PATH`.

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -147,7 +147,7 @@ class RstReader(Reader):
 class MarkdownReader(Reader):
     enabled = bool(Markdown)
     file_extensions = ['md', 'markdown', 'mkd']
-    default_extensions = ['codehilite', 'extra']
+    default_extensions = ['codehilite(css_class=highlight)', 'extra']
 
     def __init__(self, *args, **kwargs):
         super(MarkdownReader, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Code blocks in reST and Markdown was producing different CSS classes (`highlight` and `codehilite` respectively) [#746]. This PR unifies those under the `highlight` name, so that it's easier to manage content with both `.rst` and `.md` files. 
