### PR TITLE
Fix {category} and {tag} placeholders when called from subdirs

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -197,6 +197,9 @@ class Content(object):
             \2""".format(instrasite_link_regex)
         hrefs = re.compile(regex, re.X)
 
+        def join_siteurl(path):
+            return '/'.join((siteurl, path))
+
         def replacer(m):
             what = m.group('what')
             value = urlparse(m.group('value'))
@@ -214,16 +217,15 @@ class Content(object):
                     )
 
                 if path in self._context['filenames']:
-                    origin = '/'.join((siteurl,
-                             self._context['filenames'][path].url))
+                    origin = join_siteurl(self._context['filenames'][path].url)
                     origin = origin.replace('\\', '/')  # for Windows paths.
                 else:
                     logger.warning("Unable to find {fn}, skipping url"
                                    " replacement".format(fn=path))
             elif what == 'category':
-                origin = Category(path, self.settings).url
+                origin = join_siteurl(Category(path, self.settings).url)
             elif what == 'tag':
-                origin = Tag(path, self.settings).url
+                origin = join_siteurl(Tag(path, self.settings).url)
 
             # keep all other parts, such as query, fragment, etc.
             parts = list(value)
@@ -237,7 +239,6 @@ class Content(object):
 
     @memoized
     def get_content(self, siteurl):
-
         if hasattr(self, '_get_content'):
             content = self._get_content()
         else:

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -194,7 +194,12 @@ class TestPage(unittest.TestCase):
         page = Page(**args)
         content = page.get_content('http://notmyidea.org')
         self.assertEqual(content, ('A simple test, with a '
-                                   '<a href="tag/tagname.html">link</a>'))
+                                   '<a href="http://notmyidea.org/tag/tagname.html">link</a>'))
+
+        page = Page(**args)
+        content = page.get_content('..')
+        self.assertEqual(content, ('A simple test, with a '
+                                   '<a href="../tag/tagname.html">link</a>'))
 
         # Category
         args['content'] = ('A simple test, with a '
@@ -203,7 +208,13 @@ class TestPage(unittest.TestCase):
         content = page.get_content('http://notmyidea.org')
         self.assertEqual(content,
                          ('A simple test, with a '
-                          '<a href="category/category.html">link</a>'))
+                          '<a href="http://notmyidea.org/category/category.html">link</a>'))
+
+        page = Page(**args)
+        content = page.get_content('..')
+        self.assertEqual(content,
+                         ('A simple test, with a '
+                          '<a href="../category/category.html">link</a>'))
 
     def test_intrasite_link(self):
         # type does not take unicode in PY2 and bytes in PY3, which in


### PR DESCRIPTION
{category} placeholder was failing for me when called from a page in a subdir. This change fixes it by applying the to {category} and {tag} the same operations applied to {filename}.
