### PR TITLE
Sort author and category pages using same sort as tags

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -335,6 +335,7 @@ class ArticlesGenerator(Generator):
         """Generate category pages."""
         category_template = self.get_template('category')
         for cat, articles in self.categories:
+            articles.sort(key=attrgetter('date'), reverse=True)
             dates = [article for article in self.dates if article in articles]
             write(cat.save_as, category_template, self.context,
                 category=cat, articles=articles, dates=dates,
@@ -345,6 +346,7 @@ class ArticlesGenerator(Generator):
         """Generate Author pages."""
         author_template = self.get_template('author')
         for aut, articles in self.authors:
+            articles.sort(key=attrgetter('date'), reverse=True)
             dates = [article for article in self.dates if article in articles]
             write(aut.save_as, author_template, self.context,
                 author=aut, articles=articles, dates=dates,

--- a/pelican/tests/output/basic/author/alexis-metaireau.html
+++ b/pelican/tests/output/basic/author/alexis-metaireau.html
@@ -26,37 +26,7 @@
 
             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="/oh-yeah.html">Oh yeah !</a></h1>
-<footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00">
-                Wed 20 October 2010
-        </abbr>
-
-        <address class="vcard author">
-                By <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-<p>In <a href="/category/bar.html">bar</a>. </p>
-<p>tags: <a href="/tag/oh.html">oh</a><a href="/tag/bar.html">bar</a><a href="/tag/yeah.html">yeah</a></p>
-</footer><!-- /.post-info --><div class="section" id="why-not">
-<h2>Why not ?</h2>
-<p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
-YEAH !</p>
-<img alt="alternate text" src="|filename|/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
-</div>
-                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/this-is-a-super-article.html" rel="bookmark"
-                           title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
-
-                <div class="entry-content">
+                    <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
 <footer class="post-info">
         <abbr class="published" title="2010-12-02T10:14:00">
                 Thu 02 December 2010
@@ -67,10 +37,50 @@ YEAH !</p>
         </address>
 <p>In <a href="/category/yeah.html">yeah</a>. </p>
 <p>tags: <a href="/tag/foo.html">foo</a><a href="/tag/bar.html">bar</a><a href="/tag/foobar.html">foobar</a></p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
-as well as <strong>inline markup</strong>.</p>
+</footer><!-- /.post-info --><p>Some content here !</p>
+<div class="section" id="this-is-a-simple-title">
+<h2>This is a simple title</h2>
+<p>And here comes the cool <a class="reference external" href="http://books.couchdb.org/relax/design-documents/views">stuff</a>.</p>
+<img alt="alternate text" src="|filename|/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
+<img alt="alternate text" src="|filename|/pictures/Sushi_Macro.jpg" style="width: 600px; height: 450px;" />
+<pre class="literal-block">
+&gt;&gt;&gt; from ipdb import set_trace
+&gt;&gt;&gt; set_trace()
+</pre>
+<p>→ And now try with some utf8 hell: ééé</p>
+</div>
+                </article>
+            </aside><!-- /#featured -->
+                <section id="content" class="body">
+                    <h1>Other articles</h1>
+                    <hr />
+                    <ol id="posts-list" class="hfeed">
 
-                <a class="readmore" href="/this-is-a-super-article.html">read more</a>
+            <li><article class="hentry">
+                <header>
+                    <h1><a href="/oh-yeah.html" rel="bookmark"
+                           title="Permalink to Oh yeah !">Oh yeah !</a></h1>
+                </header>
+
+                <div class="entry-content">
+<footer class="post-info">
+        <abbr class="published" title="2010-10-20T10:14:00">
+                Wed 20 October 2010
+        </abbr>
+
+        <address class="vcard author">
+                By <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+        </address>
+<p>In <a href="/category/bar.html">bar</a>. </p>
+<p>tags: <a href="/tag/oh.html">oh</a><a href="/tag/bar.html">bar</a><a href="/tag/yeah.html">yeah</a></p>
+</footer><!-- /.post-info -->                <div class="section" id="why-not">
+<h2>Why not ?</h2>
+<p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
+YEAH !</p>
+<img alt="alternate text" src="|filename|/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
+</div>
+
+                <a class="readmore" href="/oh-yeah.html">read more</a>
                 </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->

--- a/pelican/tests/output/custom/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau.html
@@ -30,7 +30,57 @@
 
             <aside id="featured" class="body">
                 <article>
-                    <h1 class="entry-title"><a href="../a-markdown-powered-article.html">A markdown powered article</a></h1>
+                    <h1 class="entry-title"><a href="../filename_metadata-example.html">FILENAME_METADATA example</a></h1>
+<footer class="post-info">
+        <abbr class="published" title="2012-11-30T00:00:00">
+                Fri 30 November 2012
+        </abbr>
+
+        <address class="vcard author">
+                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+        </address>
+<p>In <a href="../category/misc.html">misc</a>. </p>
+
+</footer><!-- /.post-info --><p>Some cool stuff!</p>
+<p>There are <a href="../filename_metadata-example.html#disqus_thread">comments</a>.</p>                </article>
+            </aside><!-- /#featured -->
+                <section id="content" class="body">
+                    <h1>Other articles</h1>
+                    <hr />
+                    <ol id="posts-list" class="hfeed">
+
+            <li><article class="hentry">
+                <header>
+                    <h1><a href="../second-article.html" rel="bookmark"
+                           title="Permalink to Second article">Second article</a></h1>
+                </header>
+
+                <div class="entry-content">
+<footer class="post-info">
+        <abbr class="published" title="2012-02-29T00:00:00">
+                Wed 29 February 2012
+        </abbr>
+
+        <address class="vcard author">
+                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+        </address>
+<p>In <a href="../category/misc.html">misc</a>. </p>
+<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations:
+        <a href="../second-article-fr.html">fr</a>
+
+</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+
+                <a class="readmore" href="../second-article.html">read more</a>
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
+            </article></li>
+
+            <li><article class="hentry">
+                <header>
+                    <h1><a href="../a-markdown-powered-article.html" rel="bookmark"
+                           title="Permalink to A markdown powered article">A markdown powered article</a></h1>
+                </header>
+
+                <div class="entry-content">
 <footer class="post-info">
         <abbr class="published" title="2011-04-20T00:00:00">
                 Wed 20 April 2011
@@ -41,14 +91,12 @@
         </address>
 <p>In <a href="../category/cat1.html">cat1</a>. </p>
 
-</footer><!-- /.post-info --><p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->                <p>You're mutually oblivious.</p>
 <p><a href="../unbelievable.html">a root-relative link to unbelievable</a>
-<a href="../unbelievable.html">a file-relative link to unbelievable</a></p><p>There are <a href="../a-markdown-powered-article.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<a href="../unbelievable.html">a file-relative link to unbelievable</a></p>
+                <a class="readmore" href="../a-markdown-powered-article.html">read more</a>
+<p>There are <a href="../a-markdown-powered-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
+            </article></li>
 
             <li><article class="hentry">
                 <header>
@@ -71,52 +119,6 @@
 
                 <a class="readmore" href="../article-1.html">read more</a>
 <p>There are <a href="../article-1.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-2.html" rel="bookmark"
-                           title="Permalink to Article 2">Article 2</a></h1>
-                </header>
-
-                <div class="entry-content">
-<footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00">
-                Thu 17 February 2011
-        </abbr>
-
-        <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-<p>In <a href="../category/cat1.html">cat1</a>. </p>
-
-</footer><!-- /.post-info -->                <p>Article 2</p>
-
-                <a class="readmore" href="../article-2.html">read more</a>
-<p>There are <a href="../article-2.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-3.html" rel="bookmark"
-                           title="Permalink to Article 3">Article 3</a></h1>
-                </header>
-
-                <div class="entry-content">
-<footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00">
-                Thu 17 February 2011
-        </abbr>
-
-        <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-<p>In <a href="../category/cat1.html">cat1</a>. </p>
-
-</footer><!-- /.post-info -->                <p>Article 3</p>
-
-                <a class="readmore" href="../article-3.html">read more</a>
-<p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->
 <p class="paginator">

--- a/pelican/tests/output/custom/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau2.html
@@ -32,25 +32,72 @@
                     <ol id="posts-list" class="hfeed" start="3">
             <li><article class="hentry">
                 <header>
-                    <h1><a href="../filename_metadata-example.html" rel="bookmark"
-                           title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a></h1>
+                    <h1><a href="../article-2.html" rel="bookmark"
+                           title="Permalink to Article 2">Article 2</a></h1>
                 </header>
 
                 <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00">
-                Fri 30 November 2012
+        <abbr class="published" title="2011-02-17T00:00:00">
+                Thu 17 February 2011
         </abbr>
 
         <address class="vcard author">
                 By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>. </p>
+<p>In <a href="../category/cat1.html">cat1</a>. </p>
 
-</footer><!-- /.post-info -->                <p>Some cool stuff!</p>
+</footer><!-- /.post-info -->                <p>Article 2</p>
 
-                <a class="readmore" href="../filename_metadata-example.html">read more</a>
-<p>There are <a href="../filename_metadata-example.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
+                <a class="readmore" href="../article-2.html">read more</a>
+<p>There are <a href="../article-2.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
+            </article></li>
+
+            <li><article class="hentry">
+                <header>
+                    <h1><a href="../article-3.html" rel="bookmark"
+                           title="Permalink to Article 3">Article 3</a></h1>
+                </header>
+
+                <div class="entry-content">
+<footer class="post-info">
+        <abbr class="published" title="2011-02-17T00:00:00">
+                Thu 17 February 2011
+        </abbr>
+
+        <address class="vcard author">
+                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+        </address>
+<p>In <a href="../category/cat1.html">cat1</a>. </p>
+
+</footer><!-- /.post-info -->                <p>Article 3</p>
+
+                <a class="readmore" href="../article-3.html">read more</a>
+<p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
+            </article></li>
+
+            <li><article class="hentry">
+                <header>
+                    <h1><a href="../this-is-a-super-article.html" rel="bookmark"
+                           title="Permalink to This is a super article !">This is a super article !</a></h1>
+                </header>
+
+                <div class="entry-content">
+<footer class="post-info">
+        <abbr class="published" title="2010-12-02T10:14:00">
+                Thu 02 December 2010
+        </abbr>
+
+        <address class="vcard author">
+                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+        </address>
+<p>In <a href="../category/yeah.html">yeah</a>. </p>
+<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/foobar.html">foobar</a></p>
+</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+as well as <strong>inline markup</strong>.</p>
+
+                <a class="readmore" href="../this-is-a-super-article.html">read more</a>
+<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
 
             <li><article class="hentry">
@@ -81,55 +128,6 @@ YEAH !</p>
 
                 <a class="readmore" href="../oh-yeah.html">read more</a>
 <p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
-                           title="Permalink to Second article">Second article</a></h1>
-                </header>
-
-                <div class="entry-content">
-<footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00">
-                Wed 29 February 2012
-        </abbr>
-
-        <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-<p>In <a href="../category/misc.html">misc</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/baz.html">baz</a></p>Translations:
-        <a href="../second-article-fr.html">fr</a>
-
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
-
-                <a class="readmore" href="../second-article.html">read more</a>
-<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../this-is-a-super-article.html" rel="bookmark"
-                           title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
-
-                <div class="entry-content">
-<footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00">
-                Thu 02 December 2010
-        </abbr>
-
-        <address class="vcard author">
-                By <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
-        </address>
-<p>In <a href="../category/yeah.html">yeah</a>. </p>
-<p>tags: <a href="../tag/foo.html">foo</a><a href="../tag/bar.html">bar</a><a href="../tag/foobar.html">foobar</a></p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
-as well as <strong>inline markup</strong>.</p>
-
-                <a class="readmore" href="../this-is-a-super-article.html">read more</a>
-<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->
 <p class="paginator">


### PR DESCRIPTION
This standardizes the sort between author, tag, and category pages  This doesn't provide a config override. 
