### PR TITLE
Fix bug with getlocale. Fix #690.

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -56,12 +56,11 @@ def strftime(date, date_format):
         # *yuck* like this:
         #        "Øl trinken beim Besäufnis"
         #    --> "&#216;l trinken beim Bes&#228;ufnis"
-        date_format = date_format.encode('ascii',
-            errors="xmlcharrefreplace")
+        date_format = date_format.encode('ascii', errors="xmlcharrefreplace")
         result = date.strftime(date_format)
         # strftime() returns an encoded byte string
         # which we must decode into unicode.
-        lang_code, enc = locale.getlocale(locale.LC_ALL)
+        lang_code, enc = locale.getlocale(locale.LC_TIME)
         if enc:
             result = result.decode(enc)
         else:


### PR DESCRIPTION
See https://github.com/getpelican/pelican/issues/690#issuecomment-16360522
From the `getlocale` doc :

```
category may be one of the LC_* values except LC_ALL. It defaults to LC_CTYPE.
```

So `getlocale(locale.LC_ALL)` should not be used, This commit replace it with
`LC_TIME` as we are here concerned with date & time.
