### PR TITLE
Split multiple authors on ',' instead of every character

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -46,7 +46,7 @@ METADATA_PROCESSORS = {
     'status': lambda x, y: x.strip(),
     'category': Category,
     'author': Author,
-    'authors': lambda x, y: [Author(author, y) for author in x],
+    'authors': lambda x, y: [Author(author.strip(), y) for author in x.split(',')],
 }
 
 logger = logging.getLogger(__name__)

--- a/pelican/tests/content/article_with_multiple_authors.html
+++ b/pelican/tests/content/article_with_multiple_authors.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <title>This is an article with multiple authors!</title>
+        <meta name="authors" content="First Author, Second Author" />
+    </head>
+</html>

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -361,7 +361,7 @@ class HTMLReaderTest(ReaderTest):
             self.assertEqual(value, page.metadata[key], key)
 
     def test_article_with_multiple_authors(self):
-        page = self.read_file(path='article_with_multiple_authors.rst')
+        page = self.read_file(path='article_with_multiple_authors.html')
         expected = {
             'authors': ['First Author', 'Second Author']
         }


### PR DESCRIPTION
The authors-tag splits every word in characters, but it should split on ',', like tags do.

I also updated the tests to use a html-file for the html-test.

Remarks:
- I can't get the tests to fail with the old code.
- I added a .strip() for authors. This should probably also be used for tags.
