### PR TITLE
Add the setting SLUGIFY_ATTRIBUTE Refs: #197

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -166,6 +166,10 @@ Setting name (default value)                                                    
 `PYGMENTS_RST_OPTIONS` (``[]``)                                                  A list of default Pygments settings for your reStructuredText
                                                                                  code blocks. See :ref:`internal_pygments_options` for a list of
                                                                                  supported options.
+
+`SLUGIFY_SOURCE` (``'input'``)                                                Specifies where you want the slug to be automatically generated 
+                                                                                 from. Can be set to 'title' to use the Title: metadata tag or 
+                                                                                 'basename' to use the articles basename to make a slug. 
 ===============================================================================  =====================================================================
 
 .. [#] Default is the system locale.

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -96,9 +96,15 @@ class Content(object):
 
             self.in_default_lang = (self.lang == default_lang)
 
-        # create the slug if not existing, from the title
-        if not hasattr(self, 'slug') and hasattr(self, 'title'):
-            self.slug = slugify(self.title,
+        # create the slug if not existing, generate slug according to 
+        # setting of SLUG_ATTRIBUTE
+        if not hasattr(self, 'slug'):
+            if settings['SLUGIFY_SOURCE'] == 'title' and hasattr(self, 'title'):
+                self.slug = slugify(self.title,
+                                settings.get('SLUG_SUBSTITUTIONS', ()))
+            elif settings['SLUGIFY_SOURCE'] == 'basename' and source_path != None:
+                basename = os.path.basename(os.path.splitext(source_path)[0])
+                self.slug = slugify(basename,
                                 settings.get('SLUG_SUBSTITUTIONS', ()))
 
         self.source_path = source_path

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -116,6 +116,7 @@ DEFAULT_CONFIG = {
     'IGNORE_FILES': ['.#*'],
     'SLUG_SUBSTITUTIONS': (),
     'INTRASITE_LINK_REGEX': '[{|](?P<what>.*?)[|}]',
+    'SLUGIFY_SOURCE': 'title'
     }
 
 PYGMENTS_RST_OPTIONS = None

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -32,6 +32,7 @@ class TestPage(unittest.TestCase):
                 'title': 'foo bar',
                 'author': 'Blogger',
             },
+            'source_path': '/path/to/file/foo.ext'
         }
 
     def test_use_args(self):
@@ -77,9 +78,15 @@ class TestPage(unittest.TestCase):
         self.assertEqual(page.summary, '')
 
     def test_slug(self):
-        # If a title is given, it should be used to generate the slug.
-        page = Page(**self.page_kwargs)
+        page_kwargs = self._copy_page_kwargs()
+        settings = get_settings()
+        page_kwargs['settings'] = settings
+        settings['SLUGIFY_SOURCE'] = "title"
+        page = Page(**page_kwargs)
         self.assertEqual(page.slug, 'foo-bar')
+        settings['SLUGIFY_SOURCE'] = "basename"
+        page = Page(**page_kwargs)
+        self.assertEqual(page.slug, 'foo')
 
     def test_defaultlang(self):
         # If no lang is given, default to the default one.


### PR DESCRIPTION
This new setting allows slugs to be generated automatically from either the article title or basename.

I added documentation and I think I did it right, but I don't understand how to write the tests. Would somebody be able to give me a quick and dirty idea of what I should be testing for?
