### PR TITLE
.mailmap: Add mappings to consolidate author names and emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,24 @@
+Alexis Métaireau <alexis@notmyidea.org>
+Alexis Métaireau <alexis@notmyidea.org> <alexis, notmyidea, org>
+Alexis Métaireau <alexis@notmyidea.org> <ametaireau@gmail.com>
+Axel Haustant <noirbizarre@gmail.com> <axel.haustant.ext@mappy.com>
+Axel Haustant <noirbizarre@gmail.com> <axel.haustant@valtech.fr>
+Dave Mankoff <mankyd@gmail.com>
+Feth Arezki <feth@tuttu.info>
+Guillaume <guillaume@lame.homelinux.com>
+Guillaume <guillaume@lame.homelinux.com> <guillaume@mint.(none)>
+Guillaume B <guitreize@gmail.com>
+Guillermo López <guilan70@hotmail.com>
+Guillermo López <guilan70@hotmail.com> <guillermo.lopez@outlook.com>
+Jomel Imperio <jimperio@gmail.com>
+Justin Mayer <entrop@gmail.com>
+Justin Mayer <entrop@gmail.com> <entroP@gmail.com>
+Marco Milanesi <kpanic@gnufunk.org> <marcom@openquake.org>
+Massimo Santini <santini@dsi.unimi.it> <santini@spillane.docenti.dsi.unimi.it>
+Rémy HUBSCHER <hubscher.remy@gmail.com> <remy.hubscher@ionyse.com>
+Simon Conseil <contact@saimon.org>
+Simon Liedtke <liedtke.simon@googlemail.com>
+Skami18 <skami@skami-laptop.dyndns.org>
+Stuart Colville <muffinresearchlabs@gmail.com> <muffinresearch@gmail.com>
+Stéphane Bunel <stephane@lutetium.(none)>
+tBunnyMan <WagThatTail@Me.com>


### PR DESCRIPTION
See "MAPPING AUTHORS" in git-shortlog(1) for syntax details.

I don't think I've accidentally merged two distinct people together, but I
added

  Guillaume B guitreize@gmail.com

to avoid someone accidentally merging him into

  Guillaume guillaume@lame.homelinux.com

I'm pretty sure these are two different Guillaumes.
