### PR TITLE
Fix bug with MacOS in utils.strftime

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -211,7 +211,7 @@ class TestUtils(LoggedTestCase):
     # right now, this uses Turkish locale
     # why Turkish? because I know Turkish :). And it produces non-ascii output
     # Feel free to extend with different locales
-    @unittest.skipUnless(locale_available('tr_TR') or
+    @unittest.skipUnless(locale_available('tr_TR.UTF-8') or
                          locale_available('Turkish'),
                          'Turkish locale needed')
     def test_strftime_locale_dependent(self):
@@ -221,15 +221,13 @@ class TestUtils(LoggedTestCase):
         if platform == 'win32':
             locale.setlocale(locale.LC_TIME, str('Turkish'))
         else:
-            locale.setlocale(locale.LC_TIME, str('tr_TR'))
+            locale.setlocale(locale.LC_TIME, str('tr_TR.UTF-8'))
 
         d = datetime.date(2012, 8, 29)
 
         # simple
         self.assertEqual(utils.strftime(d, '%d %B %Y'), '29 Ağustos 2012')
         self.assertEqual(utils.strftime(d, '%d %b %Y'), '29 Ağu 2012')
-        self.assertEqual(utils.strftime(d, '%a, %d %b %Y'),
-                         'Çrş, 29 Ağu 2012')
         self.assertEqual(utils.strftime(d, '%A, %d %B %Y'),
                          'Çarşamba, 29 Ağustos 2012')
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -39,7 +39,7 @@ def strftime(date, date_format):
     '''
 
     # grab candidate format options
-    format_options = '%+.?'
+    format_options = '%.'
     candidates = re.findall(format_options, date_format)
 
     # replace candidates with placeholders for later % formatting
@@ -51,19 +51,14 @@ def strftime(date, date_format):
 
     formatted_candidates = []
     for candidate in candidates:
-        try:
-            # a valid format string should be ascii
-            candidate.encode('ascii')
-        except UnicodeEncodeError:
-            # if it fails, it's not a valid format option
-            # put the candidate back as it was
-            formatted = candidate
-        else:
-            # if it's ascii, pass it to strftime to format
+        # test for valid C89 directives only
+        if candidate[1] in 'aAbBcdfHIjmMpSUwWxXyYzZ%':
             formatted = date.strftime(candidate)
             # convert Py2 result to unicode
             if not six.PY3 and enc is not None:
                 formatted = formatted.decode(enc)
+        else:
+            formatted = candidate
         formatted_candidates.append(formatted)
 
     # put formatted candidates back and return


### PR DESCRIPTION
Force using C89 directives (i.e. mentioned in the Python documentation).

This is to fix the bug reported by @justinmayer on tests for #851.
