### PR TITLE
tests/test_readers.py: Remove redundant 'expected' check in AdReaderTest

### DIFF
--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -303,17 +303,6 @@ class AdReaderTest(unittest.TestCase):
         for key, value in expected.items():
             self.assertEqual(value, metadata[key], key)
 
-        expected = {
-            'category': 'Blog',
-            'author': 'Author O. Article',
-            'title': 'Test AsciiDoc File Header',
-            'date': datetime.datetime(2011, 9, 15, 9, 5),
-            'tags': ['Linux', 'Python', 'Pelican'],
-        }
-
-        for key, value in expected.items():
-            self.assertEqual(value, metadata[key], key)
-
     @unittest.skipUnless(readers.asciidoc, "asciidoc isn't installed")
     def test_article_with_asc_options(self):
         # test to ensure the ASCIIDOC_OPTIONS is being used


### PR DESCRIPTION
AdReaderTest.test_article_with_asc_extension() has had duplicate checks on the
expected metadata since it was created by 49f481e3 (Add asciidoc reader
support, 2013-10-28).  This commit removes the duplicate entry.
