### PR TITLE
Add translation metadata support.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -392,6 +392,19 @@ identifier. If you'd rather not explicitly define the slug this way, you must
 then instead ensure that the translated article titles are identical, since the
 slug will be auto-generated from the article title.
 
+If you do not want the original version of one specific article to be detected
+by the ``DEFAULT_LANG`` setting, use the ``translation`` metadata to specify
+which posts are translations::
+
+    Foobar is not dead
+    ##################
+
+    :slug: foobar-is-not-dead
+    :lang: en
+    :translation: true
+
+    That's true, foobar is still alive!
+
 Syntax highlighting
 -------------------
 

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -85,12 +85,28 @@ class TestUtils(LoggedTestCase):
 
     def test_process_translations(self):
         # create a bunch of articles
+        # 1: no translation metadata
         fr_article1 = get_article(lang='fr', slug='yay', title='Un titre',
                                   content='en français')
         en_article1 = get_article(lang='en', slug='yay', title='A title',
                                   content='in english')
+        # 2: reverse which one is the translation thanks to metadata
+        fr_article2 = get_article(lang='fr', slug='yay2', title='Un titre',
+                                  content='en français')
+        en_article2 = get_article(lang='en', slug='yay2', title='A title',
+                                  content='in english',
+                                  extra_metadata={'translation': 'true'})
+        # 3: back to default language detection if all items have the
+        #    translation metadata
+        fr_article3 = get_article(lang='fr', slug='yay3', title='Un titre',
+                                  content='en français',
+                                  extra_metadata={'translation': 'yep'})
+        en_article3 = get_article(lang='en', slug='yay3', title='A title',
+                                  content='in english',
+                                  extra_metadata={'translation': 'yes'})
 
-        articles = [fr_article1, en_article1]
+        articles = [fr_article1, en_article1, fr_article2, en_article2,
+                    fr_article3, en_article3]
 
         index, trans = utils.process_translations(articles)
 
@@ -98,6 +114,16 @@ class TestUtils(LoggedTestCase):
         self.assertIn(fr_article1, trans)
         self.assertNotIn(en_article1, trans)
         self.assertNotIn(fr_article1, index)
+
+        self.assertIn(fr_article2, index)
+        self.assertIn(en_article2, trans)
+        self.assertNotIn(fr_article2, trans)
+        self.assertNotIn(en_article2, index)
+
+        self.assertIn(en_article3, index)
+        self.assertIn(fr_article3, trans)
+        self.assertNotIn(en_article3, trans)
+        self.assertNotIn(fr_article3, index)
 
     def test_files_changed(self):
         # Test if file changes are correctly detected

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -395,7 +395,9 @@ def process_translations(content_list):
 
     Returns a tuple with two lists (index, translations).  Index list includes
     items in default language or items which have no variant in default
-    language.
+    language. Items with the `translation` metadata set to something else than
+    `False` or `false` will be used as translations, unless all the items with
+    the same slug have that metadata.
 
     For each content_list item, sets the 'translations' attribute.
     """
@@ -406,8 +408,18 @@ def process_translations(content_list):
 
     for slug, items in grouped_by_slugs:
         items = list(items)
+        # items with `translation` metadata will be used as translations…
+        default_lang_items = list(filter(
+                lambda i: i.metadata.get('translation', 'false').lower()
+                        == 'false',
+                items))
+        # …unless all items with that slug are translations
+        if not default_lang_items:
+            default_lang_items = items
+
         # find items with default language
-        default_lang_items = list(filter(attrgetter('in_default_lang'), items))
+        default_lang_items = list(filter(attrgetter('in_default_lang'),
+                default_lang_items))
         len_ = len(default_lang_items)
         if len_ > 1:
             logger.warning('there are %s variants of "%s"' % (len_, slug))


### PR DESCRIPTION
Allows user to control which posts are the translations independently of the DEFAULT_LANG setting.

Added corresponding unit test and documentation as well.
