### PR TITLE
Fix for getpelican/pelican#1198

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -147,12 +147,7 @@ class Writer(object):
 
         def _write_file(template, localcontext, output_path, name, override):
             """Render the template write the file."""
-            old_locale = locale.setlocale(locale.LC_ALL)
-            locale.setlocale(locale.LC_ALL, str('C'))
-            try:
-                output = template.render(localcontext)
-            finally:
-                locale.setlocale(locale.LC_ALL, old_locale)
+            output = template.render(localcontext)
             path = os.path.join(output_path, name)
             try:
                 os.makedirs(os.path.dirname(path))


### PR DESCRIPTION
When rendering templates, the locale was set to C in getpelican/pelican@ddcccfeaa952d2e1e24ceac94e5d66c73b57c01b

If one used a locale that made use of unicode characters (like et_EE.UTF-8)
the files on disk would be in correct locale while links would be to C.

Works with Python3, gives ascii decoding errors with Python2