### PR TITLE
Adding a FEED_ALL_ATOM check in the "social" div.

### DIFF
--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -53,7 +53,9 @@
                 <div class="social">
                         <h2>social</h2>
                         <ul>
+                            {% if FEED_ALL_ATOM %}
                             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate">atom feed</a></li>
+                            {% endif %}
                             {% if FEED_ALL_RSS %}
                             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}" type="application/rss+xml" rel="alternate">rss feed</a></li>
                             {% endif %}


### PR DESCRIPTION
The head section has a tests for FEED_ALL_ATOM when building the atom link.  This diff add a similar test in the "social" div.
