### PR TITLE
Fix "server didn't start" error message in develop_server.sh

### DIFF
--- a/pelican/tools/templates/develop_server.sh.in
+++ b/pelican/tools/templates/develop_server.sh.in
@@ -75,7 +75,7 @@ function start_up(){
     echo "Pelican didn't start. Is the Pelican package installed?"
     return 1
   elif ! alive $$srv_pid ; then
-    echo "The HTTP server didn't start. Is there another service using port 8000?"
+    echo "The HTTP server didn't start. Is there another service using port" $$port "?"
     return 1
   fi
   echo 'Pelican and HTTP server processes now running in background.'


### PR DESCRIPTION
It has port 8000 hardcoded into it, which is confusing when the server runs on
another port.
