### PR TITLE
Make relative URLs work on Windows.

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -317,7 +317,7 @@ def path_to_url(path):
     if os.sep == '/':
         return path
     else:
-        '/'.join(split_all(path))
+        return '/'.join(split_all(path))
 
 
 def truncate_html_words(s, num, end_text='...'):


### PR DESCRIPTION
Minor fix. On Windows, relative paths were being generated with a leading "None" because of this bug.
