### PR TITLE
fix for issue #761: handle unicode correctly in summary for Markdown

### DIFF
--- a/pelican/log.py
+++ b/pelican/log.py
@@ -36,7 +36,7 @@ class ANSIFormatter(Formatter):
 
     """
     def format(self, record):
-        msg = str(record.msg)
+        msg = record.getMessage()
         if record.levelname == 'INFO':
             return ansi('cyan', '-> ') + msg
         elif record.levelname == 'WARNING':
@@ -58,9 +58,9 @@ class TextFormatter(Formatter):
 
     def format(self, record):
         if not record.levelname or record.levelname == 'INFO':
-            return record.msg
+            return record.getMessage()
         else:
-            return record.levelname + ': ' + record.msg
+            return record.levelname + ': ' + record.getMessage()
 
 
 def init(level=None, logger=getLogger(), handler=StreamHandler()):

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -162,7 +162,7 @@ class MarkdownReader(Reader):
         for name, value in meta.items():
             name = name.lower()
             if name == "summary":
-                summary_values = "\n".join(str(item) for item in value)
+                summary_values = "\n".join(value)
                 summary = self._md.convert(summary_values)
                 output[name] = self.process_metadata(name, summary)
             else:

--- a/pelican/tests/content/article_with_markdown_and_nonascii_summary.md
+++ b/pelican/tests/content/article_with_markdown_and_nonascii_summary.md
@@ -1,0 +1,18 @@
+Title: マックOS X 10.8でパイソンとVirtualenvをインストールと設定
+Slug: python-virtualenv-on-mac-osx-mountain-lion-10.8
+Date: 2012-12-20
+Tags: パイソン, マック
+Category: 指導書
+Summary: パイソンとVirtualenvをまっくでインストールする方法について明確に説明します。
+
+Writing unicode is certainly fun.
+
+パイソンとVirtualenvをまっくでインストールする方法について明確に説明します。
+
+And let's mix languages.
+
+первый пост
+
+Now another.
+
+İlk yazı çok özel değil.

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -88,7 +88,8 @@ class TestArticlesGenerator(unittest.TestCase):
              'article'],
             ['This is an article without category !', 'published',
              'TestCategory', 'article'],
-            ['This is a super article !', 'published', 'yeah', 'article']
+            ['This is a super article !', 'published', 'yeah', 'article'],
+            ['マックOS X 10.8でパイソンとVirtualenvをインストールと設定', 'published', '指導書', 'article']
         ]
         self.assertItemsEqual(articles_expected, articles)
 
@@ -97,7 +98,7 @@ class TestArticlesGenerator(unittest.TestCase):
         generator = self.get_populated_generator()
         categories = [cat.name for cat, _ in generator.categories]
         categories_expected = ['Default', 'TestCategory', 'Yeah', 'test',
-                               'yeah']
+                               'yeah', '指導書']
         self.assertEquals(categories, categories_expected)
 
     def test_do_not_use_folder_as_category(self):
@@ -114,7 +115,7 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_context()
 
         categories = [cat.name for cat, _ in generator.categories]
-        self.assertEquals(categories, ['Default', 'Yeah', 'test', 'yeah'])
+        self.assertEquals(categories, ['Default', 'Yeah', 'test', 'yeah', '指導書'])
 
     def test_direct_templates_save_as_default(self):
 

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -131,6 +131,19 @@ class MdReaderTest(unittest.TestCase):
         for key, value in metadata.items():
             self.assertEquals(value, expected[key], key)
 
+        content, metadata = reader.read(
+            _path('article_with_markdown_and_nonascii_summary.md'))
+        expected = {
+            'title': 'マックOS X 10.8でパイソンとVirtualenvをインストールと設定',
+            'summary': '<p>パイソンとVirtualenvをまっくでインストールする方法について明確に説明します。</p>',
+            'category': '指導書',
+            'date': datetime.datetime(2012, 12, 20),
+            'tags': ['パイソン', 'マック'],
+            'slug': 'python-virtualenv-on-mac-osx-mountain-lion-10.8',
+        }
+        for key, value in metadata.items():
+            self.assertEquals(value, expected[key], key)
+
     @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
     def test_article_with_file_extensions(self):
         reader = readers.MarkdownReader({})


### PR DESCRIPTION
This fixes issue #761. Explicit `str` call when generating the `summary` for Markdown files was causing problems with non-ascii text. This fixes it and also adds a new test case for non-ascii metadata handling.

This also fixes a minor bug in `log` module. It wasn't handling cases with non-ascii file/path names correctly in Python 2..
