### PR TITLE
Fix the behavior of Markdown extensions.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -188,8 +188,9 @@ class MarkdownReader(BaseReader):
 
     def __init__(self, *args, **kwargs):
         super(MarkdownReader, self).__init__(*args, **kwargs)
-        self.extensions = self.settings['MD_EXTENSIONS']
-        self.extensions.append('meta')
+        self.extensions = list(self.settings['MD_EXTENSIONS'])
+        if 'meta' not in self.extensions:
+            self.extensions.append('meta')
 
     def _parse_metadata(self, meta):
         """Return the dict containing document metadata"""
@@ -404,11 +405,6 @@ class Readers(object):
                 continue
 
             self.readers[fmt] = reader_class(self.settings)
-
-            settings_key = '%s_EXTENSIONS' % fmt.upper()
-
-            if settings_key in self.settings:
-                self.readers[fmt].extensions = self.settings[settings_key]
 
     @property
     def extensions(self):


### PR DESCRIPTION
There was several issues here:
- `self.extensions` was adding 'meta' multiple times (ref #1058)
- `self.extensions` was keeping a reference to `self.settings['MD_EXTENSIONS']`,
  so adding 'meta' to it.
- the `%s_EXTENSIONS` block coming after, it was overriding `self.extensions`
  with `self.settings['EXTENSIONS']` (while it was a reference, it was working,
  but ...). As this is currently used only for Mardown, the simplest solution is
  to remove this, and let each reader manage its `_EXTENSIONS` setting.
