### PR TITLE
Fixes #1143, spaces in filename links

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -213,6 +213,10 @@ class Content(object):
                         os.path.join(self.relative_dir, path)
                     )
 
+                # spaces in filename
+                if path not in self._context['filenames'] and '%20' in path:
+                    path = path.replace('%20', ' ')
+
                 if path in self._context['filenames']:
                     origin = '/'.join((siteurl,
                              self._context['filenames'][path].url))


### PR DESCRIPTION
If %20 in path and path doesn't exist, replaces %20 with spaces.
