### PR TITLE
added THEME_STATIC_DIR setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -547,6 +547,9 @@ Setting name (default value)                        What does it do?
                                                     or absolute path to a theme folder, or the name of a
                                                     default theme or a theme installed via
                                                     ``pelican-themes`` (see below).
+`THEME_STATIC_DIR` (``'theme'``)                    Destination directory in the output path where
+                                                    Pelican will place the files collected from
+                                                    `THEME_STATIC_PATHS`. Default is `theme`.
 `THEME_STATIC_PATHS` (``['static']``)               Static theme paths you want to copy. Default
                                                     value is `static`, but if your theme has
                                                     other static paths, you can put them here.

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -564,7 +564,8 @@ class StaticGenerator(Generator):
 
     def generate_output(self, writer):
         self._copy_paths(self.settings['THEME_STATIC_PATHS'], self.theme,
-                         'theme', self.output_path, os.curdir)
+                         self.settings['THEME_STATIC_DIR'], self.output_path,
+                         os.curdir)
         # copy all Static files
         for sc in self.staticfiles:
             source_path = os.path.join(self.path, sc.source_path)

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -35,6 +35,7 @@ DEFAULT_CONFIG = {
     'OUTPUT_PATH': 'output',
     'MARKUP': ('rst', 'md'),
     'STATIC_PATHS': ['images', ],
+    'THEME_STATIC_DIR': 'theme',
     'THEME_STATIC_PATHS': ['static', ],
     'FEED_ALL_ATOM': os.path.join('feeds', 'all.atom.xml'),
     'CATEGORY_FEED_ATOM': os.path.join('feeds', '%s.atom.xml'),

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -3,7 +3,7 @@
 <head>
         <meta charset="utf-8">
         <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
-        <link rel="stylesheet" href="{{ SITEURL }}/theme/css/{{ CSS_FILE }}">
+        <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/{{ CSS_FILE }}">
         {% if FEED_ALL_ATOM %}
         <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
         {% endif %}


### PR DESCRIPTION
The theme static output directory path is now customisable via settings.
i.e. you can now use 'assets' instead of 'theme'.
