### PR TITLE
WordPress custom posts and attachment download

### DIFF
--- a/pelican/tests/content/wordpressexport.xml
+++ b/pelican/tests/content/wordpressexport.xml
@@ -681,6 +681,273 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.]]></con
             <wp:meta_key>_edit_last</wp:meta_key>
             <wp:meta_value><![CDATA[3]]></wp:meta_value>
         </wp:postmeta>
+    </item>   
+    <item>
+        <title>A custom post in category 4</title>
+        <link>http://thisisa.test/?p=175</link>
+        <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+        <dc:creator>bob</dc:creator>
+        <guid isPermaLink="false">http://thisisa.test/?p=175</guid>
+        <description></description>
+        <content:encoded><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+<ul>
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+</ul>
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>175</wp:post_id>
+        <wp:post_date>2012-02-16 15:52:55</wp:post_date>
+        <wp:post_date_gmt>0000-00-00 00:00:00</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>custpost1cat4</wp:post_name>
+        <wp:status>publish</wp:status>
+        <wp:post_parent>0</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>custom1</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <category domain="category" nicename="category-4"><![CDATA[Category 4]]></category>
+        <wp:postmeta>
+            <wp:meta_key>_edit_last</wp:meta_key>
+            <wp:meta_value><![CDATA[3]]></wp:meta_value>
+        </wp:postmeta>
     </item>
-</channel>
+    <item>
+        <title>A custom post in category 5</title>
+        <link>http://thisisa.test/?p=176</link>
+        <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+        <dc:creator>bob</dc:creator>
+        <guid isPermaLink="false">http://thisisa.test/?p=176</guid>
+        <description></description>
+        <content:encoded><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+<ul>
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+</ul>
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>176</wp:post_id>
+        <wp:post_date>2012-02-16 15:52:55</wp:post_date>
+        <wp:post_date_gmt>0000-00-00 00:00:00</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>custpost1cat5</wp:post_name>
+        <wp:status>publish</wp:status>
+        <wp:post_parent>0</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>custom1</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <category domain="category" nicename="category-5"><![CDATA[Category 5]]></category>
+        <wp:postmeta>
+            <wp:meta_key>_edit_last</wp:meta_key>
+            <wp:meta_value><![CDATA[3]]></wp:meta_value>
+        </wp:postmeta>
+        </item>   
+        <item>
+        <title>A 2nd custom post type also in category 5</title>
+        <link>http://thisisa.test/?p=177</link>
+        <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+        <dc:creator>bob</dc:creator>
+        <guid isPermaLink="false">http://thisisa.test/?p=177</guid>
+        <description></description>
+        <content:encoded><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+<ul>
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+    <li>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</li>
+</ul>
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>177</wp:post_id>
+        <wp:post_date>2012-02-16 15:52:55</wp:post_date>
+        <wp:post_date_gmt>0000-00-00 00:00:00</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>custpost2cat5</wp:post_name>
+        <wp:status>publish</wp:status>
+        <wp:post_parent>0</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>custom2</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <category domain="category" nicename="category-5"><![CDATA[Category 5]]></category>
+        <wp:postmeta>
+            <wp:meta_key>_edit_last</wp:meta_key>
+            <wp:meta_value><![CDATA[3]]></wp:meta_value>
+        </wp:postmeta>
+    </item>
+    <item>
+        <title>Attachment with a parent</title>
+        <link>http://thisisa.test/?attachment_id=24</link>
+        <pubDate>Sat, 04 Feb 2012 03:17:33 +0000</pubDate>
+        <dc:creator>bob</dc:creator>
+        <guid isPermaLink="false">http://thisurlisinvalid.notarealdomain/not_an_image.jpg</guid>
+        <description></description>
+        <content:encoded><![CDATA[]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>25</wp:post_id>
+        <wp:post_date>2012-02-04 03:17:33</wp:post_date>
+        <wp:post_date_gmt>2012-02-04 03:17:33</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>attachment-with-a-parent</wp:post_name>
+        <wp:status>inherit</wp:status>
+        <wp:post_parent>8</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>attachment</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <wp:attachment_url>http://thisurlisinvalid.notarealdomain/not_an_image.jpg</wp:attachment_url>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_metadata</wp:meta_key>
+            <wp:meta_value><![CDATA[a:5:{s:5:"width";s:3:"150";s:6:"height";s:3:"186";s:14:"hwstring_small";s:22:"height='96' width='77'";s:4:"file";s:20:"2012/02/pelican.png";s:10:"image_meta";a:10:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";}}]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attached_file</wp:meta_key>
+            <wp:meta_value><![CDATA[2012/02/stuff.png]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_image_alt</wp:meta_key>
+            <wp:meta_value><![CDATA[Stuff]]></wp:meta_value>
+        </wp:postmeta>
+    </item>
+    <item>
+        <title>2nd Attachment to same parent</title>
+        <link>http://thisisa.test/?attachment_id=25</link>
+        <pubDate>Sat, 04 Feb 2012 03:17:33 +0000</pubDate>
+        <dc:creator>bob</dc:creator>
+        <guid isPermaLink="false">http://en.wikipedia.org/wiki/File:Pelikan_Walvis_Bay.jpg</guid>
+        <description></description>
+        <content:encoded><![CDATA[]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>25</wp:post_id>
+        <wp:post_date>2012-02-04 03:17:33</wp:post_date>
+        <wp:post_date_gmt>2012-02-04 03:17:33</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>2nd[attachment-to-same-parent</wp:post_name>
+        <wp:status>inherit</wp:status>
+        <wp:post_parent>8</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>attachment</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <wp:attachment_url>http://en.wikipedia.org/wiki/File:Pelikan_Walvis_Bay.jpg</wp:attachment_url>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_metadata</wp:meta_key>
+            <wp:meta_value><![CDATA[a:5:{s:5:"width";s:3:"150";s:6:"height";s:3:"186";s:14:"hwstring_small";s:22:"height='96' width='77'";s:4:"file";s:20:"2012/02/pelican.png";s:10:"image_meta";a:10:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";}}]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attached_file</wp:meta_key>
+            <wp:meta_value><![CDATA[2012/02/stuff.png]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_image_alt</wp:meta_key>
+            <wp:meta_value><![CDATA[Stuff]]></wp:meta_value>
+        </wp:postmeta>
+    </item>
+    <item>
+        <title>Attachment with a different parent</title>
+        <link>http://thisisa.test/?attachment_id=26</link>
+        <pubDate>Sat, 04 Feb 2012 03:17:33 +0000</pubDate>
+        <dc:creator>bob</dc:creator>
+        <guid isPermaLink="false">http://thisurlisinvalid.notarealdomain</guid>
+        <description></description>
+        <content:encoded><![CDATA[]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>25</wp:post_id>
+        <wp:post_date>2012-02-04 03:17:33</wp:post_date>
+        <wp:post_date_gmt>2012-02-04 03:17:33</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>attachment-with-a-different-parent</wp:post_name>
+        <wp:status>inherit</wp:status>
+        <wp:post_parent>25</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>attachment</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <wp:attachment_url>http://thisurlisinvalid.notarealdomain</wp:attachment_url>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_metadata</wp:meta_key>
+            <wp:meta_value><![CDATA[a:5:{s:5:"width";s:3:"150";s:6:"height";s:3:"186";s:14:"hwstring_small";s:22:"height='96' width='77'";s:4:"file";s:20:"2012/02/pelican.png";s:10:"image_meta";a:10:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";}}]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attached_file</wp:meta_key>
+            <wp:meta_value><![CDATA[2012/02/stuff.png]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_image_alt</wp:meta_key>
+            <wp:meta_value><![CDATA[Stuff]]></wp:meta_value>
+        </wp:postmeta>
+    </item>
+ </channel>
 </rss>

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -4,9 +4,11 @@ from __future__ import unicode_literals, print_function
 import os
 import re
 
-from pelican.tools.pelican_import import wp2fields, fields2pelican, decode_wp_content, build_header
+from pelican.tools.pelican_import import wp2fields, fields2pelican, decode_wp_content, build_header, build_markdown_header, get_attachments, download_attachments
 from pelican.tests.support import (unittest, temporary_folder, mute,
                                    skipIfNoExecutable)
+
+from pelican.utils import slugify
 
 CUR_DIR = os.path.dirname(__file__)
 WORDPRESS_XML_SAMPLE = os.path.join(CUR_DIR, 'content', 'wordpressexport.xml')
@@ -29,6 +31,7 @@ class TestWordpressXmlImporter(unittest.TestCase):
 
     def setUp(self):
         self.posts = list(wp2fields(WORDPRESS_XML_SAMPLE))
+        self.custposts = list(wp2fields(WORDPRESS_XML_SAMPLE, True))
 
     def test_ignore_empty_posts(self):
         self.assertTrue(self.posts)
@@ -54,6 +57,112 @@ class TestWordpressXmlImporter(unittest.TestCase):
             fname = list(silent_f2p(test_post, 'markdown', temp, dirpage=True))[0]
             self.assertTrue(fname.endswith('pages%sempty.md' % os.path.sep))
 
+    def test_dircat(self):
+        silent_f2p = mute(True)(fields2pelican)
+        test_posts = []
+        for post in self.posts:
+            # check post kind
+            if len(post[5]) > 0: # Has a category
+                test_posts.append(post)
+        with temporary_folder() as temp:
+            fnames = list(silent_f2p(test_posts, 'markdown', temp, dircat=True))
+        index = 0
+        for post in test_posts:
+            name = post[2]
+            category = slugify(post[5][0])
+            name += '.md'
+            filename = os.path.join(category, name)
+            out_name = fnames[index]
+            self.assertTrue(out_name.endswith(filename))
+            index += 1
+    
+    def test_unless_custom_post_all_items_should_be_pages_or_posts(self):
+        self.assertTrue(self.posts)
+        pages_data = []
+        for title, content, fname, date, author, categ, tags, kind, format in self.posts:
+            if kind == 'page' or kind == 'article':
+                pass
+            else:
+                pages_data.append((title, fname))
+        self.assertEqual(0, len(pages_data))
+    
+    def test_recognise_custom_post_type(self):
+        self.assertTrue(self.custposts)
+        cust_data = []
+        for title, content, fname, date, author, categ, tags, kind, format in self.custposts:
+            if kind == 'article' or kind == 'page':
+                pass
+            else:
+                cust_data.append((title, kind))
+        self.assertEqual(3, len(cust_data))
+        self.assertEqual(('A custom post in category 4', 'custom1'), cust_data[0])
+        self.assertEqual(('A custom post in category 5', 'custom1'), cust_data[1])
+        self.assertEqual(('A 2nd custom post type also in category 5', 'custom2'), cust_data[2])
+     
+    def test_custom_posts_put_in_own_dir(self):
+        silent_f2p = mute(True)(fields2pelican)
+        test_posts = []
+        for post in self.custposts:
+            # check post kind
+            if post[7] == 'article' or post[7] == 'page':
+                pass
+            else:
+                test_posts.append(post)
+        with temporary_folder() as temp:
+            fnames = list(silent_f2p(test_posts, 'markdown', temp, wp_custpost = True))
+        index = 0
+        for post in test_posts:
+            name = post[2]
+            kind = post[7]
+            name += '.md'
+            filename = os.path.join(kind, name)
+            out_name = fnames[index]
+            self.assertTrue(out_name.endswith(filename))
+            index += 1
+
+    def test_custom_posts_put_in_own_dir_and_catagory_sub_dir(self):
+        silent_f2p = mute(True)(fields2pelican)
+        test_posts = []
+        for post in self.custposts:
+            # check post kind
+            if post[7] == 'article' or post[7] == 'page':
+                pass
+            else:
+                test_posts.append(post)
+        with temporary_folder() as temp:
+            fnames = list(silent_f2p(test_posts, 'markdown', temp, 
+                wp_custpost=True, dircat=True))
+        index = 0
+        for post in test_posts:
+            name = post[2]
+            kind = post[7]
+            category = slugify(post[5][0])
+            name += '.md'
+            filename = os.path.join(kind, category, name)
+            out_name = fnames[index]
+            self.assertTrue(out_name.endswith(filename))
+            index += 1
+
+    def test_wp_custpost_true_dirpage_false(self):
+        #pages should only be put in their own directory when dirpage = True
+        silent_f2p = mute(True)(fields2pelican)
+        test_posts = []
+        for post in self.custposts:
+            # check post kind
+            if post[7] == 'page':
+                test_posts.append(post)
+        with temporary_folder() as temp:
+            fnames = list(silent_f2p(test_posts, 'markdown', temp, 
+                wp_custpost=True, dirpage=False))
+        index = 0
+        for post in test_posts:
+            name = post[2]
+            name += '.md'
+            filename = os.path.join('pages', name)
+            out_name = fnames[index]
+            self.assertFalse(out_name.endswith(filename))
+        
+ 
     def test_can_toggle_raw_html_code_parsing(self):
         def r(f):
             with open(f) as infile:
@@ -137,3 +246,48 @@ class TestBuildHeader(unittest.TestCase):
                 'これは広い幅の文字だけで構成されたタイトルです\n' +
                 '##############################################\n\n')
 
+    def test_galleries_added_to_header(self):
+        header = build_header('test', None, None, None, None, 
+                None, ['output/test1', 'output/test2'])
+        self.assertEqual(header, 'test\n####\n' + ':attachments: output/test1, ' 
+                + 'output/test2\n\n')
+
+    def test_galleries_added_to_markdown_header(self):
+        header = build_markdown_header('test', None, None, None, None, None,
+            ['output/test1', 'output/test2'])
+        self.assertEqual(header, 'Title: test\n' + 'Attachments: output/test1, '
+                + 'output/test2\n\n')
+
+@unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')       
+class TestWordpressXMLAttachements(unittest.TestCase):        
+    def setUp(self):
+        self.attachments = get_attachments(WORDPRESS_XML_SAMPLE)
+    
+    def test_recognise_attachments(self):
+        self.assertTrue(self.attachments)
+        self.assertTrue(len(self.attachments.keys()) == 3)
+
+    def test_attachments_associated_with_correct_post(self):
+        self.assertTrue(self.attachments)
+        for post in self.attachments.keys():
+            if post is None:
+                self.assertTrue(self.attachments[post][0] == 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Pelican_lakes_entrance02.jpg/240px-Pelican_lakes_entrance02.jpg')
+            elif post == 'with-excerpt':
+                self.assertTrue(self.attachments[post][0] == 'http://thisurlisinvalid.notarealdomain/not_an_image.jpg')
+                self.assertTrue(self.attachments[post][1] == 'http://en.wikipedia.org/wiki/File:Pelikan_Walvis_Bay.jpg')
+            elif post == 'with-tags':
+                self.assertTrue(self.attachments[post][0] == 'http://thisurlisinvalid.notarealdomain')
+            else:
+                self.fail('all attachments should match to a filename or None, {}'.format(post))
+
+    def test_download_attachments(self):
+        real_file = os.path.join(CUR_DIR, 'content/article.rst')
+        good_url = 'file://' + real_file
+        bad_url = 'http://www.notarealsite.notarealdomain/not_a_file.txt'
+        silent_da = mute()(download_attachments)
+        with temporary_folder() as temp:
+            #locations = download_attachments(temp, [good_url, bad_url])
+            locations = list(silent_da(temp, [good_url, bad_url]))
+            self.assertTrue(len(locations) == 1)
+            directory = locations[0]
+            self.assertTrue(directory.endswith('content/article.rst'))


### PR DESCRIPTION
I wrote two extensions for the pelican-import command line tool. 

The first adds support for wordpress custom post types. Adding the `--wp-custpost` option outputs custom posts into their own directory. If used with the `dircat` option, posts will be placed as `/output/custompostname/category/posts`.

The second option is `--wp-attach`. This downloads all files in the WordPress XML file where the post type is an attachment. Attachments usually have a parent. The parent posts will have a list of attachments generated and added to their header. The header list will be the paths to the files, relative to the output folder.  All attachments will be downloaded even if they don't have a parent. This option is useful if you are changing servers or want to start fresh. 

Sorry both features are in the same pull request. I realised later that they should've been separate features, but I'd been working on both before I realised this. Also there is a bit of unnecessary refactoring. I was cleaning the code up because I was using different parts of the fields2pelican code originally but I changed my strategy after a while. All code has been tested on python27 and python33 and all tests pass so nothing is broken, hopefully you think the result is more readable. :)
