### PR TITLE
Prepend siteurl (or relative_url) to {tag} and {category} links

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -244,9 +244,10 @@ class Content(object):
                                     "Other resources were not found"
                                     " and their urls not replaced"))
             elif what == 'category':
-                origin = Category(path, self.settings).url
+                origin = '/'.join((siteurl,
+                                   Category(path, self.settings).url))
             elif what == 'tag':
-                origin = Tag(path, self.settings).url
+                origin = '/'.join((siteurl, Tag(path, self.settings).url))
 
             # keep all other parts, such as query, fragment, etc.
             parts = list(value)

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -212,17 +212,33 @@ class TestPage(unittest.TestCase):
                            '<a href="|tag|tagname">link</a>')
         page = Page(**args)
         content = page.get_content('http://notmyidea.org')
-        self.assertEqual(content, ('A simple test, with a '
-                                   '<a href="tag/tagname.html">link</a>'))
+        self.assertEqual(
+            content,
+            'A simple test, with a '
+            '<a href="http://notmyidea.org/tag/tagname.html">link</a>'
+        )
 
         # Category
         args['content'] = ('A simple test, with a '
                            '<a href="|category|category">link</a>')
         page = Page(**args)
         content = page.get_content('http://notmyidea.org')
-        self.assertEqual(content,
-                         ('A simple test, with a '
-                          '<a href="category/category.html">link</a>'))
+        self.assertEqual(
+            content,
+            'A simple test, with a '
+            '<a href="http://notmyidea.org/category/category.html">link</a>'
+        )
+
+        # relative_url
+        args['content'] = ('A simple test, with a '
+                           '<a href="|category|category">link</a>')
+        page = Page(**args)
+        content = page.get_content('../../..')
+        self.assertEqual(
+            content,
+            'A simple test, with a '
+            '<a href="../../../category/category.html">link</a>'
+        )
 
     def test_intrasite_link(self):
         # type does not take unicode in PY2 and bytes in PY3, which in


### PR DESCRIPTION
I _think_, though am not sure, that the [unit tests](https://github.com/danielrichman/pelican/compare/cateogry_tag_siteurls?expand=1#diff-a6e75eddaf0b1d483ecdfcac11dad813L215) for `{tag}`/`|tag|`/etc. links are testing incorrect behaviour.

This patch puts site-url in front of intra-site links to tags or categories.
