### PR TITLE
docs/plugins.rst: fix signal name "page_generator_context"

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -80,7 +80,7 @@ article_generator_finalized     article_generator               invoked at the e
 get_generators                  generators                      invoked in Pelican.get_generator_classes,
                                                                 can return a Generator, or several
                                                                 generator in a tuple or in a list.
-page_generate_context           page_generator, metadata
+page_generator_context          page_generator, metadata
 page_generator_init             page_generator                  invoked in the PagesGenerator.__init__
 page_generator_finalized        page_generator                  invoked at the end of PagesGenerator.generate_context
 content_object_init             content_object                  invoked at the end of Content.__init__ (see note below)


### PR DESCRIPTION
The old "pages_generate_context" dates from before pelican-3.2
standardization, but AFAIK, "page_generate_context" was never correct.
