### PR TITLE
Add `bare_title` to metadata when `title` exists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Release history
   longer article-specific
 * Deprecate ``FILES_TO_COPY`` in favor of ``STATIC_PATHS`` and
   ``EXTRA_PATH_METADATA``
+* Add ``bare_title`` to metadata when ``title`` exists,
+  allowing for non-typogrified ``<title>`` tag when ``TYPOGRIFY=True``.
 
 3.2.1 and 3.2.2
 ===============

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -447,6 +447,9 @@ class Readers(object):
             find_empty_alt(content, path)
 
         # eventually filter the content with typogrify if asked so
+        if 'title' in metadata:
+            # Allow templates to include non-typogrified title in <title> tag.
+            metadata['bare_title'] = metadata['title']
         if content and self.settings['TYPOGRIFY']:
             from typogrify.filters import typogrify
             content = typogrify(content)

--- a/pelican/tests/content/article.rst
+++ b/pelican/tests/content/article.rst
@@ -1,4 +1,4 @@
-Article title
+Article TITLE
 #############
 
 This is some content. With some stuff to "typogrify".

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -67,7 +67,7 @@ class TestArticlesGenerator(unittest.TestCase):
     def test_generate_context(self):
 
         articles_expected = [
-            ['Article title', 'published', 'Default', 'article'],
+            ['Article TITLE', 'published', 'Default', 'article'],
             ['Article with markdown and summary metadata multi', 'published',
              'Default', 'article'],
             ['Article with markdown and summary metadata single', 'published',

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -51,6 +51,7 @@ class RstReaderTest(ReaderTest):
             'author': 'Alexis Métaireau',
             'title': 'Rst with filename metadata',
         }
+        expected['bare_title'] = expected['title']
         for key, value in page.metadata.items():
             self.assertEqual(value, expected[key], key)
 
@@ -63,6 +64,7 @@ class RstReaderTest(ReaderTest):
             'title': 'Rst with filename metadata',
             'date': datetime.datetime(2012, 11, 29),
         }
+        expected['bare_title'] = expected['title']
         for key, value in page.metadata.items():
             self.assertEqual(value, expected[key], key)
 
@@ -80,6 +82,7 @@ class RstReaderTest(ReaderTest):
             'slug': 'article_with_filename_metadata',
             'mymeta': 'foo',
         }
+        expected['bare_title'] = expected['title']
         for key, value in page.metadata.items():
             self.assertEqual(value, expected[key], key)
 
@@ -113,6 +116,26 @@ class RstReaderTest(ReaderTest):
                         '<span class="caps">TLA</span></abbr>.</p>\n')
 
             self.assertEqual(page.content, expected)
+        except ImportError:
+            return unittest.skip('need the typogrify distribution')
+
+    def test_bare_title(self):
+        # if nothing is specified in the settings, the content should be
+        # unmodified
+        page = self.read_file(path='article.rst')
+        expected_bare_title = 'Article TITLE'
+        expected_title = 'Article TITLE'
+        self.assertEqual(page.bare_title, expected_bare_title)
+        self.assertEqual(page.title, expected_title)
+
+        try:
+            # otherwise, typogrify should be applied to title,
+            # but not to bare_title
+            page = self.read_file(path='article.rst', TYPOGRIFY=True)
+            expected_bare_title = 'Article TITLE'
+            expected_title = 'Article&nbsp;<span class="caps">TITLE</span>'
+            self.assertEqual(page.bare_title, expected_bare_title)
+            self.assertEqual(page.title, expected_title)
         except ImportError:
             return unittest.skip('need the typogrify distribution')
 


### PR DESCRIPTION
When `TYPOGRIFY=True` and you have a post with ALL CAPS in its title, the `<title>` tag of the page will incorrectly contain a <span class="caps"> element.

By allowing use of `bare_title` in templates, this allows you to use the "typogrified" version of the title in your page content, while using the bare title in the `<title>` tag.
