### PR TITLE
Run tag names through escape filter to avoid invalid HTML

### DIFF
--- a/pelican/themes/notmyidea/templates/taglist.html
+++ b/pelican/themes/notmyidea/templates/taglist.html
@@ -1,2 +1,2 @@
-{% if article.tags %}<p>tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a> {% endfor %}</p>{% endif %}
+{% if article.tags %}<p>tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag | escape }}</a> {% endfor %}</p>{% endif %}
 {% if PDF_PROCESSOR %}<p><a href="{{ SITEURL }}/pdf/{{ article.slug }}.pdf">get the pdf</a></p>{% endif %}


### PR DESCRIPTION
If a tag contains characters like <> or &, we currently generate invalid HTML. 
This is easily fixed by sending the tag through the jinja escape filter.

(This bug is not theoretical, I hit it when using C++ template names for tags,
like "boost::variant<>".)
