### PR TITLE
DOC: fix the Markdown example for static index page URL override

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -122,7 +122,7 @@ your home page. The following Markdown example could be stored in
 ``content/pages/home.md``::
 
     Title: Welcome to My Site
-    URL: /
+    URL: 
     save_as: index.html
 
     Thank you for visiting. Welcome!


### PR DESCRIPTION
Probably the smallest pull request ever.  I found that if, in Markdown, URL is set to `/`, the links are corrupted (I think they end up blank).  By trial and error I found that the empty string properly points to the site url. It seems an extra slash is prepended to what the user sets.  If URL is `/`, the link ends up as `<a href="//" ...` which is broken.
