### PR TITLE
Warn that signal receivers are weakly-referenced

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -57,6 +57,12 @@ which you map the signals to your plugin logic. Let's take a simple example::
     def register():
         signals.initialized.connect(test)
 
+.. note::
+
+    Signal receivers are weakly-referenced, thus, they must not be defined
+    within your ``register`` callable or they will be garbage-collected before
+    the signal is emitted.
+
 List of signals
 ===============
 


### PR DESCRIPTION
For the signal get_generators in particular, it may seem natural to use a lambda or inner function as the signal receiver, but this does not work as the receiver is collected before it can be called.
