### PR TITLE
Fixing github ribbon bug--issue #1273

### DIFF
--- a/pelican/tests/output/basic/theme/css/main.css
+++ b/pelican/tests/output/basic/theme/css/main.css
@@ -449,3 +449,8 @@ li:last-child .hentry, #content > .hentry {border: 0; margin: 0;}
 	
 	#add-comment input[type='submit'] {float: right; margin: 0 .5em;}
 	#add-comment * {margin-bottom: .5em;}
+/*Fix github ribbon*/
+@media screen and (max-width: 768px){
+	img{
+		width: auto !important;
+	}


### PR DESCRIPTION
Hey!  I found that when the screen was less than 768px wide, the github ribbon had 100% width and covered lots of text--this should fix that problem!  Let me know if you need anything to be different.
