### PR TITLE
Output sources for translations as well.

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -669,3 +669,5 @@ class SourceFileGenerator(Generator):
         logger.info(' Generating source files...')
         for obj in chain(self.context['articles'], self.context['pages']):
             self._create_source(obj)
+            for obj_trans in obj.translations:
+                self._create_source(obj_trans)


### PR DESCRIPTION
In case `OUTPUT_SOURCES` is set to `True`, pages and articles which are translations are currently not copied in their original format.

This pull request is to fix that wrong behaviour.
