### PR TITLE
force argparse output to be unicode in Py2

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -8,6 +8,7 @@ import sys
 import time
 import logging
 import argparse
+import locale
 
 from pelican import signals
 
@@ -274,6 +275,18 @@ def get_config(args):
         config['THEME'] = abstheme if os.path.exists(abstheme) else args.theme
     if args.delete_outputdir is not None:
         config['DELETE_OUTPUT_DIRECTORY'] = args.delete_outputdir
+
+    # argparse returns bytes in Py2. There is no definite answer as to which
+    # encoding argparse (or sys.argv) uses.
+    # "Best" option seems to be locale.getpreferredencoding()
+    # ref: http://mail.python.org/pipermail/python-list/2006-October/405766.html
+    if not six.PY3:
+        enc = locale.getpreferredencoding()
+        for key in config:
+            if key in ('PATH', 'OUTPUT_PATH', 'THEME'):
+                config[key] = config[key].decode(enc)
+            if key == "MARKUP":
+                config[key] = [a.decode(enc) for a in config[key]]
     return config
 
 


### PR DESCRIPTION
In Py2, the result of `argparse` is bytes. Since pelican assumes everything is unicode, this causes problems because at some point implicit conversion is unavoidable.

Most obvious way to observe the problem is when the content path has non-ascii chars:

```
$ ls contént/
test.rst  тест.md

$ pelican -s pelican.conf.py contént
CRITICAL: 'ascii' codec can't decode byte 0xc3 in position 41: ordinal not in range(128)
```

When the path is ascii but there is a file with non-ascii char, the problem occurs with `-r` (autoreload) option.

```
$ ls content/
test.rst  тест.md

$ pelican -s pelican.conf.py content

$ rm -rf output

$ pelican -s pelican.conf.py -r content
WARNING: No valid files found in content. Nothing to generate.
```

This PR solves that by converting the relevant `argparse` output to unicode in Py2
