### PR TITLE
Fix for issue #1182

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -186,7 +186,8 @@ needed by Pelican.
         print('Using project associated with current virtual environment.'
               'Will save to:\n%s\n' % CONF['basedir'])
     else:
-        CONF['basedir'] = os.path.abspath(ask('Where do you want to create your new web site?', answer=str_compat, default=args.path))
+        CONF['basedir'] = os.path.abspath(os.path.expanduser(
+            ask('Where do you want to create your new web site?', answer=str_compat, default=args.path)))
 
     CONF['sitename'] = ask('What will be the title of this web site?', answer=str_compat, default=args.title)
     CONF['author'] = ask('Who will be the author of this web site?', answer=str_compat, default=args.author)


### PR DESCRIPTION
Hi,
I fixed this trivial issue the same way as described by jculpon, I actually discovered it as well when starting a blog myself.

``` bash
(pelican)wvi@kryten:~/virtualenvs/pelican/bin>pelican-quickstart
Welcome to pelican-quickstart v3.3.0.

This script will help you create a new Pelican-based website.

Please answer the following questions so this script can generate the files
needed by Pelican.


> Where do you want to create your new web site? [.] ~/tmp/test1
> What will be the title of this web site? TEST1
> Who will be the author of this web site? TESTER1
> What will be the default language of this web site? [en] 
> Do you want to specify a URL prefix? e.g., http://example.com   (Y/n) n
> Do you want to enable article pagination? (Y/n) 
> How many articles per page do you want? [10] 
> Do you want to generate a Fabfile/Makefile to automate generation and publishing? (Y/n) 
> Do you want an auto-reload & simpleHTTP script to assist with theme and site development? (Y/n) 
> Do you want to upload your website using FTP? (y/N) 
> Do you want to upload your website using SSH? (y/N) 
> Do you want to upload your website using Dropbox? (y/N) 
> Do you want to upload your website using S3? (y/N) 
> Do you want to upload your website using Rackspace Cloud Files? (y/N) 
Done. Your new project is available at /home/wvi/tmp/test1
(pelican)wvi@kryten:~/virtualenvs/pelican/bin>l /home/wvi/tmp/test1/
total 28
drwxr-xr-x 2 wvi users 4096 Dec 23 21:37 content
-rwxr-xr-x 1 wvi users 2179 Dec 23 21:37 develop_server.sh
-rw-r--r-- 1 wvi users 1481 Dec 23 21:37 fabfile.py
-rw-r--r-- 1 wvi users 3759 Dec 23 21:37 Makefile
drwxr-xr-x 2 wvi users 4096 Dec 23 21:37 output
-rw-r--r-- 1 wvi users  790 Dec 23 21:37 pelicanconf.py
-rw-r--r-- 1 wvi users  508 Dec 23 21:37 publishconf.py
(pelican)wvi@kryten:~/virtualenvs/pelican/bin>

```
