### PR TITLE
tests: Avoid hidden logic with better .assert*() method choices

### DIFF
--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -108,7 +108,7 @@ class TestArticlesGenerator(unittest.TestCase):
             sorted(['Default', 'TestCategory', 'Yeah', 'test', '指導書']),
             sorted(['Default', 'TestCategory', 'yeah', 'test', '指導書']),
         )
-        self.assertTrue(sorted(categories) in categories_alternatives)
+        self.assertIn(sorted(categories), categories_alternatives)
         # test for slug
         categories = [cat.slug for cat, _ in generator.categories]
         categories_expected = ['default', 'testcategory', 'yeah', 'test',
@@ -136,7 +136,7 @@ class TestArticlesGenerator(unittest.TestCase):
             sorted(['Default', 'Yeah', 'test', '指導書']),
             sorted(['Default', 'yeah', 'test', '指導書']),
         )
-        self.assertTrue(sorted(categories) in categories_alternatives)
+        self.assertIn(sorted(categories), categories_alternatives)
         # test for slug
         categories = [cat.slug for cat, _ in generator.categories]
         categories_expected = ['default', 'yeah', 'test', 'zhi-dao-shu']

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -76,13 +76,13 @@ class TestWordpressXmlImporter(unittest.TestCase):
 
     def test_decode_html_entities_in_titles(self):
         test_posts = [post for post in self.posts if post[2] == 'html-entity-test']
-        self.assertTrue(len(test_posts) == 1)
+        self.assertEqual(len(test_posts), 1)
 
         post = test_posts[0]
         title = post[0]
         self.assertTrue(title, "A normal post with some <html> entities in the"
                                " title. You can't miss them.")
-        self.assertTrue('&' not in title)
+        self.assertNotIn('&', title)
 
     def test_decode_wp_content_returns_empty(self):
         """ Check that given an empty string we return an empty string."""

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -186,7 +186,7 @@ class TestUtils(LoggedTestCase):
         test_directory = os.path.join(os.path.dirname(__file__),
                                       'does_not_exist')
         utils.clean_output_dir(test_directory)
-        self.assertTrue(not os.path.exists(test_directory))
+        self.assertFalse(os.path.exists(test_directory))
 
     def test_clean_output_dir_is_file(self):
         test_directory = os.path.join(os.path.dirname(__file__),
@@ -195,7 +195,7 @@ class TestUtils(LoggedTestCase):
         f.write('')
         f.close()
         utils.clean_output_dir(test_directory)
-        self.assertTrue(not os.path.exists(test_directory))
+        self.assertFalse(os.path.exists(test_directory))
 
     def test_strftime(self):
         d = datetime.date(2012, 8, 29)


### PR DESCRIPTION
We'll get better failure messages if we use an assertion method that 
understands the comparison we're trying to make.  If you make the comparison
by hand and assertTrue(), you don't get much constructive feedback ;).
