### PR TITLE
Add 'asciidoc' to the ASCIIDoc possible extensions

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -334,7 +334,7 @@ class AsciiDocReader(BaseReader):
     """Reader for AsciiDoc files"""
 
     enabled = bool(asciidoc)
-    file_extensions = ['asc']
+    file_extensions = ['asc', 'asciidoc']
     default_options = ["--no-header-footer", "-a newline=\\n"]
 
     def read(self, source_path):


### PR DESCRIPTION
Since '.asc' are also a file type for PGP and a few other stuff.  Since '.asciidoc' is a used extension for ASCIIDoc document, I only add this extension to the list of possible detectable files in Pelican.
