### PR TITLE
pelican should also parse the summary for {filename}

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -278,7 +278,8 @@ class Content(object):
         content.
         """
         if hasattr(self, '_summary'):
-            return self._summary
+            return self._update_content(self._summary,
+                                        self._context.get('localsiteurl', ''))
 
         if self.settings['SUMMARY_MAX_LENGTH'] is None:
             return self.content

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -287,6 +287,19 @@ class TestPage(unittest.TestCase):
             '?utm_whatever=234&highlight=word#section-2">link</a>'
         )
 
+        # also test for summary in metadata
+        args['metadata']['summary'] = (
+            'A simple summary test, with a '
+            '<a href="|filename|article.rst">link</a>'
+        )
+        args['context']['localsiteurl'] = 'http://notmyidea.org'
+        p = Page(**args)
+        self.assertEqual(
+            p.summary,
+            'A simple summary test, with a '
+            '<a href="http://notmyidea.org/article.html">link</a>'
+        )
+
     def test_intrasite_link_more(self):
         # type does not take unicode in PY2 and bytes in PY3, which in
         # combination with unicode literals leads to following insane line:


### PR DESCRIPTION
Pelican does not parse the summary of an article for replacing the local links with the {filename} syntax.

if the article start with :

```rst

Title
-----

:summary: I want to link a previous_ article

.. _article: {filename}my_previous_post.rst

Lorem ipsum dolor…

```

Then the interlink will not be processed and interpreted. A broken link will be inserted if I try to display this summary on the articles page.

Correction : in contents.py call the _update_content method when loading the summary :

```python
    def _get_summary(self):
        """Returns the summary of an article.

        This is based on the summary metadata if set, otherwise truncate the
        content.
        """
        if hasattr(self, '_summary'):
            return self._update_content(self._summary, self._context.get('localsiteurl', ''))
            …

```