### PR TITLE
change the inhibition value of *_SAVE_AS to ''

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -269,9 +269,9 @@ Setting name (default value)                            What does it do?
 `TAG_SAVE_AS` (``'tag/{slug}.html'``)                   The location to save the tag page.
 `AUTHOR_URL` (``'author/{slug}.html'``)                 The URL to use for an author.
 `AUTHOR_SAVE_AS` (``'author/{slug}.html'``)             The location to save an author.
-`YEAR_ARCHIVE_SAVE_AS` (False)                          The location to save per-year archives of your posts.
-`MONTH_ARCHIVE_SAVE_AS` (False)                         The location to save per-month archives of your posts.
-`DAY_ARCHIVE_SAVE_AS` (False)                           The location to save per-day archives of your posts.
+`YEAR_ARCHIVE_SAVE_AS` (``''``)                         The location to save per-year archives of your posts.
+`MONTH_ARCHIVE_SAVE_AS` (``''``)                        The location to save per-month archives of your posts.
+`DAY_ARCHIVE_SAVE_AS` (``''``)                          The location to save per-day archives of your posts.
 `SLUG_SUBSTITUTIONS`  (``()``)                          Substitutions to make prior to stripping out
                                                         non-alphanumerics when generating slugs. Specified
                                                         as a list of 2-tuples of ``(from, to)`` which are
@@ -282,7 +282,7 @@ Setting name (default value)                            What does it do?
 
     If you do not want one or more of the default pages to be created (e.g.,
     you are the only author on your site and thus do not need an Authors page),
-    set the corresponding ``*_SAVE_AS`` setting to ``None`` to prevent the
+    set the corresponding ``*_SAVE_AS`` setting to ``''`` to prevent the
     relevant page from being generated.
 
 `DIRECT_TEMPLATES`

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -81,9 +81,9 @@ DEFAULT_CONFIG = {
     'PAGINATION_PATTERNS': [
         (0, '{name}{number}{extension}', '{name}{number}{extension}'),
     ],
-    'YEAR_ARCHIVE_SAVE_AS': False,
-    'MONTH_ARCHIVE_SAVE_AS': False,
-    'DAY_ARCHIVE_SAVE_AS': False,
+    'YEAR_ARCHIVE_SAVE_AS': '',
+    'MONTH_ARCHIVE_SAVE_AS': '',
+    'DAY_ARCHIVE_SAVE_AS': '',
     'RELATIVE_URLS': False,
     'DEFAULT_LANG': 'en',
     'TAG_CLOUD_STEPS': 4,

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -140,7 +140,7 @@ class Writer(object):
         :param **kwargs: additional variables to pass to the templates
         """
 
-        if name is False:
+        if name is False or name == "":
             return
         elif not name:
             # other stuff, just return for now


### PR DESCRIPTION
Previously, the documentation claimed the value of None for this purpose
even though False was used for certain defaults. The values False and
None cause warnings to be emitted from URLWrapper._from_settings though,
so the new way of inhibiting page generation is to set a *_SAVE_AS value
to the empty string.

Note: I am submitting this on the behalf of helmut who can be found on IRC with that name.
