### PR TITLE
Append slash to href of link to site home

### DIFF
--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -33,7 +33,7 @@
 
 <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="{{ SITEURL }}">{{ SITENAME }} <strong>{{ SITESUBTITLE }}</strong></a></h1>
+                <h1><a href="{{ SITEURL }}/">{{ SITENAME }} <strong>{{ SITESUBTITLE }}</strong></a></h1>
         </header><!-- /#banner -->
         <nav id="menu"><ul>
         {% for title, link in MENUITEMS %}


### PR DESCRIPTION
This is necessary to make the link to the site home work locally, because then SITEURL may be set to an empty string (in fact the Pelican default configuration sets it to an empty string in pelicanconf.py). This will also make the behavior consistent with the builtin notmyidea theme.
