### PR TITLE
fix UnicodeDecodeError chinese-char in Tags

### DIFF
--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -68,7 +68,7 @@ class URLWrapper(object):
 
         """
         setting = "%s_%s" % (self.__class__.__name__.upper(), key)
-        value = self.settings[setting]
+        value = unicode(self.settings[setting])
         if not isinstance(value, six.string_types):
             logger.warning('%s is set to %s' % (setting, value))
             return value


### PR DESCRIPTION
Found this bug in post-3.1 version, it fails build my blog every time. I'm using Python 2.7
