### PR TITLE
Fix #1039 ATOM feed for sites using https or a subdirectory

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -8,6 +8,9 @@ import logging
 
 if not six.PY3:
     from codecs import open
+    from urlparse import urlparse
+else:
+    from urllib.parse import urlparse
 
 from feedgenerator import Atom1Feed, Rss201rev2Feed
 from jinja2 import Markup
@@ -41,11 +44,13 @@ class Writer(object):
     def _add_item_to_the_feed(self, feed, item):
 
         title = Markup(item.title).striptags()
+        link = '%s/%s' % (self.site_url, item.url)
         feed.add_item(
             title=title,
-            link='%s/%s' % (self.site_url, item.url),
-            unique_id='tag:%s,%s:%s' % (self.site_url.replace('http://', ''),
-                                        item.date.date(), item.url),
+            link=link,
+            unique_id='tag:%s,%s:%s' % (urlparse(link).netloc,
+                                        item.date.date(),
+                                        urlparse(link).path.lstrip('/')),
             description=item.get_content(self.site_url),
             categories=item.tags if hasattr(item, 'tags') else None,
             author_name=getattr(item, 'author', ''),


### PR DESCRIPTION
Fixes issue #1039.  Atom feed is invalid when SITEURL has
https or a subdirectory, for example:
- https://myblog.com/
- http://mysite.com/blog
