### PR TITLE
Move PDF generation to a plugin (Fixes #1009)

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -14,8 +14,8 @@ import collections
 from pelican import signals
 
 from pelican.generators import (ArticlesGenerator, PagesGenerator,
-                                StaticGenerator, PdfGenerator,
-                                SourceFileGenerator, TemplatePagesGenerator)
+                                StaticGenerator, SourceFileGenerator,
+                                TemplatePagesGenerator)
 from pelican.log import init
 from pelican.settings import read_settings
 from pelican.utils import clean_output_dir, folder_watcher, file_watcher
@@ -199,8 +199,6 @@ class Pelican(object):
 
         if self.settings['TEMPLATE_PAGES']:
             generators.append(TemplatePagesGenerator)
-        if self.settings['PDF_GENERATOR']:
-            generators.append(PdfGenerator)
         if self.settings['OUTPUT_SOURCES']:
             generators.append(SourceFileGenerator)
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -581,52 +581,6 @@ class StaticGenerator(Generator):
             logger.info('copying {} to {}'.format(sc.source_path, sc.save_as))
 
 
-class PdfGenerator(Generator):
-    """Generate PDFs on the output dir, for all articles and pages coming from
-    rst"""
-    def __init__(self, *args, **kwargs):
-        super(PdfGenerator, self).__init__(*args, **kwargs)
-        try:
-            from rst2pdf.createpdf import RstToPdf
-            pdf_style_path = os.path.join(self.settings['PDF_STYLE_PATH'])
-            pdf_style = self.settings['PDF_STYLE']
-            self.pdfcreator = RstToPdf(breakside=0,
-                                       stylesheets=[pdf_style],
-                                       style_path=[pdf_style_path])
-        except ImportError:
-            raise Exception("unable to find rst2pdf")
-
-    def _create_pdf(self, obj, output_path):
-        if obj.source_path.endswith('.rst'):
-            filename = obj.slug + ".pdf"
-            output_pdf = os.path.join(output_path, filename)
-            # print('Generating pdf for', obj.source_path, 'in', output_pdf)
-            with open(obj.source_path) as f:
-                self.pdfcreator.createPdf(text=f.read(), output=output_pdf)
-            logger.info(' [ok] writing %s' % output_pdf)
-
-    def generate_context(self):
-        pass
-
-    def generate_output(self, writer=None):
-        # we don't use the writer passed as argument here
-        # since we write our own files
-        logger.info(' Generating PDF files...')
-        pdf_path = os.path.join(self.output_path, 'pdf')
-        if not os.path.exists(pdf_path):
-            try:
-                os.mkdir(pdf_path)
-            except OSError:
-                logger.error("Couldn't create the pdf output folder in " +
-                             pdf_path)
-
-        for article in self.context['articles']:
-            self._create_pdf(article, pdf_path)
-
-        for page in self.context['pages']:
-            self._create_pdf(page, pdf_path)
-
-
 class SourceFileGenerator(Generator):
     def generate_context(self):
         self.output_extension = self.settings['OUTPUT_SOURCES_EXTENSION']


### PR DESCRIPTION
Remove PDF generator from core and move into a plugin. See issue #1009 for more details.

TODO: The list of Pelican features includes "PDF generation" -- if this is still desirable, should it be updated to point to the plugin?
