### PR TITLE
Handle critical exception logging correctly in localized systems

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -378,7 +378,13 @@ def main():
             pelican.run()
 
     except Exception as e:
-        logger.critical(e)
+        # localized systems have errors in native language if locale is set
+        # so convert the message to unicode with the correct encoding
+        msg = str(e)
+        if not six.PY3:
+            msg = msg.decode(locale.getpreferredencoding(False))
+
+        logger.critical(msg)
 
         if (args.verbosity == logging.DEBUG):
             raise


### PR DESCRIPTION
Python generates certain exception messages (like `IOError`) in system
language, if locale is set. This ensures that the message is properly
converted to unicode in Python 2.

Old behavior

```
$ pelican -s pelican.conf.py -o ~/o content
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 850, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 723, in format
    return fmt.format(record)
  File "/home/dturgut/src/pelican/pelican/log.py", line 47, in format
    return ansi('bgred', record.levelname) + ': ' + msg
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 32: ordinal not in range(128)
Logged from file __init__.py, line 389
```

New behavior:

```
$ pelican -s pelican.conf.py -o ~/o content
CRITICAL: [Errno 13] Permission non accordée: '/home/dturgut/o/theme'
```
