### PR TITLE
Add support for ISSO (http://posativ.org/isso/) comment system.

### DIFF
--- a/pelican/themes/notmyidea/templates/article.html
+++ b/pelican/themes/notmyidea/templates/article.html
@@ -14,20 +14,25 @@
       {% include 'article_infos.html' %}
       {{ article.content }}
     </div><!-- /.entry-content -->
-    {% if DISQUS_SITENAME and SITEURL and article.status != "draft" %}
+    {% if SITEURL and article.status != "draft" %}
     <div class="comments">
       <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = '{{ DISQUS_SITENAME }}';
-        var disqus_identifier = '{{ article.url }}';
-        var disqus_url = '{{ SITEURL }}/{{ article.url }}';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
+      {% if ISSO_SITEURL %}
+        <section id="isso-thread"></section>
+      {% endif %}
+      {% if DISQUS_SITENAME %}
+        <div id="disqus_thread"></div>
+        <script type="text/javascript">
+          var disqus_shortname = '{{ DISQUS_SITENAME }}';
+          var disqus_identifier = '{{ article.url }}';
+          var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+          (function() {
+          var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+          dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+          (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+          })();
+        </script>
+      {% endif %}
       <noscript>Please enable JavaScript to view the comments.</noscript>
     </div>
     {% endif %}

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -79,5 +79,6 @@
 {% include 'analytics.html' %}
 {% include 'piwik.html' %}
 {% include 'disqus_script.html' %}
+{% include 'isso_script.html' %}
 </body>
 </html>

--- a/pelican/themes/notmyidea/templates/comments.html
+++ b/pelican/themes/notmyidea/templates/comments.html
@@ -1,1 +1,4 @@
-{% if DISQUS_SITENAME %}<p>There are <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">comments</a>.</p>{% endif %}
+{% if SITEURL %}<p>There are 
+  {% if DISQUS_SITENAME %}<a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">{% endif %}
+  {% if ISSO_SITEURL %}<a href="{{ SITEURL }}/{{ article.url }}#isso-thread">{% endif %}
+Comments</a>.</p>{% endif %}

--- a/pelican/themes/notmyidea/templates/isso_script.html
+++ b/pelican/themes/notmyidea/templates/isso_script.html
@@ -1,0 +1,4 @@
+{% if ISSO_SITEURL %}
+<script data-isso="{{ ISSO_SITEURL }}/"
+        src="{{ ISSO_SITEURL }}/js/embed.min.js"></script>
+{% endif %}


### PR DESCRIPTION
Hi,

this commit adds support for self-hosted ISSO comment system to have an alternative to the Disqus. The code is quite simple (it adds ISSO_SITEURL config variable) and it already runs on deb.sury.org.

Thanks for considering this pull request.

O.