### PR TITLE
allows pelican-themes symlink command to use relative paths not beginnin...

### DIFF
--- a/pelican/tests/TestTheme/theme/a.html
+++ b/pelican/tests/TestTheme/theme/a.html
@@ -1,0 +1,1 @@
+this is a test

--- a/pelican/tests/test_pelican_themes.py
+++ b/pelican/tests/test_pelican_themes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
+
+import os
+
+from pelican.tools.pelican_themes import symlink, _THEMES_PATH
+from pelican.tests.support import LoggedTestCase
+
+CURRENT_DIR_REL = os.path.dirname(__file__)
+THEME_TARGET_PATH = os.path.join(_THEMES_PATH, "theme")
+
+class TestPelicanThemes(LoggedTestCase):
+    # testing for pelican-themes commands. 
+
+    def setUp(self):
+        super(TestPelicanThemes, self).setUp()
+
+    def tearDown(self):
+        super(TestPelicanThemes, self).tearDown()
+        os.remove(THEME_TARGET_PATH)
+
+    def test_symlink_relative(self):
+        symlink(os.path.join(CURRENT_DIR_REL, "TestTheme/theme/"))
+        self.assertTrue(os.path.exists(THEME_TARGET_PATH))

--- a/pelican/tools/pelican_themes.py
+++ b/pelican/tools/pelican_themes.py
@@ -214,7 +214,7 @@ def symlink(path, v=False):
             if v:
                 print("Linking `{p}' to `{t}' ...".format(p=path, t=theme_path))
             try:
-                os.symlink(path, theme_path)
+                os.symlink(os.path.abspath(path), theme_path)
             except Exception as e:
                 err("Cannot link `{p}' to `{t}':\n{e}".format(p=path, t=theme_path, e=str(e)))
 


### PR DESCRIPTION
...g with a dot

pelican-themes -s <dir-name> creates a broken symlink when the <dir-name> is a relative path - i.e. vendor/themes/clear-theme. Afterwards the theme does not show up with pelican-themes -l. Notice that the -i or install command does allow for relative paths.

This change makes sure that the symlink command makes a correct symlink. A test file has also been added for pelican-themes.
