### PR TITLE
Add warnings for img with empty alts. Fixes #647.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -37,7 +37,6 @@ except ImportError:
 from pelican.contents import Page, Category, Tag, Author
 from pelican.utils import get_date, pelican_open
 
-
 logger = logging.getLogger(__name__)
 
 METADATA_PROCESSORS = {
@@ -103,6 +102,12 @@ class PelicanHTMLTranslator(HTMLTranslator):
 
     def depart_abbreviation(self, node):
         self.body.append('</abbr>')
+
+    def visit_image(self, node):
+        # set an empty alt if alt is not specified
+        # avoids that alt is taken from src
+        node['alt'] = node.get('alt', '')
+        return HTMLTranslator.visit_image(self, node)
 
 
 class RstReader(Reader):
@@ -390,6 +395,41 @@ def read_file(base_path, path, content_class=Page, fmt=None,
             process=reader.process_metadata))
     content, reader_metadata = reader.read(path)
     metadata.update(reader_metadata)
+
+    # create warnings for all images with empty alt (up to a certain number)
+    # as they are really likely to be accessibility flaws
+    if content:
+        # find images with empty alt
+        imgs = re.compile(r"""
+            (?:
+                # src before alt
+                <img
+                [^\>]*
+                src=(['"])(.*)\1
+                [^\>]*
+                alt=(['"])\3
+            )|(?:
+                # alt before src
+                <img
+                [^\>]*
+                alt=(['"])\4
+                [^\>]*
+                src=(['"])(.*)\5
+            )
+            """, re.X)
+        matches = re.findall(imgs, content)
+        # find a correct threshold
+        nb_warnings = 10
+        if len(matches) == nb_warnings + 1:
+            nb_warnings += 1 # avoid bad looking case
+        # print one warning per image with empty alt until threshold
+        for match in matches[:nb_warnings]:
+            logger.warning('Empty alt attribute for image {} in {}'.format(
+                           os.path.basename(match[1] + match[5]), path))
+        # print one warning for the other images with empty alt
+        if len(matches) > nb_warnings:
+            logger.warning('{} other images with empty alt attributes'.format(
+                           len(matches) - nb_warnings))
 
     # eventually filter the content with typogrify if asked so
     if content and settings and settings['TYPOGRIFY']:


### PR DESCRIPTION
That issue raises the point that with the rst format, when we don't specify the `alt` attribute, a wrong `alt` get added:

```
.. image:: |filename|/images/image.png
```

is turned into

```
<img alt="|filename|/images/image.png" src="/static/images/image.png" />
```

In mkd,

```
![](|filename|/images/image.png)
```

is turned into

```
<img alt="" src="/static/images/image.png" />
```

This PR gives the **same behaviour** in both cases (i.e. an empty `alt=""`), and also **create warnings** if `img` with empty `alt` are found:

```
WARNING: empty alt attribute for image image.png in /tmp/test/content/post.md
```

Note that the warnings will also be triggered if someone puts direct HTML in a mkd file for example, but not if that HTML is set to be a code part.

Performances tests (thanks to @justinmayer for all those blog posts to test with):
- before this PR: `Processed 1404 articles and 0 pages in 83.14 seconds.`
- after this PR: `Processed 1404 articles and 0 pages in 83.52 seconds.`

…and there was _a lot_ of warnings raised!
So the performances do not seem to be affected by this PR.

_Side note: the `alt` attribute is one of the key points of web accessibility. See the [WCAG page on that](http://www.w3.org/TR/WCAG20-TECHS/H37) for example. Giving a warning if it is missing would be a healthy way to promote best practices which make a difference._
