### PR TITLE
Remove spurious warnings when *_SAVE_AS = False

### DIFF
--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -1,12 +1,9 @@
 import os
 import functools
-import logging
 
 import six
 
 from pelican.utils import (slugify, python_2_unicode_compatible)
-
-logger = logging.getLogger(__name__)
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
When `{AUTHOR,CATEGORY,TAG...}_SAVE_AS` is set to False in pelicanconf.py, pelican warns the user about it when generating those pages, e.g.

```
WARNING: AUTHOR_SAVE_AS is set to False
```

This issue has already been raised in #744.

AFAICT, the various `*_SAVE_AS` settings all have a default value assigned to them that's not "False", so I've simply just removed the code that was generating these warnings.
