### PR TITLE
Limit and filter logs

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -143,3 +143,41 @@ and Python 3 at the same time:
   changed it where I felt necessary.
 
 - Changed xrange() back to range(), so it is valid in both Python versions.
+
+
+Logging tips
+============
+
+Try to use logging with appropriate levels.
+
+For logging messages that are not repeated, use the usual Python way:
+
+    # at top of file
+    import logging
+    logger = logging.getLogger(__name__)
+
+    # when needed
+    logger.warning('A warning that could occur only once")
+
+However, if you want to log messages that may occur several times, instead of
+a string, gives a tuple to the logging method, with two arguments:
+
+ 1. The message to log for this very execution
+ 2. A generic message that will appear if the previous one would occur to many
+    times.
+
+For example, if you want to log missing resources, use the following code:
+
+    for ressource in ressources:
+        if ressource.is_missing:
+            logger.warning((
+                'The resource {r} is missing'.format(r=ressource.name),
+                'Other resources were missing'))
+
+The logs will be displayed as follows:
+
+    WARNING: The resource prettiest_cat.jpg is missing
+    WARNING: The resource best_cat_ever.jpg is missing
+    WARNING: The resource cutest_cat.jpg is missing
+    WARNING: The resource lolcat.jpg is missing
+    WARNING: Other resources were missing

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -88,6 +88,9 @@ Setting name (default value)                                                    
                                                                                  here or a single string representing one locale.
                                                                                  When providing a list, all the locales will be tried
                                                                                  until one works.
+`LOG_FILTER` (``[]``)                                                            A list of tuples containing the logging level (up to warning)
+                                                                                 and the message to be ignored.
+                                                                                 For example: ``[(logging.WARN, 'TAG_SAVE_AS is set to False')]``
 `READERS` (``{}``)                                                               A dictionary of file extensions / Reader classes for Pelican to
                                                                                  process or ignore. For example, to avoid processing .html files,
                                                                                  set: ``READERS = {'html': None}``. To add a custom reader for the
@@ -693,6 +696,23 @@ In addition, you can use the "wide" version of the ``notmyidea`` theme by
 adding the following to your configuration::
 
     CSS_FILE = "wide.css"
+
+
+Logging
+=======
+
+Sometimes, useless lines of log appears while the generation occurs. Finding
+**the** meaningful error message in the middle of tons of annoying log outputs
+can be quite tricky. To be able to filter out all useless log messages, Pelican
+comes with the ``LOG_FILTER`` setting.
+
+``LOG_FILTER`` should be a list of tuples ``(level, msg)``, each of them being
+composed of the logging level (up to warning) and the message to be ignored.
+Simply populate the list with the logs you want to hide and they will be
+filtered out.
+
+For example: ``[(logging.WARN, 'TAG_SAVE_AS is set to False')]``
+
 
 Example settings
 ================

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -11,12 +11,15 @@ import argparse
 import locale
 import collections
 
+# pelican.log has to be the first pelican module to be loaded
+# because logging.setLoggerClass has to be called before logging.getLogger
+from pelican.log import init
+
 from pelican import signals
 
 from pelican.generators import (ArticlesGenerator, PagesGenerator,
                                 StaticGenerator, SourceFileGenerator,
                                 TemplatePagesGenerator)
-from pelican.log import init
 from pelican.readers import Readers
 from pelican.settings import read_settings
 from pelican.utils import clean_output_dir, folder_watcher, file_watcher

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -239,8 +239,10 @@ class Content(object):
                              self._context['filenames'][path].url))
                     origin = origin.replace('\\', '/')  # for Windows paths.
                 else:
-                    logger.warning("Unable to find {fn}, skipping url"
-                                   " replacement".format(fn=path))
+                    logger.warning(("Unable to find {fn}, skipping url"
+                                    " replacement".format(fn=value),
+                                    "Other ressources were not found"
+                                    " and their urls not replaced"))
             elif what == 'category':
                 origin = Category(path, self.settings).url
             elif what == 'tag':

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -19,6 +19,8 @@ except ImportError:
 
 from os.path import isabs
 
+from pelican.log import LimitFilter
+
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +100,7 @@ DEFAULT_CONFIG = {
     'MD_EXTENSIONS': ['codehilite(css_class=highlight)', 'extra'],
     'JINJA_EXTENSIONS': [],
     'JINJA_FILTERS': {},
+    'LOG_FILTER': [],
     'LOCALE': [''],  # defaults to user locale
     'DEFAULT_PAGINATION': False,
     'DEFAULT_ORPHANS': 0,
@@ -170,11 +173,15 @@ def get_settings_from_file(path, default_settings=DEFAULT_CONFIG):
 def configure_settings(settings):
     """Provide optimizations, error checking and warnings for the given
     settings.
-
+    Set up the logs to be ignored as well.
     """
     if not 'PATH' in settings or not os.path.isdir(settings['PATH']):
         raise Exception('You need to specify a path containing the content'
                         ' (see pelican --help for more information)')
+
+    # set up logs to be ignored
+    LimitFilter.ignore.update(set(settings.get('LOG_FILTER',
+                                               DEFAULT_CONFIG['LOG_FILTER'])))
 
     # lookup the theme in "pelican/themes" if the given one doesn't exist
     if not os.path.isdir(settings['THEME']):

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -83,7 +83,7 @@ class TestPelican(LoggedTestCase):
         mute(True)(pelican.run)()
         self.assertDirsEqual(self.temp_path, os.path.join(OUTPUT_PATH, 'basic'))
         self.assertLogCountEqual(
-            count=4,
+            count=3,
             msg="Unable to find.*skipping url replacement",
             level=logging.WARNING)
 


### PR DESCRIPTION
Having clear logs messages is very important to be able to spot quickly when something is wrong. In other words, if you have too many logs messages for nothing, you won't notice the very one important log message in the middle of all the others.
So to limit the number of log messages (especially the useless ones), three ideas have been implemented: removing duplicates, limit the number of similar log messages, and allow the user to specify some log messages she wants to filter out.

More precisely, this PR does 4 different things:
1. drop duplicates logs (up to WARN level)
2. allow for logs to be grouped in categories and enforce a maximum number of logs per group (5 lines of log)
3. change previously existing logs to take advantage of the previous points (e.g. almost revert c875c27e83941ecd2bcd401efe07b35421de704c, which simplyfies the code base)
4. add a `LOG_FILTER` setting

Points 2 and 4 are explained below.

Thanks for @saimn for clarifying commit c875c27e83941ecd2bcd401efe07b35421de704c, and people on IRC in general to vote for the name of the new setting, `LOG_FILTER`.
# Log grouping

This feature was introduced for empty `alt` attributes only in #895. The idea was that if you have 1000 images, instead of having 1000 times `WARNING: Empty alt attribute for image [image_src] in [file_source]`, you only have a few, and then a message saying that there is more.

Here is an example after this PR (as you can see, the threshold has been set to 5):

```
WARNING: Unable to find 1.png, skipping url replacement
WARNING: Unable to find 2.png, skipping url replacement
WARNING: Unable to find 3.png, skipping url replacement
WARNING: Unable to find 4.png, skipping url replacement
WARNING: Other ressources were not found and their urls not replaced
```

To use the log grouping function, instead of passing the log message, give a tuple `(log_message, message_if_too_many)`.

For example, change:

```
logger.warning("Unable to find {fn}, skipping url replacement".format(fn=value))
```

for:

```
logger.warning(("Unable to find {fn}, skipping url replacement".format(fn=value),
                       "Other ressources were not found and their urls not replaced"))
```
# Add a `LOG_FILTER` setting

The `LOG_FILTER` setting is added. It should contain an iterable of tuples of the form `(log_level, log_message)`.

The idea behind this setting is that some configurations raise useless logs.

Say for example that you don't want to generate tags pages on you website. You will get this warning every time for nothing, as you did set this setting to `False` on purpose:

```
WARNING: TAG_SAVE_AS is set to False
```

So now, you simply adds that to you setting file:

```
import logging
LOG_FILTER = [(logging.WARN, 'TAG_SAVE_AS is set to False)] # or replace the list by a tuple/…
```

That means that you need one line per log that you want to remove… but this should not be a problem. In other words, if you want to remove a lots of logs, you are doing something wrong in the first place.
# Putting everything together

Say you did not pay attention and did not specify `alt` attributes (that bad!). Here are the warnings you get:

```
WARNING: Empty alt attribute for image 1.png in /tmp/blog/content/post1.md
WARNING: Empty alt attribute for image 2.png in /tmp/blog/content/post1.md
WARNING: Empty alt attribute for image hbar.png in /tmp/blog/content/post1.md
WARNING: Empty alt attribute for image 3.png in /tmp/blog/content/post1.md
WARNING: Other images have empty alt attributes
```

But wait, the _hbar.png_ file is just an horizontal bar without meaning, so it's fine **(*)** if it has an empty `alt` attribute! So you add that warning to `LOG_FILTER` in your setting file, and generate your blog again. This time, you get:

```
WARNING: Empty alt attribute for image 1.png in /tmp/blog/content/post1.md
WARNING: Empty alt attribute for image 2.png in /tmp/blog/content/post1.md
WARNING: Empty alt attribute for image 3.png in /tmp/blog/content/post1.md
WARNING: Empty alt attribute for image 4.png in /tmp/blog/content/post1.md
WARNING: Other images have empty alt attributes
```

In other words, you still have the same number of warnings (you forgot to put a lot of `alt` attributes, shame on you), but now you know that the image _4.png_ is missing an `alt` attribute as well.

**(*)**: well, you should probably do it in CSS instead, but that was the easiest example that I thought about for legitimate images without `alt` attributes.
