### PR TITLE
Add lang-tag feeds generation.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -594,6 +594,14 @@ Setting name (default value)                             What does it do?
 `DEFAULT_LANG` (``'en'``)                                The default language to use.
 `TRANSLATION_FEED_ATOM` ('feeds/all-%s.atom.xml'[3]_)    Where to put the Atom feed for translations.
 `TRANSLATION_FEED_RSS` (``None``, i.e. no RSS)           Where to put the RSS feed for translations.
+`LANG_TAG_FEED_ATOM` (``None``, i.e. no Atom feed)       Where to put the Atom feed for a given lang and a
+                                                         given tag. For example:
+                                                         ``'feeds/%(lang)s-%(tag)s.atom.xml'``
+`LANG_TAG_FEED_RSS` (``None``, i.e. no RSS)`             Where to put the RSS feed for a given lang and a
+                                                         given tag.
+`LANG_TAG_FEED_FILTER` (``None``, i.e. no filter         Allow to filter which lang and tag you want
+                                                         to generate. You need to use tuple list.
+                                                         For example: ``{('fr, 'myTag'), (en, myTag)}``
 =====================================================    =====================================================
 
 .. [3] %s is the language

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -4,9 +4,9 @@ from __future__ import unicode_literals
 import os
 from codecs import open
 try:
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, ANY
 except ImportError:
-    from mock import MagicMock
+    from mock import MagicMock, ANY
 from shutil import rmtree
 from tempfile import mkdtemp
 
@@ -267,6 +267,23 @@ class TestArticlesGenerator(unittest.TestCase):
         authors = [author.slug for author, _ in self.generator.authors]
         authors_expected = ['alexis-metaireau', 'first-author', 'second-author']
         self.assertEqual(sorted(authors), sorted(authors_expected))
+
+    def test_generate_lang_tag_feeds(self):
+        settings = get_settings(filenames={})
+        settings['LANG_TAG_FEED_FILTER'] = {('en', 'bar'), }
+        settings['LANG_TAG_FEED_ATOM'] = 'feeds/%(lang)s-%(tag)s.atom.xml'
+        settings['FEED_ALL_ATOM'] = None
+        settings['TRANSLATION_FEED_ATOM'] = None
+        settings['CATEGORY_FEED_ATOM'] = None
+
+        generator = ArticlesGenerator(
+            context=settings, settings=settings,
+            path=CONTENT_DIR, theme=settings['THEME'], output_path=None)
+        generator.generate_context()
+        writer = MagicMock()
+        generator.generate_feeds(writer)
+        writer.write_feed.assert_called_with(ANY, ANY,
+                                             'feeds/en-bar.atom.xml')
 
 
 class TestPageGenerator(unittest.TestCase):


### PR DESCRIPTION
This new functionnality allow user to generate feeds for a specified tag and a specified language.
The most traditional use case is for country based/international planet subscription.