### PR TITLE
Encoding issue in pelican-quickstart. Fixes #904

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -37,8 +37,7 @@ def _input_compat(prompt):
     if six.PY3:
         r = input(prompt)
     else:
-        # FIXME: why use this with @decoding_strings?
-        r = raw_input(prompt).decode('utf-8')
+        r = raw_input(prompt)
     return r
 
 if six.PY3:


### PR DESCRIPTION
Easy fix as suggested in the comment from 5e4622b229aa69a5355215980c6dc4330beb5420 (line 40).
