### PR TITLE
Fix bug #1165

### DIFF
--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -69,7 +69,7 @@ class Paginator(object):
 
 class Page(object):
     def __init__(self, name, object_list, number, paginator, settings):
-        self.name = name
+        self.name, self.extension = os.path.splitext(name)
         self.object_list = object_list
         self.number = number
         self.paginator = paginator
@@ -143,6 +143,7 @@ class Page(object):
             'settings': self.settings,
             'base_name': os.path.dirname(self.name),
             'number_sep': '/',
+            'extension':  self.extension,
         }
 
         if self.number == 1:

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -79,7 +79,7 @@ DEFAULT_CONFIG = {
     'AUTHOR_URL': 'author/{slug}.html',
     'AUTHOR_SAVE_AS': os.path.join('author', '{slug}.html'),
     'PAGINATION_PATTERNS': [
-        (0, '{name}{number}.html', '{name}{number}.html'),
+        (0, '{name}{number}{extension}', '{name}{number}{extension}'),
     ],
     'YEAR_ARCHIVE_SAVE_AS': False,
     'MONTH_ARCHIVE_SAVE_AS': False,

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
+import six
+
+from pelican.tests.support import unittest, get_settings
+
+from pelican.paginator import Paginator
+from pelican.contents import Article
+from pelican.settings import DEFAULT_CONFIG
+from jinja2.utils import generate_lorem_ipsum
+
+# generate one paragraph, enclosed with <p>
+TEST_CONTENT = str(generate_lorem_ipsum(n=1))
+TEST_SUMMARY = generate_lorem_ipsum(n=1, html=False)
+
+class TestPage(unittest.TestCase):
+    def setUp(self):
+        super(TestPage, self).setUp()
+        self.page_kwargs = {
+            'content': TEST_CONTENT,
+            'context': {
+                'localsiteurl': '',
+            },
+            'metadata': {
+                'summary': TEST_SUMMARY,
+                'title': 'foo bar',
+                'author': 'Blogger',
+            },
+            'source_path': '/path/to/file/foo.ext'
+        }
+
+    def test_save_as_preservation(self):
+        settings = get_settings()
+        # fix up pagination rules
+        from pelican.paginator import PaginationRule
+        pagination_rules = [
+            PaginationRule(*r) for r in settings.get(
+                'PAGINATION_PATTERNS',
+                DEFAULT_CONFIG['PAGINATION_PATTERNS'],
+            )
+        ]
+        settings['PAGINATION_PATTERNS'] = sorted(
+            pagination_rules,
+            key=lambda r: r[0],
+        )
+
+        object_list = [Article(**self.page_kwargs), Article(**self.page_kwargs)]
+        paginator = Paginator('foobar.foo', object_list, settings)
+        page = paginator.page(1)
+        self.assertEqual(page.save_as, 'foobar.foo')

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -179,10 +179,9 @@ class Writer(object):
 
         # pagination
         if paginated:
-            name_root = os.path.splitext(name)[0]
 
             # pagination needed, init paginators
-            paginators = {key: Paginator(name_root, val, self.settings)
+            paginators = {key: Paginator(name, val, self.settings)
                           for key, val in paginated.items()}
 
             # generated pages, and write


### PR DESCRIPTION
As I understand it the pagination code is stripping the extension from the TAG_SAVE_AS , CATEGORY_SAVE_AS , and AUTHOR_SAVE_AS settings. Then an extension is reapplied from the pagination SAVE_AS setting. This means that the TAG_SAVE_AS , CATEGORY_SAVE_AS , and AUTHOR_SAVE_AS settings have no affect on the files extension.

This fix saves the extension from incoming files to be written, strips any extension applied by the pagination code, and reapplies the old extension.

This means that setting an extension the pagination SAVE_AS setting now has no affect, but the other settings have control of the extension.

Perhaps I need to update the documentation?
