### PR TITLE
When converting file path URL if file path contains %20 change it to space

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -217,6 +217,11 @@ class Content(object):
                     origin = '/'.join((siteurl,
                              self._context['filenames'][path].url))
                     origin = origin.replace('\\', '/')  # for Windows paths.
+                elif path.replace('%20', ' ') in self._context['filenames']:
+                    path_with_spaces = path.replace('%20', ' ')
+                    origin = '/'.join((siteurl,
+                             self._context['filenames'][path_with_spaces].url))
+                    origin = origin.replace('\\', '/')  # for Windows paths.
                 else:
                     logger.warning("Unable to find {fn}, skipping url"
                                    " replacement".format(fn=path))


### PR DESCRIPTION
Consider following link
`[link](|filename|2007-08-22 exhausted.md)`

MarkdownReader converts it to `2007-08-22%20exhausted.md`.

When Pelican tries to convert file path url, it first checks whether the
file is present in specified directories or not.

It does not find `2007-08-22%20exhausted.md` because its name on file
system is `2007-08-22 exhausted.md`.

This fix replaces `%20` with space.

Closes  getpelican/pelican#1062
