### PR TITLE
Remove "clean" task from "make html"; revert "make clean" behavior to "rm -rf"

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -44,7 +44,7 @@ html:
 	$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)
 
 clean:
-	[ ! -d $$(OUTPUTDIR) ] || find $$(OUTPUTDIR) -mindepth 1 -delete
+	[ ! -d $$(OUTPUTDIR) ] || rm -rf $$(OUTPUTDIR)
 
 regenerate:
 	$$(PELICAN) -r $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)


### PR DESCRIPTION
This pull request fixes two outstanding issues via two changes to the default Makefile generated by the `pelican-quickstart` script.

The first change, e9fec3b, fixes #637 thusly:

> This change removes the "clean" task from the "html" and "regenerate"
> tasks. The previous behavior ignored whether the DELETE_OUTPUT_DIRECTORY
> setting was set to True or not and deleted everything in the output
> directory every time the "make html" or "make regenerate" task was run.
> In addition to violating the Principle of Least Astonishment, there was
> also the potential for data loss if the user wasn't careful when
> defining the output directory location in the Makefile.
> 
> The new behavior therefore relies primarily on the
> DELETE_OUTPUT_DIRECTORY setting to control if and when the output
> directory is cleaned. The default settings and Makefile generated by the
> pelican-quickstart command, for example, no longer clean the output
> directory when the "make html" task is run. If the user wants to change
> this behavior and have the output directory cleaned on every "make html"
> run, the recommended method would be to set DELETE_OUTPUT_DIRECTORY to
> True in pelicanconf.py. Alternatively, the user can manually run "make
> clean", with the caveat that the output directory and its contents will
> be entirely destroyed, including any otherwise to-be-retained files or
> folders specified in the OUTPUT_RETENTION setting. It is for that reason
> that relying on the DELETE_OUTPUT_DIRECTORY setting is instead
> recommended.
> 
> As before, DELETE_OUTPUT_DIRECTORY is set to True in the publishconf.py
> settings file generated by the pelican-quickstart script. This way, any
> potentially old and irrelevant files will be automatically removed
> before the latest version of the site is transferred to the production
> server environment.
> 
> In summary, this change allows for the sanest possible default settings,
> while still allowing end users to customize output cleaning to their
> preferred behavior with a minimum of confusion.

The second change, bf0a508, fixes #773:

> The change to the "make clean" task in 764a2cf from "rm -rf" to instead
> relying on GNU "find" appears to have broken cross-platform portability,
> likely causing problems on *BSD and other platforms. This commit reverts
> that change back to the previous "rm -rf" behavior.

Does anyone have any comments or feedback on these changes?
