### PR TITLE
Exit code should not be successful on restructuredtext errors

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -155,7 +155,8 @@ class RstReader(BaseReader):
     def _get_publisher(self, source_path):
         extra_params = {'initial_header_level': '2',
                         'syntax_highlight': 'short',
-                        'input_encoding': 'utf-8'}
+                        'input_encoding': 'utf-8',
+                        'exit_status_level': 2}
         user_params = self.settings.get('DOCUTILS_SETTINGS')
         if user_params:
             extra_params.update(user_params)
@@ -166,7 +167,7 @@ class RstReader(BaseReader):
         pub.writer.translator_class = PelicanHTMLTranslator
         pub.process_programmatic_settings(None, extra_params, None)
         pub.set_source(source_path=source_path)
-        pub.publish()
+        pub.publish(enable_exit_status=True)
         return pub
 
     def read(self, source_path):


### PR DESCRIPTION
Currently, if there is a restructured syntax error, the exit code is still 0.

```
$ make publish
 ...
 .../content/article.rst:34: (ERROR/3) Unexpected indentation.
 .../content/article.rst:36: (WARNING/2) Block quote ends without a blank line; unexpected unindent.
 Done: Processed 60 articles and 1 pages in 3.03 seconds.

$ echo $?
0
```

I [use Travis to build the blog](http://blog.mathieu-leplatre.info/publish-your-pelican-blog-on-github-pages-via-travis-ci.html). It would be great if I could publish the output only if there is no rST error at all :)

```
# .travis.yml
script:
   - make publish
after_sucess:
   - make github
```

This change allows to fail and exit loudly.

```
 $ make publish
 ...
 .../content/article.rst:34: (ERROR/3) Unexpected indentation.
 .../content/article.rst:36: (WARNING/2) Block quote ends without a blank line; unexpected unindent.
 make: *** [publish] Erreur 13

$ echo $?
2
```
