### PR TITLE
Add configuration settings for custom tests and globals in jinja2 environment

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -76,10 +76,16 @@ Setting name (default value)                                            What doe
                                                                         output directory. One use case would be the preservation of version
                                                                         control data. For example: ``(".hg", ".git", ".bzr")``
 `JINJA_EXTENSIONS` (``[]``)                                             A list of any Jinja2 extensions you want to use.
-`JINJA_FILTERS` (``{}``)                                                A list of custom Jinja2 filters you want to use.
+`JINJA_FILTERS` (``{}``)                                                A dictionary of custom Jinja2 filters you want to use.
                                                                         The dictionary should map the filtername to the filter function.
                                                                         For example: ``{'urlencode': urlencode_filter}``
                                                                         See `Jinja custom filters documentation`_.
+`JINJA_GLOBALS` (``{}``)                                                A dictionary of custom objects to map into the Jinja2 global environment
+                                                                        namespace. The dictionary should map the global name to the global
+                                                                        attribute. See `Jinja global namespace documentation`_.
+`JINJA_TESTS` (``{}``)                                                  A dictionary of custom Jinja2 tests you want to use.
+                                                                        The dictionary should map the testname to the test function.
+                                                                        See `Jinja custom tests documentation`_.
 `LOCALE` (''[#]_)                                                       Change the locale. A list of locales can be provided
                                                                         here or a single string representing one locale.
                                                                         When providing a list, all the locales will be tried
@@ -165,6 +171,10 @@ Setting name (default value)                                            What doe
 =====================================================================   =====================================================================
 
 .. [#] Default is the system locale.
+
+.. _Jinja custom filters documentation: http://jinja.pocoo.org/docs/api/#custom-filters
+.. _Jinja global namespace documentation: http://jinja.pocoo.org/docs/api/#the-global-namespace
+.. _Jinja custom tests documentation: http://jinja.pocoo.org/docs/api/#custom-tests
 
 
 URL settings
@@ -680,6 +690,3 @@ Example settings
 
 .. literalinclude:: ../samples/pelican.conf.py
     :language: python
-
-
-.. _Jinja custom filters documentation: http://jinja.pocoo.org/docs/api/#custom-filters

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -72,6 +72,14 @@ class Generator(object):
         custom_filters = self.settings['JINJA_FILTERS']
         self.env.filters.update(custom_filters)
 
+        # get custom Jinja globals from user settings
+        custom_globals = self.settings['JINJA_GLOBALS']
+        self.env.globals.update(custom_globals)
+
+        # get custom Jinja tests from user settings
+        custom_tests = self.settings['JINJA_TESTS']
+        self.env.tests.update(custom_tests)
+
         signals.generator_init.send(self)
 
     def get_template(self, name):

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -94,6 +94,8 @@ DEFAULT_CONFIG = {
     'MD_EXTENSIONS': ['codehilite(css_class=highlight)', 'extra'],
     'JINJA_EXTENSIONS': [],
     'JINJA_FILTERS': {},
+    'JINJA_GLOBALS': {},
+    'JINJA_TESTS': {},
     'LOCALE': [''],  # defaults to user locale
     'DEFAULT_PAGINATION': False,
     'DEFAULT_ORPHANS': 0,


### PR DESCRIPTION
Pelican currently has a setting for custom Jinja2 filters, but not for custom tests or custom environment namespace globals.  This pull request adds both.
