### PR TITLE
add signal article_generator_pretaxonomy (was: split ArticlesGenerator.generate_context tags, categories functionality)

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -76,6 +76,9 @@ article_generator_context           article_generator, metadata
 article_generator_preread           article_generator              invoked before a article is read in ArticlesGenerator.generate_context;
                                                                    use if code needs to do something before every article is parsed
 article_generator_init              article_generator              invoked in the ArticlesGenerator.__init__
+article_generator_pretaxonomy       article_generator              invoked before categories and tags lists are created
+                                                                   useful when e.g. modifying the list of articles to be generated
+                                                                   so that removed articles are not leaked in categories or tags
 article_generator_finalized         article_generator              invoked at the end of ArticlesGenerator.generate_context
 article_generator_write_article     article_generator, content     invoked before writing each article, the article is passed as content
 article_writer_finalized            article_generator, writer      invoked after all articles and related pages have been written, but before

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -421,6 +421,8 @@ class ArticlesGenerator(Generator):
 
         self.articles, self.translations = process_translations(all_articles)
 
+        signals.article_generator_pretaxonomy.send(self)        
+
         for article in self.articles:
             # only main articles are listed in categories and tags
             # not translations

--- a/pelican/signals.py
+++ b/pelican/signals.py
@@ -17,6 +17,7 @@ readers_init = signal('readers_init')
 generator_init = signal('generator_init')
 
 article_generator_init = signal('article_generator_init')
+article_generator_pretaxonomy = signal('article_generator_pretaxonomy')
 article_generator_finalized = signal('article_generator_finalized')
 article_generator_write_article = signal('article_generator_write_article')
 article_writer_finalized = signal('article_writer_finalized')


### PR DESCRIPTION
the functionality is now in `_generate_aggregate_context`
This enables plugins (e.g. i18n_subsites) to reuse the code when
some articles are e.g. moved to drafts (e.g. HIDE_UNTRANSLATED_CONTENT)

The i18n_subsites comment is in PR state atm: https://github.com/getpelican/pelican-plugins/pull/139
