### PR TITLE
Reader name now accessible for articles and pages

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -440,6 +440,8 @@ class Readers(FileStampDataCacher):
         metadata.update(parse_path_metadata(
             source_path=source_path, settings=self.settings,
             process=reader.process_metadata))
+        reader_name = reader.__class__.__name__
+        metadata['reader'] = reader_name.replace('Reader', '').lower()
 
         content, reader_metadata = self.get_cached_data(path, (None, None))
         if content is None:

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -59,6 +59,7 @@ class RstReaderTest(ReaderTest):
             'category': 'yeah',
             'author': 'Alexis Métaireau',
             'title': 'Rst with filename metadata',
+            'reader': 'rst',
         }
         for key, value in page.metadata.items():
             self.assertEqual(value, expected[key], key)
@@ -71,6 +72,7 @@ class RstReaderTest(ReaderTest):
             'author': 'Alexis Métaireau',
             'title': 'Rst with filename metadata',
             'date': SafeDatetime(2012, 11, 29),
+            'reader': 'rst',
         }
         for key, value in page.metadata.items():
             self.assertEqual(value, expected[key], key)
@@ -88,6 +90,7 @@ class RstReaderTest(ReaderTest):
             'date': SafeDatetime(2012, 11, 29),
             'slug': 'article_with_filename_metadata',
             'mymeta': 'foo',
+            'reader': 'rst',
         }
         for key, value in page.metadata.items():
             self.assertEqual(value, expected[key], key)


### PR DESCRIPTION
I added an extra metadata field that allows you to access the name of the reader currently used in articles and pages. This is convenient when you want to include/exclude certain format-dependent css/js depending on the format of the page/article. Some extra restructured text css comes to mind.

I didn't know where to put this in the documentation. Any pointers would be welcome :)

All tests are working. I did notice some inconsistencies in the `test_readers.py` though:
Some of the tests (like `RstReaderTest`) read and parse a file like this `page = self.read_file(path='article_with_metadata.rst')`, which in turn uses the `Readers` interface to access the reader, like this:

``` python
def read_file(self, path, **kwargs):
        # Isolate from future API changes to readers.read_file
        r = readers.Readers(settings=get_settings(**kwargs))
        return r.read_file(base_path=CONTENT_PATH, path=path)
```

Some other tests (like `MdReaderTest`) access the reader directly, like this:
`reader = readers.MarkdownReader(settings=get_settings())`

Because the reader name gets added in the `Readers` class, it's not accessible in the `MdReaderTest`. Maybe all Reader tests should use the `self.read_file` method?
