### PR TITLE
Add feeds for each author

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -461,6 +461,8 @@ Setting name (default value)                        What does it do?
                                                     language.
 `CATEGORY_FEED_ATOM` ('feeds/%s.atom.xml'[2]_)      Where to put the category Atom feeds.
 `CATEGORY_FEED_RSS` (``None``, i.e. no RSS)         Where to put the category RSS feeds.
+`AUTHOR_FEED_ATOM` ('feeds/%s.atom.xml'[2]_)        Where to put the author Atom feeds.
+`AUTHOR_FEED_RSS` ('feeds/%s.rss.xml'[2]_)          Where to put the author RSS feeds.
 `TAG_FEED_ATOM` (``None``, i.e. no tag feed)        Relative URL to output the tag Atom feed. It should
                                                     be defined using a "%s" match in the tag name.
 `TAG_FEED_RSS` (``None``, ie no RSS tag feed)       Relative URL to output the tag RSS feed

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -234,6 +234,18 @@ class ArticlesGenerator(Generator):
                                   self.settings['CATEGORY_FEED_RSS']
                                   % cat.slug, feed_type='rss')
 
+        for auth, arts in self.authors:
+            arts.sort(key=attrgetter('date'), reverse=True)
+            if self.settings.get('AUTHOR_FEED_ATOM'):
+                writer.write_feed(arts, self.context,
+                                  self.settings['AUTHOR_FEED_ATOM']
+                                  % auth.slug)
+
+            if self.settings.get('AUTHOR_FEED_RSS'):
+                writer.write_feed(arts, self.context,
+                                  self.settings['AUTHOR_FEED_RSS']
+                                  % auth.slug, feed_type='rss')
+
         if (self.settings.get('TAG_FEED_ATOM')
                 or self.settings.get('TAG_FEED_RSS')):
             for tag, arts in self.tags.items():

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -39,6 +39,8 @@ DEFAULT_CONFIG = {
     'THEME_STATIC_PATHS': ['static', ],
     'FEED_ALL_ATOM': os.path.join('feeds', 'all.atom.xml'),
     'CATEGORY_FEED_ATOM': os.path.join('feeds', '%s.atom.xml'),
+    'AUTHOR_FEED_ATOM': os.path.join('feeds', '%s.atom.xml'),
+    'AUTHOR_FEED_RSS': os.path.join('feeds', '%s.rss.xml'),
     'TRANSLATION_FEED_ATOM': os.path.join('feeds', 'all-%s.atom.xml'),
     'FEED_MAX_ITEMS': '',
     'SITEURL': '',
@@ -242,6 +244,7 @@ def configure_settings(settings):
         'FEED_ATOM', 'FEED_RSS',
         'FEED_ALL_ATOM', 'FEED_ALL_RSS',
         'CATEGORY_FEED_ATOM', 'CATEGORY_FEED_RSS',
+        'AUTHOR_FEED_ATOM', 'AUTHOR_FEED_RSS',
         'TAG_FEED_ATOM', 'TAG_FEED_RSS',
         'TRANSLATION_FEED_ATOM', 'TRANSLATION_FEED_RSS',
     ]


### PR DESCRIPTION
I maintain a group pelican blog and we'd love the ability to have feeds for each author.  This feature seemed straightforward to create - it's just the code for category feeds, adapted slightly.
