### PR TITLE
Apply typogrify on article summary as well

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -462,10 +462,13 @@ class Readers(object):
             find_empty_alt(content, path)
 
         # eventually filter the content with typogrify if asked so
-        if content and self.settings['TYPOGRIFY']:
+        if self.settings['TYPOGRIFY']:
             from typogrify.filters import typogrify
-            content = typogrify(content)
-            metadata['title'] = typogrify(metadata['title'])
+            if content:
+                content = typogrify(content)
+                metadata['title'] = typogrify(metadata['title'])
+            if 'summary' in metadata:
+                metadata['summary'] = typogrify(metadata['summary'])
 
         if context_signal:
             logger.debug('signal {}.send({}, <metadata>)'.format(

--- a/pelican/tests/content/article_with_metadata.rst
+++ b/pelican/tests/content/article_with_metadata.rst
@@ -9,5 +9,5 @@ This is a super article !
 :author: Alexis Métaireau
 :summary:
     Multi-line metadata should be supported
-    as well as **inline markup**.
+    as well as **inline markup** and stuff to "typogrify"...
 :custom_field: http://notmyidea.org

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -40,7 +40,8 @@ class RstReaderTest(ReaderTest):
             'title': 'This is a super article !',
             'summary': '<p class="first last">Multi-line metadata should be'
                        ' supported\nas well as <strong>inline'
-                       ' markup</strong>.</p>\n',
+                       ' markup</strong> and stuff to &quot;typogrify'
+                       '&quot;...</p>\n',
             'date': datetime.datetime(2010, 12, 2, 10, 14),
             'modified': datetime.datetime(2010, 12, 2, 10, 20),
             'tags': ['foo', 'bar', 'foobar'],
@@ -122,6 +123,30 @@ class RstReaderTest(ReaderTest):
                 'acronym"><span class="caps">TLA</span></abbr>.</p>\n')
 
             self.assertEqual(page.content, expected)
+        except ImportError:
+            return unittest.skip('need the typogrify distribution')
+
+    def test_typogrify_summary(self):
+        # if nothing is specified in the settings, the summary should be
+        # unmodified
+        page = self.read_file(path='article_with_metadata.rst')
+        expected = ('<p class="first last">Multi-line metadata should be'
+                    ' supported\nas well as <strong>inline'
+                    ' markup</strong> and stuff to &quot;typogrify'
+                    '&quot;...</p>\n')
+
+        self.assertEqual(page.metadata['summary'], expected)
+
+        try:
+            # otherwise, typogrify should be applied
+            page = self.read_file(path='article_with_metadata.rst',
+                                  TYPOGRIFY=True)
+            expected = ('<p class="first last">Multi-line metadata should be'
+                        ' supported\nas well as <strong>inline'
+                        ' markup</strong> and stuff to&nbsp;&quot;typogrify'
+                        '&quot;&#8230;</p>\n')
+
+            self.assertEqual(page.metadata['summary'], expected)
         except ImportError:
             return unittest.skip('need the typogrify distribution')
 


### PR DESCRIPTION
If `typogrify` is enabled, it seems decent to apply it to the summary as well, so that we can easily use quotes and such. The test `test_typogrify_summary` check this behavior, independently from the content typogrify-ing.
