### PR TITLE
Add a debug target to the template makefile

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -43,7 +43,8 @@ help:
 	@echo '   s3_upload                        upload the web site via S3         '
 	@echo '   github                           upload the web site via gh-pages   '
 	@echo '                                                                       '
-
+	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html'
+	@echo '                                                                       '
 
 html: clean $$(OUTPUTDIR)/index.html
 


### PR DESCRIPTION
If the DEBUG variable is set to 1 (e.g. 'DEBUG=1 make target') pelicans debugging output will be enabled.
