### PR TITLE
Use the `docutils` variable to check if docutils is installed, not `core`

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 import os
 import re
-import logging
+
 try:
     import docutils
     import docutils.core
@@ -15,7 +15,7 @@ try:
     # import the directives to have pygments support
     from pelican import rstdirectives  # NOQA
 except ImportError:
-    core = False
+    docutils = False
 try:
     from markdown import Markdown
 except ImportError:


### PR DESCRIPTION
The variable used to check if docutils is available is `docutils`, not `core`.

This check for docutils could be removed as docutils is a dependency of pelican and `pkg_resources` seems to check for dependencies before running pelican, so it seems it is not possible to run pelican without docutils.
