### PR TITLE
Fixes #1382

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -120,6 +120,8 @@ class Generator(object):
             extensions are allowed)
         """
         files = []
+        if type(paths) == type(''):
+            paths = [paths]
         for path in paths:
             root = os.path.join(self.path, path)
 


### PR DESCRIPTION
A quick test to determine if the incoming path is a simple string, and
if so convert to a single item list with said string. This ensures older
configs will work as they did prior to the multiple paths commit. If the
old behavior is deprecated, I would suggest documenting it as such and
perhaps adding a deprecation warning here.
