### PR TITLE
__import__ fails for unicode 'fromlist' in Py2.x

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -66,7 +66,7 @@ class Pelican(object):
             if isinstance(plugin, six.string_types):
                 logger.debug("Loading plugin `{0}`".format(plugin))
                 try:
-                    plugin = __import__(plugin, globals(), locals(), 'module')
+                    plugin = __import__(plugin, globals(), locals(), str('module'))
                 except ImportError as e:
                     logger.error("Can't find plugin `{0}`: {1}".format(plugin, e))
                     continue


### PR DESCRIPTION
Minor fix for PLUGIN_PATH/PLUGINS handling. `__import__` fails when `fromlist` is unicode in Py2.x. It's OK in Py3.x. This forces it to be `str`.
