### PR TITLE
Modify notmyidea to include class="active" on pages

### DIFF
--- a/pelican/tests/output/basic/a-markdown-powered-article.html
+++ b/pelican/tests/output/basic/a-markdown-powered-article.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
                                     <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/archives.html
+++ b/pelican/tests/output/basic/archives.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/article-1.html
+++ b/pelican/tests/output/basic/article-1.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
                                     <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/article-2.html
+++ b/pelican/tests/output/basic/article-2.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
                                     <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/article-3.html
+++ b/pelican/tests/output/basic/article-3.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
                                     <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/author/alexis-metaireau.html
+++ b/pelican/tests/output/basic/author/alexis-metaireau.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/categories.html
+++ b/pelican/tests/output/basic/categories.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <ul>

--- a/pelican/tests/output/basic/category/bar.html
+++ b/pelican/tests/output/basic/category/bar.html
@@ -18,9 +18,9 @@
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
                                                                     <li class="active"><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/category/cat1.html
+++ b/pelican/tests/output/basic/category/cat1.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
                                     <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/category/misc.html
+++ b/pelican/tests/output/basic/category/misc.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/category/yeah.html
+++ b/pelican/tests/output/basic/category/yeah.html
@@ -17,9 +17,9 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
                                     <li class="active"><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->

--- a/pelican/tests/output/basic/filename_metadata-example.html
+++ b/pelican/tests/output/basic/filename_metadata-example.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/index.html
+++ b/pelican/tests/output/basic/index.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/oh-yeah.html
+++ b/pelican/tests/output/basic/oh-yeah.html
@@ -18,9 +18,9 @@
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
                                                                     <li class="active"><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/override/index.html
+++ b/pelican/tests/output/basic/override/index.html
@@ -15,12 +15,12 @@
         <header id="banner" class="body">
                 <h1><a href="/">A Pelican Blog </a></h1>
                 <nav><ul>
-                                                    <li><a href="/override/">Override url/save_as</a></li>
+                                                    <li class="active"><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/basic/pages/this-is-a-test-hidden-page.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/basic/pages/this-is-a-test-page.html
@@ -16,11 +16,11 @@
                 <h1><a href="/">A Pelican Blog </a></h1>
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
-                                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li class="active"><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/second-article-fr.html
+++ b/pelican/tests/output/basic/second-article-fr.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/second-article.html
+++ b/pelican/tests/output/basic/second-article.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/basic/tag/bar.html
+++ b/pelican/tests/output/basic/tag/bar.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/tag/baz.html
+++ b/pelican/tests/output/basic/tag/baz.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/tag/foo.html
+++ b/pelican/tests/output/basic/tag/foo.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/tag/foobar.html
+++ b/pelican/tests/output/basic/tag/foobar.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/tag/oh.html
+++ b/pelican/tests/output/basic/tag/oh.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/tag/yeah.html
+++ b/pelican/tests/output/basic/tag/yeah.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/basic/this-is-a-super-article.html
+++ b/pelican/tests/output/basic/this-is-a-super-article.html
@@ -17,9 +17,9 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
-                                    <li ><a href="/category/misc.html">misc</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
+                                    <li><a href="/category/misc.html">misc</a></li>
                                     <li class="active"><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->

--- a/pelican/tests/output/basic/unbelievable.html
+++ b/pelican/tests/output/basic/unbelievable.html
@@ -17,10 +17,10 @@
                 <nav><ul>
                                                     <li><a href="/override/">Override url/save_as</a></li>
                                     <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="/category/bar.html">bar</a></li>
-                                    <li ><a href="/category/cat1.html">cat1</a></li>
+                                                                    <li><a href="/category/bar.html">bar</a></li>
+                                    <li><a href="/category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="/category/misc.html">misc</a></li>
-                                    <li ><a href="/category/yeah.html">yeah</a></li>
+                                    <li><a href="/category/yeah.html">yeah</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/a-markdown-powered-article.html
+++ b/pelican/tests/output/custom/a-markdown-powered-article.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
                                     <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/archives.html
+++ b/pelican/tests/output/custom/archives.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/article-1.html
+++ b/pelican/tests/output/custom/article-1.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
                                     <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/article-2.html
+++ b/pelican/tests/output/custom/article-2.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
                                     <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/article-3.html
+++ b/pelican/tests/output/custom/article-3.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
                                     <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau2.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/categories.html
+++ b/pelican/tests/output/custom/categories.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <ul>

--- a/pelican/tests/output/custom/category/bar.html
+++ b/pelican/tests/output/custom/category/bar.html
@@ -21,9 +21,9 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->

--- a/pelican/tests/output/custom/category/cat1.html
+++ b/pelican/tests/output/custom/category/cat1.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
                                     <li class="active"><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/category/yeah.html
+++ b/pelican/tests/output/custom/category/yeah.html
@@ -22,9 +22,9 @@
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
                                                                     <li class="active"><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom/drafts/a-draft-article.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/filename_metadata-example.html
+++ b/pelican/tests/output/custom/filename_metadata-example.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/index.html
+++ b/pelican/tests/output/custom/index.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/index2.html
+++ b/pelican/tests/output/custom/index2.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/jinja2_template.html
+++ b/pelican/tests/output/custom/jinja2_template.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         

--- a/pelican/tests/output/custom/oh-yeah-fr.html
+++ b/pelican/tests/output/custom/oh-yeah-fr.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/oh-yeah.html
+++ b/pelican/tests/output/custom/oh-yeah.html
@@ -21,9 +21,9 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
                                     <li class="active"><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->

--- a/pelican/tests/output/custom/override/index.html
+++ b/pelican/tests/output/custom/override/index.html
@@ -19,12 +19,12 @@
         <header id="banner" class="body">
                 <h1><a href="../">Alexis' log </a></h1>
                 <nav><ul>
-                                                    <li><a href="../override/">Override url/save_as</a></li>
+                                                    <li class="active"><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-page.html
@@ -20,11 +20,11 @@
                 <h1><a href="../">Alexis' log </a></h1>
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
-                                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                    <li class="active"><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/second-article-fr.html
+++ b/pelican/tests/output/custom/second-article-fr.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/second-article.html
+++ b/pelican/tests/output/custom/second-article.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/tag/baz.html
+++ b/pelican/tests/output/custom/tag/baz.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/tag/foobar.html
+++ b/pelican/tests/output/custom/tag/foobar.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/tag/oh.html
+++ b/pelican/tests/output/custom/tag/oh.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/tag/yeah.html
+++ b/pelican/tests/output/custom/tag/yeah.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="../override/">Override url/save_as</a></li>
                                     <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="../category/yeah.html">yeah</a></li>
-                                    <li ><a href="../category/misc.html">misc</a></li>
-                                    <li ><a href="../category/cat1.html">cat1</a></li>
-                                    <li ><a href="../category/bar.html">bar</a></li>
+                                                                    <li><a href="../category/yeah.html">yeah</a></li>
+                                    <li><a href="../category/misc.html">misc</a></li>
+                                    <li><a href="../category/cat1.html">cat1</a></li>
+                                    <li><a href="../category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
                 

--- a/pelican/tests/output/custom/this-is-a-super-article.html
+++ b/pelican/tests/output/custom/this-is-a-super-article.html
@@ -22,9 +22,9 @@
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
                                                                     <li class="active"><a href="./category/yeah.html">yeah</a></li>
-                                    <li ><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/misc.html">misc</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/tests/output/custom/unbelievable.html
+++ b/pelican/tests/output/custom/unbelievable.html
@@ -21,10 +21,10 @@
                 <nav><ul>
                                                     <li><a href="./override/">Override url/save_as</a></li>
                                     <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                                                                    <li ><a href="./category/yeah.html">yeah</a></li>
+                                                                    <li><a href="./category/yeah.html">yeah</a></li>
                                     <li class="active"><a href="./category/misc.html">misc</a></li>
-                                    <li ><a href="./category/cat1.html">cat1</a></li>
-                                    <li ><a href="./category/bar.html">bar</a></li>
+                                    <li><a href="./category/cat1.html">cat1</a></li>
+                                    <li><a href="./category/bar.html">bar</a></li>
                                                 </ul></nav>
         </header><!-- /#banner -->
         <section id="content" class="body">

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -25,13 +25,13 @@
                     <li><a href="{{ link }}">{{ title }}</a></li>
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU -%}
-                {% for page in PAGES %}
-                    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
+                {% for pg in PAGES %}
+                    <li{% if pg == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
                 {% endfor %}
                 {% endif %}
                 {% if DISPLAY_CATEGORIES_ON_MENU -%}
                 {% for cat, null in categories %}
-                    <li {% if cat == category %}class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
+                    <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
                 {% endfor %}
                 {% endif %}
                 </ul></nav>


### PR DESCRIPTION
For the notmyidea template, this adds `{% if pg == page %} class="active"{% endif %}` for pages just like the one for categories, so that when a page is selected its "tab" highlights just like the one for categories does. This mirrors the behavior of the simple template.

Required a bunch of whitespace-only changes to expected rendered output; the only substantive change is at the very bottom of the PR.
