### PR TITLE
Fix error in download_attachments() triggered by python2 unit test

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -603,8 +603,18 @@ def download_attachments(output_path, urls):
                     .format(url, e))
             logger.warning(error)
         except IOError as e: #Python 2.7 throws an IOError rather Than URLError
-            error = ("No file could be downloaded from {}; Error {}"
-                    .format(url, e))
+            # For japanese, the error might look kind of like this:
+            # e = IOError( 'socket error', socket.error(111, u'\u63a5\u7d9a\u3092\u62d2\u5426\u3055\u308c\u307e\u3057\u305f') )
+            # and not be suitable to use in "{}".format(e) , raising UnicodeDecodeError
+            # (This is at least the case on my Fedora running Python 2.7.5 
+            # (default, Feb 19 2014, 13:47:28) [GCC 4.8.2 20131212 (Red Hat 4.8.2-7)] on linux2
+            try:
+                error = ("No file could be downloaded from {}; Error {}"
+                        .format(url, e))
+            except UnicodeDecodeError:
+                # For lack of a better log message because we could not decode e, let's use repr(e)
+                error = ("No file could be downloaded from {}; Error {}"
+                        .format(url, repr(e)))
             logger.warning(error)
     return locations
 


### PR DESCRIPTION
The download_attachments error is triggered in the unit tests by a japanese
error message (接続を拒否されました) (connexion denied), that
python is not able to serialize the into a byte string.

This error weirdly does not appear every time the unit tests are run.
It might be related to the order in which the tests are run.

This error was found and fixed during the PyconUS 2014 pelican
sprint. It was discovered on a Linux Fedora20 computer running
Python2.7 in virtualenv
