### PR TITLE
Importer generates too short header line.

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -344,7 +344,9 @@ def feed2fields(file):
 
 def build_header(title, date, author, categories, tags, slug):
     """Build a header from a list of fields"""
-    header = '%s\n%s\n' % (title, '#' * len(title))
+    import unicodedata
+    title_width = sum([(2 if unicodedata.east_asian_width(c) in u"WFA" else 1) for c in title])
+    header = '%s\n%s\n' % (title, '#' * title_width)
     if date:
         header += ':date: %s\n' % date
     if author:


### PR DESCRIPTION
Situation: pelican-import command converts wordpress xml to ReST text.

It seems that header line length depends on title character length, but pelican generates following warning in html.

```
System Message: WARNING/2 
(<path_to_content>/content.rst, line 2)
Title underline too short.
```

Because some languages (ex. Japanese) used wide character. 
`#` line should  appropriately lengthened.
Instead of using len(), use unicodedata.east_asian_width to calculate correct title length.
