### PR TITLE
Fix `utils.copy` for copying files

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -550,8 +550,12 @@ class StaticGenerator(Generator):
             final_path=None):
         """Copy all the paths from source to destination"""
         for path in paths:
-            copy(path, source, os.path.join(output_path, destination),
-                 final_path)
+            if final_path:
+                copy(os.path.join(source, path),
+                     os.path.join(output_path, destination, final_path))
+            else:
+                copy(os.path.join(source, path),
+                     os.path.join(output_path, destination, path))
 
     def generate_context(self):
         self.staticfiles = []
@@ -592,7 +596,7 @@ class SourceFileGenerator(Generator):
         output_path, _ = os.path.splitext(obj.save_as)
         dest = os.path.join(self.output_path,
                             output_path + self.output_extension)
-        copy('', obj.source_path, dest)
+        copy(obj.source_path, dest)
 
     def generate_output(self, writer=None):
         logger.info(' Generating source files...')

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -350,29 +350,23 @@ class TestCopy(unittest.TestCase):
 
     def test_copy_file_same_path(self):
         self._create_file('a.txt')
-        utils.copy('',
-                   os.path.join(self.root_dir, 'a.txt'),
-                   os.path.join(self.root_dir, 'b.txt')
-                   )
+        utils.copy(os.path.join(self.root_dir, 'a.txt'),
+                   os.path.join(self.root_dir, 'b.txt'))
         self._exist_file('b.txt')
 
     def test_copy_file_different_path(self):
         self._create_dir('a')
         self._create_dir('b')
         self._create_file('a', 'a.txt')
-        utils.copy('',
-                   os.path.join(self.root_dir, 'a', 'a.txt'),
-                   os.path.join(self.root_dir, 'b', 'b.txt')
-                   )
+        utils.copy(os.path.join(self.root_dir, 'a', 'a.txt'),
+                   os.path.join(self.root_dir, 'b', 'b.txt'))
         self._exist_dir('b')
         self._exist_file('b', 'b.txt')
 
     def test_copy_file_create_dirs(self):
         self._create_file('a.txt')
-        utils.copy('',
-                   os.path.join(self.root_dir, 'a.txt'),
-                   os.path.join(self.root_dir, 'b0', 'b1', 'b2', 'b3', 'b.txt')
-                   )
+        utils.copy(os.path.join(self.root_dir, 'a.txt'),
+                   os.path.join(self.root_dir, 'b0', 'b1', 'b2', 'b3', 'b.txt'))
         self._exist_dir('b0')
         self._exist_dir('b0', 'b1')
         self._exist_dir('b0', 'b1', 'b2')
@@ -382,10 +376,8 @@ class TestCopy(unittest.TestCase):
     def test_copy_dir_same_path(self):
         self._create_dir('a')
         self._create_file('a', 'a.txt')
-        utils.copy('',
-                   os.path.join(self.root_dir, 'a'),
-                   os.path.join(self.root_dir, 'b')
-                   )
+        utils.copy(os.path.join(self.root_dir, 'a'),
+                   os.path.join(self.root_dir, 'b'))
         self._exist_dir('b')
         self._exist_file('b', 'a.txt')
 
@@ -394,20 +386,16 @@ class TestCopy(unittest.TestCase):
         self._create_dir('a0', 'a1')
         self._create_file('a0', 'a1', 'a.txt')
         self._create_dir('b0')
-        utils.copy('',
-                   os.path.join(self.root_dir, 'a0', 'a1'),
-                   os.path.join(self.root_dir, 'b0', 'b1')
-                   )
+        utils.copy(os.path.join(self.root_dir, 'a0', 'a1'),
+                   os.path.join(self.root_dir, 'b0', 'b1'))
         self._exist_dir('b0', 'b1')
         self._exist_file('b0', 'b1', 'a.txt')
 
     def test_copy_dir_create_dirs(self):
         self._create_dir('a')
         self._create_file('a', 'a.txt')
-        utils.copy('',
-                   os.path.join(self.root_dir, 'a'),
-                   os.path.join(self.root_dir, 'b0', 'b1', 'b2', 'b3', 'b')
-                   )
+        utils.copy(os.path.join(self.root_dir, 'a'),
+                   os.path.join(self.root_dir, 'b0', 'b1', 'b2', 'b3', 'b'))
         self._exist_dir('b0')
         self._exist_dir('b0', 'b1')
         self._exist_dir('b0', 'b1', 'b2')

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -256,22 +256,19 @@ def slugify(value, substitutions=()):
     return value.decode('ascii')
 
 
-def copy(path, source, destination, destination_path=None):
-    """Copy path from origin to destination.
+def copy(source, destination):
+    """Recursively copy source into destination.
+
+    If source is a file, destination has to be a file as well.
 
     The function is able to copy either files or directories.
 
-    :param path: the path to be copied from the source to the destination
-    :param source: the source dir
-    :param destination: the destination dir
-    :param destination_path: the destination path (optional)
+    :param source: the source file or directory
+    :param destination: the destination file or directory
     """
-    if not destination_path:
-        destination_path = path
 
-    source_ = os.path.abspath(os.path.expanduser(os.path.join(source, path)))
-    destination_ = os.path.abspath(
-        os.path.expanduser(os.path.join(destination, destination_path)))
+    source_ = os.path.abspath(os.path.expanduser(source))
+    destination_ = os.path.abspath(os.path.expanduser(destination))
 
     if not os.path.exists(destination_) and not os.path.isfile(source_):
         os.makedirs(destination_)


### PR DESCRIPTION
# Bug description

`utils.copy('', 'a/b.ext0', 'c/d.ext1')` is copying `a/b.ext0` into `c/d.ext1/b.ext0` (creating folder `c/d.ext1` in the process) instead of `c/d.ext1`.

Bug introduced by e03cf3f51735d5387fee7064cae89aaa1d34a0a6.
# How to reproduce

Run `pelican-quickstart`, and add the following to the setting file:

```
OUTPUT_SOURCES = True
ARTICLE_URL = 'articles/{slug}'
ARTICLE_SAVE_AS = ARTICLE_URL + '.html'
```

Create an article (e.g. `content/a.md`), and run `make html`.

_Expected behaviour:_ source output as `output/articles/hello-world.text`.
_Observed behaviour:_ source output as `output/articles/hello-word.text/a.md`.
