### PR TITLE
Support publishing to personal pages sites in quickstart

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -15,6 +15,11 @@ from pelican import __version__
 _TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                               "templates")
 
+_GITHUB_PAGES_BRANCHES = {
+    'personal': 'master',
+    'project': 'gh-pages'
+}
+
 CONF = {
     'pelican': 'pelican',
     'pelicanopts': '',
@@ -31,6 +36,7 @@ CONF = {
     'cloudfiles_api_key': 'my_rackspace_api_key',
     'cloudfiles_container': 'my_cloudfiles_container',
     'dropbox_dir': '~/Dropbox/Public/',
+    'github_pages_branch': _GITHUB_PAGES_BRANCHES['project'],
     'default_pagination': 10,
     'siteurl': '',
     'lang': 'en'
@@ -217,6 +223,11 @@ needed by Pelican.
             CONF['cloudfiles_username'] = ask('What is your Rackspace Cloud username?', str_compat, CONF['cloudfiles_username'])
             CONF['cloudfiles_api_key'] = ask('What is your Rackspace Cloud API key?', str_compat, CONF['cloudfiles_api_key'])
             CONF['cloudfiles_container'] = ask('What is the name of your Cloud Files container?', str_compat, CONF['cloudfiles_container'])
+        if ask('Do you want to upload your website using GitHub Pages?', answer=bool, default=False):
+            if ask('Is this your personal page (username.github.io)?', answer=bool, default=False):
+                CONF['github_pages_branch'] = _GITHUB_PAGES_BRANCHES['personal']
+            else:
+                CONF['github_pages_branch'] = _GITHUB_PAGES_BRANCHES['project']
 
     try:
         os.makedirs(os.path.join(CONF['basedir'], 'content'))

--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -24,6 +24,8 @@ CLOUDFILES_CONTAINER=$cloudfiles_container
 
 DROPBOX_DIR=$dropbox_dir
 
+GITHUB_PAGES_BRANCH=$github_pages_branch
+
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
 	PELICANOPTS += -D
@@ -101,7 +103,7 @@ cf_upload: publish
 	cd $(OUTPUTDIR) && swift -v -A https://auth.api.rackspacecloud.com/v1.0 -U $(CLOUDFILES_USERNAME) -K $(CLOUDFILES_API_KEY) upload -c $(CLOUDFILES_CONTAINER) .
 
 github: publish
-	ghp-import $$(OUTPUTDIR)
-	git push origin gh-pages
+	ghp-import -b $(GITHUB_PAGES_BRANCH) $$(OUTPUTDIR)
+	git push origin $(GITHUB_PAGES_BRANCH)
 
 .PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github


### PR DESCRIPTION
Previously pelican-quickstart would assume that the site it created for GitHub Pages should be published to the gh-pages branch. This is correct for project pages, but not correct for personal pages. Personal pages, which live in a
user's special username.github.io repository, are instead deployed to the master branch. This means that if you did pelican-quickstart and tried to publish your new personal site with make github you'd see nothing (or whatever old pages site you had floating around in master).

ghp-import already supports publishing to different branches, so publishing to the correct branch is just a matter of correct configuration and updating the Makefile to pass the branch along to ghp-import. pelican-quickstart now
asks if the user wants to publish to GitHub Pages, and if so, asks if this is a personal page and chooses the correct branch appropriately. I preferred this approach to prompting for an arbitrary branch because I felt that choosing the branch would feel more intimidating to someone using pelican-quickstart for the first time.

This essentially ports changes I made to my personal pages site at jculpon@82cae477a9e8712b90654f6432464369ebcc7ae5. 

I later made further changes to my Makefile to have the commit message reference the commit on the source branch that was used to build the site. If there's interest, I can pull those over too, but I figured that that's a more personal change that most people won't be interested in.
