### PR TITLE
Preserve file metadata (esp. timestamps) when copy static files to output folder.

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -573,7 +573,7 @@ class StaticGenerator(Generator):
             source_path = os.path.join(self.path, sc.source_path)
             save_as = os.path.join(self.output_path, sc.save_as)
             mkdir_p(os.path.dirname(save_as))
-            shutil.copy(source_path, save_as)
+            shutil.copy2(source_path, save_as)
             logger.info('copying {} to {}'.format(sc.source_path, sc.save_as))
 
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -289,7 +289,7 @@ def copy(path, source, destination, destination_path=None):
                 else:
                     shutil.copytree(entry_path, entry_dest)
             else:
-                shutil.copy(entry_path, destination)
+                shutil.copy2(entry_path, destination)
 
 
     if os.path.isdir(source_):
@@ -299,7 +299,7 @@ def copy(path, source, destination, destination_path=None):
         dest_dir = os.path.dirname(destination_)
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
-        shutil.copy(source_, destination_)
+        shutil.copy2(source_, destination_)
         logger.info('copying %s to %s' % (source_, destination_))
     else:
         logger.warning('skipped copy %s to %s' % (source_, destination_))


### PR DESCRIPTION
Related to #1027, but only focus on static files (theme files, images, attachments).

The method [shutil.copy2](http://docs.python.org/2/library/shutil.html#shutil.copy2) will copy file metadata as well as file content. Method [shutil.copytree](http://docs.python.org/2/library/shutil.html#shutil.copytree) internally also calls [shutil.copy2](http://docs.python.org/2/library/shutil.html#shutil.copy2) rather than [shutil.copy](http://docs.python.org/2/library/shutil.html#shutil.copy2).
