### PR TITLE
Wordpress-style <!-- more --> tag

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -231,7 +231,10 @@ class Content(object):
         if hasattr(self, '_summary'):
             return self._summary
 
-        if self.settings['SUMMARY_MAX_LENGTH']:
+        elif self.settings['SUMMARY_END']:
+            return self.content.split(self.settings['SUMMARY_MARK'])[0]
+
+        elif self.settings['SUMMARY_MAX_LENGTH']:
             return truncate_html_words(self.content,
                     self.settings['SUMMARY_MAX_LENGTH'])
         return self.content


### PR DESCRIPTION
This PR allows the user to make use of a wordpress-style `<!-- more -->` tag to denote the end of the article summary.  To use it, you must enable the setting

```
SUMMARY_END = '<!-- more -->'
```

This is superseded by the explicit setting of the summary in the article metadata, and
is entirely backward compatible: if `SUMMARY_END` is not specified, the previous behavior is preserved.
