### PR TITLE
Fix #1223 PAGINATION_PATTERNS doc example

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -548,13 +548,13 @@ second (and subsequent) pages to be ``/page/2/``, you would set
 ``PAGINATION_PATTERNS`` as follows::
 
   PAGINATION_PATTERNS = (
-      (1, '{base_name}/', '{base_name}/index.html'),
-      (2, '{base_name}/page/{number}/', '{base_name}/page/{number}/index.html'),
+      (1, '{name}/', '{name}/index.html'),
+      (2, '{name}/page/{number}/', '{name}/page/{number}/index.html'),
   )
 
 This would cause the first page to be written to
-``{base_name}/index.html``, and subsequent ones would be written into
-``page/{number}`` directories.
+``{name}/index.html``, and subsequent ones would be written into
+``{name}/page/{number}`` directories.
 
 Tag cloud
 =========


### PR DESCRIPTION
The documentation example is using `{base_name}` instead of `{name}` for `PAGINATION_PATTERNS` setting.

This makes some tags/categories/etc collapse into each other, with in turn trigger the “no overwrite” feature. See bug #1223 for more information.
