### PR TITLE
Check argument type in get_date utility function before processing it

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -180,6 +180,8 @@ def get_date(string):
 
     If no format matches the given date, raise a ValueError.
     """
+    if isinstance(string, datetime):
+        return string
     string = re.sub(' +', ' ', string)
     formats = [
         # ISO 8601


### PR DESCRIPTION
Sitemap plugin calls this method to convert `modified` metadate into
datetime. Depending on the version of Pelican `modified` can be string
or a datetime object.

Therefore get_date should check for the type of argument otherwise
Pelican fails with a critical error.
