### PR TITLE
Allow HTML files with meta tags that don't have a "name" and "content" f...

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -270,12 +270,14 @@ class HTMLReader(Reader):
             return result + '>'
 
         def _handle_meta_tag(self, attrs):
-            name = self._attr_value(attrs, 'name').lower()
-            contents = self._attr_value(attrs, 'contents', '')
+            name = self._attr_value(attrs, 'name')
+            if name:
+                name = name.lower()
+                contents = self._attr_value(attrs, 'contents', '')
 
-            if name == 'keywords':
-                name = 'tags'
-            self.metadata[name] = contents
+                if name == 'keywords':
+                    name = 'tags'
+                self.metadata[name] = contents
 
         @classmethod
         def _attr_value(cls, attrs, name, default=None):


### PR DESCRIPTION
...ield to be read by the HTMLReader.

For example, `<meta charset="utf-8" />` might appear in an HTML document.  Without this change, this causes an exception.

I have followed all steps in "How to contribute" except Python 3.2 tests.  Test output is identical to the current master 675d6c81cd6ca88c8018bd608c46735ab29ba8b5 (i.e. not perfect!)

I found this problem while developing an experimental site that had HTML5 files passing through Pelican as well as reST.
