### PR TITLE
Fix for issue #428: Use PLUGIN_PATH properly

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -24,7 +24,8 @@ Alternatively, another method is to import them and add them to the list::
     PLUGINS = [gravatar,]
 
 If your plugins are not in an importable path, you can specify a ``PLUGIN_PATH``
-in the settings::
+in the settings. ``PLUGIN_PATH`` can be an absolute path or a path relative to
+the settings file::
 
     PLUGIN_PATH = "plugins"
     PLUGINS = ["list", "of", "plugins"]

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -89,6 +89,7 @@ _DEFAULT_CONFIG = {'PATH': os.curdir,
                    'ARTICLE_PERMALINK_STRUCTURE': '',
                    'TYPOGRIFY': False,
                    'SUMMARY_MAX_LENGTH': 50,
+                   'PLUGIN_PATH': '',
                    'PLUGINS': [],
                    'TEMPLATE_PAGES': {},
                    'IGNORE_FILES': []
@@ -99,12 +100,12 @@ def read_settings(path=None, override=None):
     if path:
         local_settings = get_settings_from_file(path)
         # Make the paths relative to the settings file
-        for p in ['PATH', 'OUTPUT_PATH', 'THEME']:
+        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'PLUGIN_PATH']:
             if p in local_settings and local_settings[p] is not None \
                     and not isabs(local_settings[p]):
                 absp = os.path.abspath(os.path.normpath(os.path.join(
                             os.path.dirname(path), local_settings[p])))
-                if p != 'THEME' or os.path.exists(absp):
+                if p not in ('THEME', 'PLUGIN_PATH') or os.path.exists(absp):
                     local_settings[p] = absp
     else:
         local_settings = copy.deepcopy(_DEFAULT_CONFIG)


### PR DESCRIPTION
Fixes issue #428 by temporarily adding `PLUGIN_PATH` to the `sys.path`.

Another change: `.plugins` attribute of the `pelican` object was just a duplicate of `PLUGINS` option (i.e. strings, module objects, whatever you put there). Now it's a list of loaded module objects. I believe this is more consistent. 

It does not break anything in the Pelican core, since nothing internal cares about that attribute. If there is a custom plugin out there relying on that attribute, it might be 'breaking;. But I have no idea what anyone would do with that attribute in its old state.
