### PR TITLE
Updated pelican.server not started error message.

### DIFF
--- a/pelican/tools/templates/develop_server.sh.in
+++ b/pelican/tools/templates/develop_server.sh.in
@@ -74,7 +74,7 @@ function start_up(){
     echo "Pelican didn't start. Is the pelican package installed?"
     return 1
   elif ! alive $$srv_pid ; then
-    echo "pelican.server didn't start. Is the pelican package installed?"
+    echo "pelican.server didn't start. Is there something else which uses port 8000?"
     return 1
   fi
   echo 'Pelican and pelican.server processes now running in background.'


### PR DESCRIPTION
It previously said `'pelican.server didn't start. Is the pelican package installed?'`. That doesn't make much sense since it's pretty much the same as the error message three lines above.

However, I managed to run directly into this error while running another instance of `python -m SimpleHTTPServer` and so I thought it might make sense to update that error message a little bit.
