### PR TITLE
Do not generate invalid filenames. Fixes #814.

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -376,6 +376,15 @@ def fields2pelican(fields, out_markup, output_path, dircat=False, strip_raw=Fals
 
         filename = os.path.basename(filename)
 
+        # Enforce filename restrictions for various filesystems at once; see
+        # http://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
+        # we do not need to filter words because an extension will be appended
+        filename = re.sub(r'[<>:"/\\|?*^% ]', '-', filename) # invalid chars
+        filename = filename.lstrip('.') # should not start with a dot
+        if not filename:
+            filename = '_'
+        filename = filename[:249] # allow for 5 extra characters
+
         # option to put files in directories with categories names
         if dircat and (len(categories) > 0):
             catname = slugify(categories[0])


### PR DESCRIPTION
Turn invalid characters into underscores, remove leading dots and enforce a
maximum length. Should be fine on main file systems used by Windows, Mac OS and
Linux.
