### PR TITLE
Wordpress import error on empty <wp:post_name>

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -126,6 +126,9 @@ def wp2fields(xml):
             content = item.find('encoded').string
             filename = item.find('post_name').string
 
+            if filename is None:
+                filename = item.find('post_id').string
+
             raw_date = item.find('post_date').string
             date_object = time.strptime(raw_date, "%Y-%m-%d %H:%M:%S")
             date = time.strftime("%Y-%m-%d %H:%M", date_object)


### PR DESCRIPTION
Importing from a Wordpress XML export file:

```
WARNING: Post "No title [None]" is lacking a proper title
Traceback (most recent call last):
  File "/private/tmp/virtualenv/bin/pelican-import", line 8, in <module>
    load_entry_point('pelican==3.2', 'console_scripts', 'pelican-import')()
  File "/private/tmp/virtualenv/lib/python2.7/site-packages/pelican/tools/pelican_import.py", line 518, in main
    disable_slugs=args.disable_slugs or False)
  File "/private/tmp/virtualenv/lib/python2.7/site-packages/pelican/tools/pelican_import.py", line 379, in fields2pelican
    filename = os.path.basename(filename)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 112, in basename
    i = p.rfind('/') + 1
AttributeError: 'NoneType' object has no attribute 'rfind'
```

This is because I have several old posts with an empty `<wp:post_name>` tag:

``` xml
<wp:post_name></wp:post_name>
```

Adding

``` python
if filename is None:
    filename = item.find('post_id').string
```

after the `filename` assignment in `wp2fields()` in `pelican_import.py` seems to have worked for me.
