### PR TITLE
fix test-suite import error

### DIFF
--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 import six
 from datetime import datetime
 from sys import platform
 
-from .support import unittest, get_settings
+from pelican.tests.support import unittest, get_settings
 
 from pelican.contents import Page, Article, URLWrapper
 from pelican.settings import DEFAULT_CONFIG

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, print_function
+from __future__ import unicode_literals, print_function, absolute_import
 import logging
 import shutil
 import os
@@ -15,7 +15,7 @@ from pelican.generators import TemplatePagesGenerator
 from pelican.writers import Writer
 from pelican.settings import read_settings
 from pelican import utils
-from .support import get_article, LoggedTestCase, locale_available, unittest
+from pelican.tests.support import get_article, LoggedTestCase, locale_available, unittest
 
 
 class TestUtils(LoggedTestCase):


### PR DESCRIPTION
was having an error using relative imports on the test suite.

Using absolute imports fixes the errors
