### PR TITLE
Exception on WP import looking for <pre> tag

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -37,7 +37,7 @@ def decode_wp_content(content, br=True):
         pre_index = 0
 
         for pre_part in pre_parts:
-            start = pre_part.index("<pre")
+            start = pre_part.find("<pre")
             if start == -1:
                 content = content + pre_part
                 continue


### PR DESCRIPTION
Another quick one.  In `decode_wp_content()`:

``` python
start = pre_part.index("<pre")
```

should be:

``` python
start = pre_part.find("<pre")
```

because the next line checks for `start == -1`, but `index()` throws `ValueError` when the value can't be found, whereas `find()` returns -1.

I can send a PR for this tomorrow, but wanted to make sure I reported it tonight.
