### PR TITLE
Fix: Using a different FEED_DOMAIN has no effect on in-feed link.

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -33,7 +33,7 @@ class Writer(object):
         sitename = Markup(context['SITENAME']).striptags()
         feed = feed_class(
             title=sitename,
-            link=(self.site_url + '/'),
+            link=(self.feed_domain + '/'),
             feed_url=self.feed_url,
             description=context.get('SITESUBTITLE', ''))
         return feed
@@ -44,7 +44,7 @@ class Writer(object):
         feed.add_item(
             title=title,
             link='%s/%s' % (self.feed_domain, item.url),
-            unique_id='tag:%s,%s:%s' % (self.site_url.replace('http://', ''),
+            unique_id='tag:%s,%s:%s' % (self.feed_domain.replace('http://', ''),
                                         item.date.date(), item.url),
             description=item.get_content(self.site_url),
             categories=item.tags if hasattr(item, 'tags') else None,


### PR DESCRIPTION
If FEED_DOMAIN is not set, SITEURL will be used, as wanted.

I use it for my blog, SITEURL=//florent.peterschmitt.fr and FEED_DOMAIN='http://florent.peterschmitt.fr'.

The "//" permit the access on the site with http or https without problem, for example. But I want my feeds to be http only.
