### PR TITLE
Fix for a bug that will make autoreload fail

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -338,7 +338,7 @@ def main():
                     modified = {k: next(v) for k, v in watchers.items()}
 
                     if modified['settings']:
-                        pelican = get_instance(args)
+                        pelican, settings  = get_instance(args)
 
                     if any(modified.values()):
                         print('\n-> Modified: {}. re-generating...'.format(


### PR DESCRIPTION
When `make deveserver` or `pelican --debug --autoreload -r content/ -o output/ -s pelicanconf.py` is called, it fails with following error.

```
-> Modified: content, theme, settings. re-generating...
CRITICAL: ("'tuple' object has no attribute 'run'",)
CRITICAL: 'tuple' object has no attribute 'run'
Traceback (most recent call last):
  File "/Users/talha/Repos/VirtualEnvs/pelican-dev/bin/pelican", line 8,
  in <module>
    load_entry_point('pelican==3.3', 'console_scripts', 'pelican')()
    File
    "/Users/talha/Repos/VirtualEnvs/pelican-dev/lib/python2.7/site-packages/pelican-3.3-py2.7.egg/pelican/__init__.py",
    line 353, in main pelican.run()
```

`get_instance()` returns two values. Old code, instead of unpacking two
values in two variables, placed the tuple in a single variable
`pelican`.

Later in the same block when `pelican.run()` was called, it resulted in
error.

Either the returned value should be unpacked properly or
`pelican[0].run` should be called.
