### PR TITLE
Added TYPOGRIFY_FILTERS as discussed in #980

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -135,6 +135,10 @@ Setting name (default value)                                                    
                                                                                  incorporated into the generated HTML via the `Typogrify
                                                                                  <https://pypi.python.org/pypi/typogrify-web>`_ library,
                                                                                  which can be installed via: ``pip install typogrify-web``
+`TYPOGRIFY_FILTERS` (``['typogrify']``)                                          List of Typogrify filterst to apply if ``TYPOGRIFY`` is set to ``True``.  
+                                                                                 Default is ``['typogrify']`` which applies all the filters. For example, 
+                                                                                 to disable the ``caps`` filter, you can set ``TYPOGRIFY_FILTERS = ['amp', 
+                                                                                 'initial_quotes', 'smartypants', 'titlecase', 'widont']``.  
 `DIRECT_TEMPLATES` (``('index', 'tags', 'categories', 'authors', 'archives')``)  List of templates that are used directly to render
                                                                                  content. Typically direct templates are used to generate
                                                                                  index pages for collections of content (e.g., tags and

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -458,10 +458,13 @@ class Readers(object):
             find_empty_alt(content, path)
 
         # eventually filter the content with typogrify if asked so
+
         if content and self.settings['TYPOGRIFY']:
-            from typogrify.filters import typogrify
-            content = typogrify(content)
-            metadata['title'] = typogrify(metadata['title'])
+            import typogrify.filters
+            for filter_name in self.settings['TYPOGRIFY_FILTERS']:
+                filter = getattr(typogrify.filters, filter_name)
+                content = filter(content)
+                metadata['title'] = filter(metadata['title'])
 
         if context_signal:
             logger.debug('signal {}.send({}, <metadata>)'.format(

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -112,6 +112,7 @@ DEFAULT_CONFIG = {
     'IGNORE_FILES': ['.#*'],
     'SLUG_SUBSTITUTIONS': (),
     'INTRASITE_LINK_REGEX': '[{|](?P<what>.*?)[|}]',
+    'TYPOGRIFY_FILTERS': ['typogrify'],
     }
 
 PYGMENTS_RST_OPTIONS = None


### PR DESCRIPTION
TYPOGRIFY_FILTERS allows users to specify which typogrify filters to are be applied. This was discussed as a solution to #980, to prevent typogrify from corrupting MathJax output.