### PR TITLE
Add pycharm/jetbrains .idea folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tags
 htmlcov
 six-*.egg/
 *.orig
+.idea/


### PR DESCRIPTION
With PyCharm now having a free community edition, it makes sense to have the PyCharm settings folder ignored.
