### PR TITLE
Cleanup tox and remove mentions of webassets.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,6 @@ Pelican currently supports:
 * Publication of articles in multiple languages
 * Atom/RSS feeds
 * Code syntax highlighting
-* Asset management with `webassets`_ (optional)
 * Import from WordPress, Dotclear, or RSS feeds
 * Integration with external tools: Twitter, Google Analytics, etc. (optional)
 
@@ -67,4 +66,3 @@ client handy, use the webchat_ for quick feedback.
 .. _`#pelican on Freenode`: irc://irc.freenode.net/pelican
 .. _webchat: http://webchat.freenode.net/?channels=pelican&uio=d4
 .. _contribute: http://docs.getpelican.com/en/latest/contribute.html
-.. _webassets: https://github.com/miracle2k/webassets

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,6 @@ Pelican currently supports:
 * Publication of articles in multiple languages
 * Atom/RSS feeds
 * Code syntax highlighting
-* Asset management with `webassets`_ (optional)
 * Import from WordPress, Dotclear, or RSS feeds
 * Integration with external tools: Twitter, Google Analytics, etc. (optional)
 
@@ -80,4 +79,3 @@ A French version of the documentation is available at :doc:`fr/index`.
 .. _`Pelican's internals`: http://docs.getpelican.com/en/latest/internals.html
 .. _`#pelican on Freenode`: irc://irc.freenode.net/pelican
 .. _webchat: http://webchat.freenode.net/?channels=pelican&uio=d4
-.. _webassets: https://github.com/miracle2k/webassets

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 #
 # Now we must tell tox about this package, otherwise tox would load the old
 # libraries from PyPi.
-# 
+#
 # Run tox from the libraries source tree. It will save its package in
 # the distshare directory from where the tests here will pick it up.
 #
@@ -15,19 +15,11 @@
 # and typogrify:
 # https://github.com/dmdm/typogrify/tree/py3k
 #
-# and webassets:
-# https://github.com/dmdm/webassets/tree/py3k
-#
-#
 # CAVEAT:
 # -------
 #
-# 1/
-# Please be aware that my ports of typogrify and webassets are just 2to3'd.
-# They are not backwards compatible with Python 2.
-#
-# 2/
-# Webassets still has unresolved issues, so I deactivated it for Py32 tests.
+# Please be aware that my port of typogrify is just 2to3'd.
+# It is not backwards compatible with Python 2.
 
 
 [tox]
@@ -35,41 +27,31 @@ envlist = py27,py32,py33
 
 [testenv]
 commands =
-    unit2 discover []
-    nosetests -s pelican
+    python -m unittest discover
 deps =
 
 [testenv:py27]
 deps =
-    nose
-    unittest2
     mock
     Markdown
     BeautifulSoup4
     feedgenerator
     typogrify
-    webassets
 
 [testenv:py32]
 deps =
-    nose
-    unittest2py3k
     mock
     Markdown
     BeautifulSoup4
     feedgenerator
 #    {distshare}/smartypants-1.6.0.3.zip
 #    {distshare}/typogrify-2.0.0.zip
-#    {distshare}/webassets-0.8.dev.zip
 
 [testenv:py33]
 deps =
-    nose
-    unittest2py3k
     mock
     Markdown
     BeautifulSoup4
     feedgenerator
 #    {distshare}/smartypants-1.6.0.3.zip
 #    {distshare}/typogrify-2.0.0.zip
-#    {distshare}/webassets-0.8.dev.zip


### PR DESCRIPTION
Nose and unittest2 have been removed from pelican's dependencies, and webassets
moved to pelican-plugins.
