### PR TITLE
Accept `mdown` file extension for Markdown files.

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -232,10 +232,11 @@ Pelican implements an extension to reStructuredText to enable support for the
 
     This will be turned into :abbr:`HTML (HyperText Markup Language)`.
 
-You can also use Markdown syntax (with a file ending in ``.md``, ``.markdown``,
-or ``.mkd``). Markdown generation requires that you first explicitly install
-the ``Markdown`` package, which can be done via ``pip install Markdown``.
-Metadata syntax for Markdown posts should follow this pattern::
+You can also use Markdown syntax (with a file ending in ``.md``,
+``.markdown``, ``.mkd``, or ``.mdown``). Markdown generation requires that you
+first explicitly install the ``Markdown`` package, which can be done via ``pip
+install Markdown``. Metadata syntax for Markdown posts should follow this
+pattern::
 
     Title: My super title
     Date: 2010-12-03 10:20

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -80,7 +80,7 @@ Setting name (default value)                                            What doe
                                                                         until one works.
 `MARKUP` (``('rst', 'md')``)                                            A list of available markup languages you want
                                                                         to use. For the moment, the only available values
-                                                                        are `rst`, `md`, `markdown`, `mkd`, `html`, and `htm`.
+                                                                        are `rst`, `md`, `markdown`, `mkd`, `mdown`, `html`, and `htm`.
 `IGNORE_FILES` (``[]``)                                                 A list of file globbing patterns to match against the
                                                                         source files to be ignored by the processor. For example
                                                                         ``['.#*']`` will ignore emacs temporary files.

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -149,7 +149,7 @@ class RstReader(Reader):
 
 class MarkdownReader(Reader):
     enabled = bool(Markdown)
-    file_extensions = ['md', 'markdown', 'mkd']
+    file_extensions = ['md', 'markdown', 'mkd', 'mdown']
     default_extensions = ['codehilite(css_class=highlight)', 'extra']
 
     def __init__(self, *args, **kwargs):

--- a/pelican/tests/content/article_with_mdown_extension.mdown
+++ b/pelican/tests/content/article_with_mdown_extension.mdown
@@ -1,0 +1,10 @@
+title: Test mdown File
+category: test
+
+Test Markdown File Header
+=========================
+
+Used for pelican test
+---------------------
+
+This is another markdown test file.  Uses the mdown extension.

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -172,6 +172,14 @@ class MdReaderTest(unittest.TestCase):
                     " test</h2>\n<p>This is another markdown test file.  Uses"
                     " the markdown extension.</p>")
         self.assertEqual(content, expected)
+        # test to ensure the mdown file extension is being processed by the
+        # correct reader
+        content, metadata = reader.read(
+            _path('article_with_mdown_extension.mdown'))
+        expected = ("<h1>Test Markdown File Header</h1>\n<h2>Used for pelican"
+                    " test</h2>\n<p>This is another markdown test file.  Uses"
+                    " the mdown extension.</p>")
+        self.assertEqual(content, expected)
 
     @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
     def test_article_with_markdown_markup_extension(self):


### PR DESCRIPTION
This extension is sometimes used for Markdown files and is the default
for a few editors, such as Sublime Text.
