### PR TITLE
`ctrl+c` correctly terminates&reenables `fab serve`

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -1,6 +1,9 @@
 from fabric.api import *
 import fabric.contrib.project as project
 import os
+import sys
+import SimpleHTTPServer
+import SocketServer
 
 # Local path configuration (can be absolute or relative to fabfile)
 env.deploy_path = 'output'
@@ -32,7 +35,16 @@ def regenerate():
     local('pelican -r -s pelicanconf.py')
 
 def serve():
-    local('cd {deploy_path} && python -m SimpleHTTPServer'.format(**env))
+    os.chdir(env.deploy_path)
+    
+    PORT = 8000
+    class AddressReuseTCPServer(SocketServer.TCPServer):
+        allow_reuse_address = True
+    
+    server = AddressReuseTCPServer(('', PORT), SimpleHTTPServer.SimpleHTTPRequestHandler)
+    
+    sys.stderr.write('Serving on port {0} ...\n'.format(PORT))
+    server.serve_forever()
 
 def reserve():
     build()


### PR DESCRIPTION
Previously `ctrl+c` a `fab serve` wouldn't necessarily terminate the web server. Even if it does, re-using the command `fab serve` might result in the following error:

```
socket.error: [Errno 48] Address already in use
```

This fix manually creates a `TCPServer` with `allow_reuse_address` set to `True`, which solves this issue.

Tested on OS X 10.9.1.
