### PR TITLE
ignore emacs lock files and exception handling for watchers

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -81,9 +81,9 @@ Setting name (default value)                                            What doe
 `MARKUP` (``('rst', 'md')``)                                            A list of available markup languages you want
                                                                         to use. For the moment, the only available values
                                                                         are `rst`, `md`, `markdown`, `mkd`, `mdown`, `html`, and `htm`.
-`IGNORE_FILES` (``[]``)                                                 A list of file globbing patterns to match against the
-                                                                        source files to be ignored by the processor. For example
-                                                                        ``['.#*']`` will ignore emacs temporary files.
+`IGNORE_FILES` (``['.#*']``)                                            A list of file globbing patterns to match against the
+                                                                        source files to be ignored by the processor. For example,
+                                                                        the default ``['.#*']`` will ignore emacs lock files.
 `MD_EXTENSIONS` (``['codehilite(css_class=highlight)','extra']``)       A list of the extensions that the Markdown processor
                                                                         will use. Refer to the Python Markdown documentation's
                                                                         `Extensions section <http://pythonhosted.org/Markdown/extensions/>`_

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -353,8 +353,6 @@ def main():
  
                         pelican.run()
 
-                    time.sleep(.5)  # sleep to avoid cpu load
-
                 except KeyboardInterrupt:
                     logger.warning("Keyboard interrupt, quitting.")
                     break
@@ -365,6 +363,10 @@ def main():
                         raise
                     logger.warning(
                             'Caught exception "{0}". Reloading.'.format(e))
+
+                finally:
+                    time.sleep(.5)  # sleep to avoid cpu load
+
 
         else:
             if next(watchers['content']) is None:

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -100,7 +100,7 @@ _DEFAULT_CONFIG = {'PATH': os.curdir,
                    'PLUGIN_PATH': '',
                    'PLUGINS': [],
                    'TEMPLATE_PAGES': {},
-                   'IGNORE_FILES': []
+                   'IGNORE_FILES': ['.#*']
                    }
 
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -444,7 +444,10 @@ def folder_watcher(path, extensions, ignores=[]):
             for f in files:
                 if (f.endswith(tuple(extensions)) and
                     not any(fnmatch.fnmatch(f, ignore) for ignore in ignores)):
-                    yield os.stat(os.path.join(root, f)).st_mtime
+                    try:
+                        yield os.stat(os.path.join(root, f)).st_mtime
+                    except OSError as e:
+                        logger.warning('Caught Exception: {}'.format(e))
 
     LAST_MTIME = 0
     while True:
@@ -464,7 +467,12 @@ def file_watcher(path):
     LAST_MTIME = 0
     while True:
         if path:
-            mtime = os.stat(path).st_mtime
+            try:
+                mtime = os.stat(path).st_mtime
+            except OSError as e:
+                logger.warning('Caught Exception: {}'.format(e))
+                continue
+
             if mtime > LAST_MTIME:
                 LAST_MTIME = mtime
                 yield True


### PR DESCRIPTION
emacs creates 'lock files' (`'.#*'`) for modified files ([ref](http://www.gnu.org/software/emacs/manual/html_node/elisp/File-Locks.html)). They are invalid links with the purpose of preventing simultaneous editing of the same file. But since they are invalid, `os.stat` can't access them.

This PR adds that pattern as default for `IGNORE_FILES`.

Also exception handling for `*_watcher` generators are added so that generators won't quit unexpectedly.
