### PR TITLE
Remove `--reference-links` parameter from pelican-import

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Next release
 
 * Added the `:modified:` metadata field to complement `:date:`.
   Used to specify the last date and time an article was updated independently from the date and time it was published.
+* Produce inline links instead of reference-style links when importing content.
 
 3.3.0 (2013-09-24)
 ==================

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -519,7 +519,7 @@ def fields2pelican(fields, out_markup, output_path,
 
 
             parse_raw = '--parse-raw' if not strip_raw else ''
-            cmd = ('pandoc --normalize --reference-links {0} --from=html'
+            cmd = ('pandoc --normalize {0} --from=html'
                    ' --to={1} -o "{2}" "{3}"').format(
                     parse_raw, out_markup, out_filename, html_filename)
 


### PR DESCRIPTION
When importing WordPress content from its XML export, I have the following post content:

``` xml
(...)
<item>
    <wp:post_type>post</wp:post_type>
    (...)
    <content:encoded><![CDATA[<a href="http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation.png"><img src="http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation-162x288.png" alt="" title="conversation" width="162" height="288" class="aligncenter size-large wp-image-5378" /></a>]]></content:encoded>
    (...)
</item>
(...)
```

It's transformed by `pelican-import` to this Markdown:

``` markdown
[![][]][]

  []: http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation-162x288.png
    "conversation"
  [![][]]: http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation.png
```

Which in returns produce this HTML in Pelican:

``` html
<p>[<img alt="" src="http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation-162x288.png" title="conversation">][]</p>
<p>[<img alt="" src="http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation-162x288.png" title="conversation">]: http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation.png</p>
```

This is wrong.

Now, with this patch:

``` diff
--- ./pelican-3.1.1/pelican/tools/pelican_import.py.orig      2012-12-13 19:23:09.942693101 +0100
+++ ./pelican-3.1.1/pelican/tools/pelican_import.py     2012-11-15 20:07:08.000000000 +0100
@@ -246,7 +246,7 @@


             parse_raw = '--parse-raw' if not strip_raw else ''
-            cmd = ('pandoc --normalize {0} --from=html'
+            cmd = ('pandoc --normalize --reference-links {0} --from=html'
                    ' --to={1} -o "{2}" "{3}"').format(
                     parse_raw, out_markup, out_filename, html_filename)

```

pelican-import produce the following Markdown:

``` markdown
[![](http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation-162x288.png "conversation")](http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation.png)
```

Which is much better, as it produce the following HTML in Pelican:

``` html
<p><a href="http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation.png"><img alt="" src="http://kevin.deldycke.com/wp-content/uploads/2012/11/conversation-162x288.png" title="conversation"></a></p>
```

As `--reference-links` seems to do more harm than good (see #348). I propose to remove this parameter.
