### PR TITLE
Change type of OUTPUT_RETENTION from tuple to list.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -76,9 +76,9 @@ Setting name (followed by default value, if any)                                
                                                                                  generating new files. This can be useful in preventing older,
                                                                                  unnecessary files from persisting in your output. However, **this is
                                                                                  a destructive setting and should be handled with extreme care.**
-``OUTPUT_RETENTION = ()``                                                        A tuple of filenames that should be retained and not deleted from the
+``OUTPUT_RETENTION = []``                                                        A list of filenames that should be retained and not deleted from the
                                                                                  output directory. One use case would be the preservation of version
-                                                                                 control data. For example: ``(".hg", ".git", ".bzr")``
+                                                                                 control data. For example: ``[".hg", ".git", ".bzr"]``
 ``JINJA_EXTENSIONS = []``                                                        A list of any Jinja2 extensions you want to use.
 ``JINJA_FILTERS = {}``                                                           A list of custom Jinja2 filters you want to use.
                                                                                  The dictionary should map the filtername to the filter function.


### PR DESCRIPTION
Currently, the `OUTPUT_RETENTION` setting is described in the documentation as being a tuple. However, it seems realistic to accidentally define the setting as `OUTPUT_RETENTION = ('.git')` instead of `OUTPUT_RETENTION = ('.git',)`, which is a string rather than a tuple. The [relevant code](https://github.com/getpelican/pelican/blob/master/pelican/utils.py#L295) would then fail to retain the file/directory.

Since the `DELETE_OUTPUT_DIRECTORY` setting is destructive, it seems to be a safer option to define the setting as a list rather than a tuple to prevent this mistake from happening.

(Or would it be better to catch and correct this in the code itself?)