### PR TITLE
Markdown summary should not include content footnote

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -166,6 +166,8 @@ class MarkdownReader(Reader):
             name = name.lower()
             if name == "summary":
                 summary_values = "\n".join(value)
+                # reset the markdown instance to clear any state
+                self._md.reset()
                 summary = self._md.convert(summary_values)
                 output[name] = self.process_metadata(name, summary)
             else:

--- a/pelican/tests/content/article_with_markdown_and_footnote.md
+++ b/pelican/tests/content/article_with_markdown_and_footnote.md
@@ -1,0 +1,8 @@
+Title: Article with markdown containing footnotes
+Date: 2012-10-31
+Summary: Summary with **inline** markup *should* be supported.
+
+This is some content[^1] with some footnotes[^footnote]
+
+[^1]: Numbered footnote
+[^footnote]: Named footnote

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -90,7 +90,9 @@ class TestArticlesGenerator(unittest.TestCase):
              'TestCategory', 'article'],
             ['This is a super article !', 'published', 'yeah', 'article'],
             ['マックOS X 10.8でパイソンとVirtualenvをインストールと設定',
-             'published', '指導書', 'article']
+             'published', '指導書', 'article'],
+            ['Article with markdown containing footnotes', 'published',
+             'Default', 'article']
         ]
         self.assertEqual(sorted(articles_expected), sorted(articles))
 

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -144,6 +144,43 @@ class MdReaderTest(unittest.TestCase):
         for key, value in metadata.items():
             self.assertEqual(value, expected[key], key)
 
+
+    @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
+    def test_article_with_footnote(self):
+        reader = readers.MarkdownReader({})
+        content, metadata = reader.read(
+            _path('article_with_markdown_and_footnote.md'))
+        expected_content = (
+            '<p>This is some content'
+            '<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" '
+            'rel="footnote">1</a></sup>'
+            ' with some footnotes'
+            '<sup id="fnref:footnote"><a class="footnote-ref" '
+            'href="#fn:footnote" rel="footnote">2</a></sup></p>\n'
+            
+            '<div class="footnote">\n'
+            '<hr />\n<ol>\n<li id="fn:1">\n'
+            '<p>Numbered footnote&#160;'
+            '<a class="footnote-backref" href="#fnref:1" rev="footnote" '
+            'title="Jump back to footnote 1 in the text">&#8617;</a></p>\n'
+            '</li>\n<li id="fn:footnote">\n'
+            '<p>Named footnote&#160;'
+            '<a class="footnote-backref" href="#fnref:footnote" rev="footnote" '
+            'title="Jump back to footnote 2 in the text">&#8617;</a></p>\n'
+            '</li>\n</ol>\n</div>')
+        expected_metadata = {
+            'title': 'Article with markdown containing footnotes',
+            'summary': (
+                '<p>Summary with <strong>inline</strong> markup '
+                '<em>should</em> be supported.</p>'),
+            'date': datetime.datetime(2012, 10, 31),
+            'slug': 'article-with-markdown-containing-footnotes',
+        }
+        self.assertEqual(content, expected_content)
+        for key, value in metadata.items():
+            self.assertEqual(value, expected_metadata[key], key)
+
+
     @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
     def test_article_with_file_extensions(self):
         reader = readers.MarkdownReader({})


### PR DESCRIPTION
Markdown instance carries state for subsequent uses. Content
and summary parsing is done with the same instance. Since
footnotes are processed with an extension and stored as state,
content footnote is duplicated for summary.

This PR adds a `.reset()` call before summary parsing to clear
the state. It also adds a test case with footnotes.
