### PR TITLE
source files copy as file not as a new directory

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -592,7 +592,7 @@ class SourceFileGenerator(Generator):
         output_path, _ = os.path.splitext(obj.save_as)
         dest = os.path.join(self.output_path,
                             output_path + self.output_extension)
-        copy('', obj.source_path, dest)
+        copy('', obj.source_path, dest, is_file=True)
 
     def generate_output(self, writer=None):
         logger.info(' Generating source files...')

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -256,7 +256,7 @@ def slugify(value, substitutions=()):
     return value.decode('ascii')
 
 
-def copy(path, source, destination, destination_path=None):
+def copy(path, source, destination, destination_path=None, is_file=False):
     """Copy path from origin to destination.
 
     The function is able to copy either files or directories.
@@ -273,7 +273,7 @@ def copy(path, source, destination, destination_path=None):
     destination_ = os.path.abspath(
         os.path.expanduser(os.path.join(destination, destination_path)))
 
-    if not os.path.exists(destination_):
+    if not os.path.exists(destination_) and not is_file:
         os.makedirs(destination_)
 
     def recurse(source, destination):


### PR DESCRIPTION
When OUTPUT_SOURCES is set to True, the copy function within util.py checks if the destination path is a directory. If not, a directory is made. Instead of the intended result like this:

/output/my-post-name/index.html
/output/my-post-name/index.txt

It results in:

/output/my-post-name/index.txt/my-post-name.txt

Where index.txt is a directory.
