### PR TITLE
Fixes #708 SUMMARY_MAX_LENGTH=0 should return empty string

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -231,10 +231,11 @@ class Content(object):
         if hasattr(self, '_summary'):
             return self._summary
 
-        if self.settings['SUMMARY_MAX_LENGTH']:
-            return truncate_html_words(self.content,
-                    self.settings['SUMMARY_MAX_LENGTH'])
-        return self.content
+        if self.settings['SUMMARY_MAX_LENGTH'] is None:
+            return self.content
+
+        return truncate_html_words(self.content,
+                self.settings['SUMMARY_MAX_LENGTH'])
 
     def _set_summary(self, summary):
         """Dummy function"""

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -71,6 +71,9 @@ class TestPage(unittest.TestCase):
         settings['SUMMARY_MAX_LENGTH'] = 10
         page = Page(**page_kwargs)
         self.assertEqual(page.summary, truncate_html_words(TEST_CONTENT, 10))
+        settings['SUMMARY_MAX_LENGTH'] = 0
+        page = Page(**page_kwargs)
+        self.assertEqual(page.summary, '')
 
     def test_slug(self):
         # If a title is given, it should be used to generate the slug.


### PR DESCRIPTION
As title says. Setting `0` was treated the same way as setting `None` for `SUMMARY_MAX_LENGTH`. `0` should return 0 words, i.e. empty string.
