### PR TITLE
Add period to period_archives context. Refs #1044.

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -253,6 +253,29 @@ page_name               TAG_URL where everything after `{slug}` is removed
                         -- useful for pagination links
 ===================     ===================================================
 
+period_archives.html
+--------------------
+
+This template will be processed for each year of your posts if a path
+for YEAR_ARCHIVE_SAVE_AS is defined, each month if MONTH_ARCHIVE_SAVE_AS
+is defined and each day if DAY_ARCHIVE_SAVE_AS is defined.
+
+===================     ===================================================
+Variable                Description
+===================     ===================================================
+period                  A tuple of the form (`year`, `month`, `day`) that
+                        indicates the current time period. `year` and `day`
+                        are numbers while `month` is a string. This tuple
+                        only contains `year` if the time period is a
+                        given year. It contains both `year` and `month`
+                        if the time period is over years and months and
+                        so on.
+
+===================     ===================================================
+
+You can see an example of how to use `period` in the ``simple`` theme's
+period_archives.html
+
 Feeds
 =====
 

--- a/pelican/themes/notmyidea/templates/period_archives.html
+++ b/pelican/themes/notmyidea/templates/period_archives.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<section id="content" class="body">
+<h1>Archives for {{ period | reverse | join(' ') }}</h1>
+
+<dl>
+{% for article in dates %}
+    <dt>{{ article.locale_date }}</dt>
+    <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+{% endfor %}
+</dl>
+</section>
+{% endblock %}

--- a/pelican/themes/simple/templates/period_archives.html
+++ b/pelican/themes/simple/templates/period_archives.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Archives for {{ period | reverse | join(' ') }}</h1>
+
+<dl>
+{% for article in dates %}
+    <dt>{{ article.locale_date }}</dt>
+    <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+{% endfor %}
+</dl>
+{% endblock %}


### PR DESCRIPTION
- Adds period tuple of (year, month, day) matching the time
  period of the current archive. Note that this is done
  to the archive context if period_archives.html doesn't exist.
- Adds tests to verify this.
- Adds documentation in themes.rst about period in period_archives.html.

I completed @dbrgn's work (Issue #1044.) and changed the _year_, _year_name_... variables to a _period_ variable to be less verbose in the templates.
