### PR TITLE
refactored utils.strftime

### DIFF
--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -10,6 +10,7 @@ from six import StringIO
 import logging
 from logging.handlers import BufferingHandler
 import unittest
+import locale
 
 from functools import wraps
 from contextlib import contextmanager
@@ -145,6 +146,18 @@ def module_exists(module_name):
     except ImportError:
         return False
     else:
+        return True
+
+
+def locale_available(locale_):
+    old_locale = locale.setlocale(locale.LC_TIME)
+
+    try:
+        locale.setlocale(locale.LC_TIME, str(locale_))
+    except locale.Error:
+        return False
+    else:
+        locale.setlocale(locale.LC_TIME, old_locale)
         return True
 
 


### PR DESCRIPTION
`utils.strftime` was hacky. I believe this is a better implementation. This also solves the 'normalization' problem of non-ascii characters, since only formattable substrings are passed to builtin `strftime`.

This also includes the fix proposed by #850 to issue #690. Since it's the correct approach because builtin `strftime` functions in Py2 will return a bytestring encoded with the encoding defined by `LC_TIME` ([ref](http://docs.python.org/2/library/locale.html#locale.LC_TIME)).

This PR also adds two tests for `strftime`.
