### PR TITLE
Better duck typing in isinstance check

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -9,6 +9,7 @@ import time
 import logging
 import argparse
 import locale
+import collections
 
 from pelican import signals
 
@@ -205,7 +206,7 @@ class Pelican(object):
         for pair in signals.get_generators.send(self):
             (funct, value) = pair
 
-            if not isinstance(value, (tuple, list)):
+            if not isinstance(value, collections.Iterable):
                 value = (value, )
 
             for v in value:


### PR DESCRIPTION
I think `isinstance(value, (tuple, list)` can safely be replaced with `isinstance(value, collections.Iterable)`.
