### PR TITLE
Fix filename replacement on Windows.

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -209,6 +209,9 @@ class Content(object):
                         os.path.join(self.relative_dir, value)
                     )
 
+                # Make sure value has os-compatible path string, which is how
+                # it will be keyed in the context filenames dictionary.
+                value = os.path.join(*value.split('/'))
                 if value in self._context['filenames']:
                     origin = '/'.join((siteurl,
                              self._context['filenames'][value].url))


### PR DESCRIPTION
The context filenames dictionary keys are os-generated paths to the files, which on windows, uses \ instead of /, but the filename replacer was looking only for / if the filename began with /. The result was that filename replacements beginning with / would fail when pelican was run on Windows.

Attached pull request resolves by breaking apart filename and reassembling it using os.path.join() before looking for it among the context filename keys.
