### PR TITLE
Needed a signal for my subcategory plugin

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -482,6 +482,7 @@ class ArticlesGenerator(Generator):
     def generate_output(self, writer):
         self.generate_feeds(writer)
         self.generate_pages(writer)
+        signals.article_writer_finalized.send(self, writer=writer)
 
 
 class PagesGenerator(Generator):

--- a/pelican/signals.py
+++ b/pelican/signals.py
@@ -19,6 +19,7 @@ generator_init = signal('generator_init')
 article_generator_init = signal('article_generator_init')
 article_generator_finalized = signal('article_generator_finalized')
 article_generator_write_article = signal('article_generator_write_article')
+article_writer_finalized = signal('article_writer_finalized')
 
 page_generator_init = signal('page_generator_init')
 page_generator_finalized = signal('page_generator_finalized')


### PR DESCRIPTION
Added a signal after the article generator finishes writing the feeds and the pages. Delivers the generator and the writer so that I can then write out the subcategory pages.
