### PR TITLE
Added lxml to the list of dependencies for the tox tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     Markdown
     BeautifulSoup4
     typogrify
+    lxml
 
 [testenv:py33]
 deps =
@@ -23,3 +24,4 @@ deps =
     BeautifulSoup4
     git+https://github.com/dmdm/smartypants.git#egg=smartypants
     git+https://github.com/dmdm/typogrify.git@py3k#egg=typogrify
+    lxml


### PR DESCRIPTION
My system python installs are completely clean except for virtualenv, so tox needs a complete set of non-default modules.
