### PR TITLE
Prioritize the latest version of the doc for search engines.

### DIFF
--- a/docs/_themes/pelican/layout.html
+++ b/docs/_themes/pelican/layout.html
@@ -1,4 +1,15 @@
 {% extends "basic/layout.html" %}
+{%- block linktags -%}
+  {{ super() }}
+  <link rel="canonical" href="http://docs.getpelican.com/en/latest/
+  {%- for word in pagename.split('/') -%}
+    {%- if word != 'index' -%}
+        {%- if word != '' -%}
+            {{ word }}.html
+        {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}">
+{%- endblock -%}
 {% block header %}
   {{ super() }}
   {% if pagename == 'index' %}


### PR DESCRIPTION
Make search engines only see the latest version of the documentation.

This code is picked from the [FAQ of readthedocs.org](https://read-the-docs.readthedocs.org/en/latest/faq.html#can-i-make-search-engines-only-see-one-version-of-my-docs).