### PR TITLE
Testing whether a reader class is enabled *before* calling it, otherwise...

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -347,14 +347,15 @@ def read_file(path, fmt=None, settings=None):
     if settings is None:
         settings = {}
 
-    reader = EXTENSIONS[fmt](settings)
+    cls = EXTENSIONS[fmt]
+    if not cls.enabled:
+        raise ValueError("Missing dependencies for %s" % fmt)
+
+    reader = cls(settings)
     settings_key = '%s_EXTENSIONS' % fmt.upper()
 
     if settings and settings_key in settings:
         reader.extensions = settings[settings_key]
-
-    if not reader.enabled:
-        raise ValueError("Missing dependencies for %s" % fmt)
 
     metadata = parse_path_metadata(
         path=path, settings=settings, process=reader.process_metadata)


### PR DESCRIPTION
... the test is never reached.

For example, if Markdown hasn't been installed, and you attempt read_file('foo.md') then an exception is raised in MarkdownReader.**init** as it tries to call Markdown, which is False.  The class field "enabled" was not checked before attempting to instantiate MarkdownReader.  Instead, there is a later test on the instance, which won't be reached.

I've followed all steps in "How to Contribute" except Python 3.2 tests.  Some Python 2.7 tests fail exactly as they do at the current master 675d6c81cd6ca88c8018bd608c46735ab29ba8b5

I found this bug while working on a test site with Docutils but not Markdown installed.
