### PR TITLE
Document video support in reST & Markdown.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -88,6 +88,7 @@ Joseph Reagle
 Joshua Adelman
 Julian Berman
 Justin Mayer
+Kevin Deldycke
 Kyle Fuller
 Laureline Guerin
 Leonard Huang

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -94,3 +94,8 @@ directly into your source content.
 
 Alternatively, you can also use Pelican plugins like ``liquid_tags``,
 ``pelican_youtube``, or ``pelican_vimeo`` to embed videos in your content.
+
+Moreover, markup languages like reST and Markdown have plugins that let you
+embed videos in the markup. You can use `reST video directive
+<https://gist.github.com/dbrgn/2922648>`_ for reST or `mdx_video plugin
+<https://github.com/italomaia/mdx-video>`_ for Markdown.


### PR DESCRIPTION
I uncovered an alternative way of adding native support for videos in Markdown-based content, thanks to the [`mdx_video`](https://pypi.python.org/pypi/mdx_video) plugin.

Here is a little contribution to document this option, based on user support from issue #1099.
