### PR TITLE
Adds Rackspace Cloud Files support to quickstart

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -27,6 +27,9 @@ CONF = {
     'ssh_user': 'root',
     'ssh_target_dir': '/var/www',
     's3_bucket': 'my_s3_bucket',
+    'cloudfiles_username': 'my_rackspace_username',
+    'cloudfiles_api_key': 'my_rackspace_api_key',
+    'cloudfiles_container': 'my_cloudfiles_container',
     'dropbox_dir': '~/Dropbox/Public/',
     'default_pagination': 10,
     'siteurl': '',
@@ -210,6 +213,10 @@ needed by Pelican.
             CONF['dropbox_dir'] = ask('Where is your Dropbox directory?', str_compat, CONF['dropbox_dir'])
         if ask('Do you want to upload your website using S3?', answer=bool, default=False):
             CONF['s3_bucket'] = ask('What is the name of your S3 bucket?', str_compat, CONF['s3_bucket'])
+        if ask('Do you want to upload your website using Rackspace Cloud Files?', answer=bool, default=False):
+            CONF['cloudfiles_username'] = ask('What is your Rackspace Cloud username?', str_compat, CONF['cloudfiles_username'])
+            CONF['cloudfiles_api_key'] = ask('What is your Rackspace Cloud API key?', str_compat, CONF['cloudfiles_api_key'])
+            CONF['cloudfiles_container'] = ask('What is the name of your Cloud Files container?', str_compat, CONF['cloudfiles_container'])
 
     try:
         os.makedirs(os.path.join(CONF['basedir'], 'content'))

--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -18,6 +18,10 @@ SSH_TARGET_DIR=$ssh_target_dir
 
 S3_BUCKET=$s3_bucket
 
+CLOUDFILES_USERNAME=$cloudfiles_username
+CLOUDFILES_API_KEY=$cloudfiles_api_key
+CLOUDFILES_CONTAINER=$cloudfiles_container
+
 DROPBOX_DIR=$dropbox_dir
 
 DEBUG ?= 0
@@ -41,6 +45,7 @@ help:
 	@echo '   dropbox_upload                   upload the web site via Dropbox    '
 	@echo '   ftp_upload                       upload the web site via FTP        '
 	@echo '   s3_upload                        upload the web site via S3         '
+	@echo '   cf_upload                        upload the web site via Cloud Files'
 	@echo '   github                           upload the web site via gh-pages   '
 	@echo '                                                                       '
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html'
@@ -92,8 +97,11 @@ ftp_upload: publish
 s3_upload: publish
 	s3cmd sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl-public --delete-removed
 
+cf_upload: publish
+	cd $(OUTPUTDIR) && swift -v -A https://auth.api.rackspacecloud.com/v1.0 -U $(CLOUDFILES_USERNAME) -K $(CLOUDFILES_API_KEY) upload -c $(CLOUDFILES_CONTAINER) .
+
 github: publish
 	ghp-import $$(OUTPUTDIR)
 	git push origin gh-pages
 
-.PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload github
+.PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github

--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -4,12 +4,17 @@ import os
 
 # Local path configuration (can be absolute or relative to fabfile)
 env.deploy_path = 'output'
+DEPLOY_PATH = env.deploy_path
 
 # Remote server configuration
 production = '$ssh_user@$ssh_host:$ssh_port'
 dest_path = '$ssh_target_dir'
 
-DEPLOY_PATH = env.deploy_path
+# Rackspace Cloud Files configuration settings
+env.cloudfiles_username = '$cloudfiles_username'
+env.cloudfiles_api_key = '$cloudfiles_api_key'
+env.cloudfiles_container = '$cloudfiles_container'
+
 
 def clean():
     if os.path.isdir(DEPLOY_PATH):
@@ -35,6 +40,14 @@ def reserve():
 
 def preview():
     local('pelican -s publishconf.py')
+
+def cf_upload():
+    rebuild()
+    local('cd {deploy_path} && '
+          'swift -v -A https://auth.api.rackspacecloud.com/v1.0 '
+          '-U {cloudfiles_username} '
+          '-K {cloudfiles_api_key} '
+          'upload -c {cloudfiles_container} .'.format(**env))
 
 @hosts(production)
 def publish():


### PR DESCRIPTION
Adding in Rackspace Cloud Files support to pelican-quickstart so users can do:

<pre>
$ make cf_upload
</pre>


Files will be uploaded to Cloud Files using swift, from the [python-swiftclient](https://github.com/openstack/python-swiftclient) (available in PyPI) package.

<pre>
$ pip install python-swiftclient
</pre>


The swift option "-c" has been added so that only changed files will be uploaded.
