### PR TITLE
Handle multi-line meta in markdown content properly

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -204,12 +204,18 @@ class MarkdownReader(BaseReader):
         for name, value in meta.items():
             name = name.lower()
             if name == "summary":
+                # handle summary metadata as markdown
+                # summary metadata is special case and join all list values
                 summary_values = "\n".join(value)
                 # reset the markdown instance to clear any state
                 self._md.reset()
                 summary = self._md.convert(summary_values)
                 output[name] = self.process_metadata(name, summary)
+            elif len(value) > 1:
+                # handle list metadata as list of string
+                output[name] = self.process_metadata(name, value)
             else:
+                # otherwise, handle metadata as single string
                 output[name] = self.process_metadata(name, value[0])
         return output
 

--- a/pelican/tests/content/article_with_markdown_and_footnote.md
+++ b/pelican/tests/content/article_with_markdown_and_footnote.md
@@ -2,6 +2,12 @@ Title: Article with markdown containing footnotes
 Date: 2012-10-31
 Modified: 2012-11-01
 Summary: Summary with **inline** markup *should* be supported.
+Multiline: Line Metadata should be handle properly.
+    See syntax of Meta-Data extension of Python Markdown package:
+    If a line is indented by 4 or more spaces,
+    that line is assumed to be an additional line of the value
+    for the previous keyword.
+    A keyword may have as many lines as desired.
 
 This is some content[^1] with some footnotes[^footnote]
 

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -214,6 +214,14 @@ class MdReaderTest(ReaderTest):
             'date': datetime.datetime(2012, 10, 31),
             'modified': datetime.datetime(2012, 11, 1),
             'slug': 'article-with-markdown-containing-footnotes',
+            'multiline': [
+                'Line Metadata should be handle properly.',
+                'See syntax of Meta-Data extension of Python Markdown package:',
+                'If a line is indented by 4 or more spaces,',
+                'that line is assumed to be an additional line of the value',
+                'for the previous keyword.',
+                'A keyword may have as many lines as desired.',
+            ]
         }
         self.assertEqual(content, expected_content)
         for key, value in metadata.items():


### PR DESCRIPTION
Pelican should handle multi-line meta in markdown content properly.
It was handling first line only (except summary).

Here is corresponding document:
http://pythonhosted.org/Markdown/extensions/meta_data.html#syntax

> If a line is indented by 4 or more spaces, that line is assumed to be an additional line of the value for the previous keyword. A keyword may have as many lines as desired.
