### PR TITLE
Add support for new article metadata modified date

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -301,6 +301,7 @@ this metadata in text files via the following syntax (give your file the
     ##############
 
     :date: 2010-10-03 10:20
+    :modified_date: 2011-01-10 16:56
     :tags: thats, awesome
     :category: yeah
     :slug: my-super-post
@@ -320,6 +321,7 @@ pattern::
 
     Title: My super title
     Date: 2010-12-03 10:20
+    Modified_date: 2011-01-10 16:56
     Category: Python
     Tags: pelican, publishing
     Slug: my-super-post

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -42,6 +42,7 @@ from pelican.utils import get_date, pelican_open
 METADATA_PROCESSORS = {
     'tags': lambda x, y: [Tag(tag, y) for tag in x.split(',')],
     'date': lambda x, y: get_date(x),
+    'modified_date': lambda x, y: get_date(x),
     'status': lambda x, y: x.strip(),
     'category': Category,
     'author': Author,


### PR DESCRIPTION
Modified date is a standard feature in most blog engines.

Theme developer can use this date to show last updated time of an
article and enclose its value in `<time>` element.

We cannot use mtime of a file for modified_date because it is already
used for date metadata.

Secondly, a file mtime can be affected in a lot many ways, for example,
a sync service can change it, which will be incorrect to show as last
updated time of an article.
