### PR TITLE
xml => lxml for bs4, in pelican-import.wp2fields()

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -109,7 +109,7 @@ def wp2fields(xml):
 
     with open(xml, encoding='utf-8') as infile:
         xmlfile = infile.read()
-    soup = BeautifulSoup(xmlfile, "xml")
+    soup = BeautifulSoup(xmlfile, "lxml")
     items = soup.rss.channel.findAll('item')
 
     for item in items:


### PR DESCRIPTION
This small change in the parser used in pelican-import.wp2fields() is proposed to resolve https://github.com/getpelican/pelican/issues/1113. 

I have not tested it in a full installation of Pelican, but the code now returns the expected number of items (posts), even when a formfeed is present.
