### PR TITLE
Fix tests with latest version of Smartypants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_install:
  - sudo locale-gen fr_FR.UTF-8 tr_TR.UTF-8
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then ln -s /usr/share/asciidoc/asciidocapi.py ~/virtualenv/python2.7/lib/python2.7/site-packages/; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install typogrify ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install git+https://github.com/dmdm/typogrify.git@py3k#egg=typogrify; fi
     - pip install mock nose nose-cov Markdown
     - pip install .
 script: nosetests -sv --with-coverage --cover-package=pelican pelican

--- a/pelican/tests/content/article.rst
+++ b/pelican/tests/content/article.rst
@@ -1,6 +1,6 @@
 Article title
 #############
 
-This is some content. With some stuff to "typogrify".
+THIS is some content. With some stuff to "typogrify"...
 
 Now with added support for :abbr:`TLA (three letter acronym)`.

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -104,8 +104,8 @@ class RstReaderTest(ReaderTest):
         # if nothing is specified in the settings, the content should be
         # unmodified
         page = self.read_file(path='article.rst')
-        expected = ('<p>This is some content. With some stuff to '
-                    '&quot;typogrify&quot;.</p>\n<p>Now with added '
+        expected = ('<p>THIS is some content. With some stuff to '
+                    '&quot;typogrify&quot;...</p>\n<p>Now with added '
                     'support for <abbr title="three letter acronym">'
                     'TLA</abbr>.</p>\n')
 
@@ -114,10 +114,11 @@ class RstReaderTest(ReaderTest):
         try:
             # otherwise, typogrify should be applied
             page = self.read_file(path='article.rst', TYPOGRIFY=True)
-            expected = ('<p>This is some content. With some stuff to&nbsp;'
-                        '&#8220;typogrify&#8221;.</p>\n<p>Now with added '
-                        'support for <abbr title="three letter acronym">'
-                        '<span class="caps">TLA</span></abbr>.</p>\n')
+            expected = (
+                '<p><span class="caps">THIS</span> is some content. '
+                'With some stuff to&nbsp;&quot;typogrify&quot;&#8230;</p>\n'
+                '<p>Now with added support for <abbr title="three letter '
+                'acronym"><span class="caps">TLA</span></abbr>.</p>\n')
 
             self.assertEqual(page.content, expected)
         except ImportError:

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,5 @@ deps =
     mock
     Markdown
     BeautifulSoup4
-    git+https://github.com/dmdm/smartypants.git#egg=smartypants
     git+https://github.com/dmdm/typogrify.git@py3k#egg=typogrify
     lxml


### PR DESCRIPTION
Smartypants is now Python 3 compatible but the default settings for double quotes has
been changed (http://pythonhosted.org/smartypants/changes.html).

This commit:
- updates the Typogrify test (change quotes and add more test cases: caps word,
  ellipsis)
- install Typogrify on Travis
- uses upstream version of Smartypants in tox instead of @dmdm's fork for Python 3
