### PR TITLE
Ensure headers from base.html are included.

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block head %}
+  {{ super() }}
   {% for keyword in article.keywords %}
     <meta name="keywords" contents="{{keyword}}" />
   {% endfor %}


### PR DESCRIPTION
The simple theme's article.html template overrides the 'head' block in base.html, but it does not call `super()`. Headers from base.html are therefore ignored such as stylesheet inclusions and this makes it difficult to build a theme based on simple's templates.
