### PR TITLE
Make marking articles as drafts case-insensitive

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -407,9 +407,9 @@ class ArticlesGenerator(Generator):
 
             self.add_source_path(article)
 
-            if article.status == "published":
+            if article.status.lower() == "published":
                 all_articles.append(article)
-            elif article.status == "draft":
+            elif article.status.lower() == "draft":
                 self.drafts.append(article)
             else:
                 logger.warning("Unknown status %s for file %s, skipping it." %


### PR DESCRIPTION
Previously if you tried to mark an article as a draft by using a different
casing (for example, draft) you would get a warning when building:
`Unknown status Draft for file foo.md, skipping it.` This uses a
case-insensitive comparison when looking at article status instead. I
believe this behavior is a little easier for new Pelican users.
