### PR TITLE
Basic import from Blogger export

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -699,9 +699,9 @@ def fields2pelican(fields, out_markup, output_path,
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Transform feed, WordPress, Tumblr, Dotclear, or Posterous "
-                    "files into reST (rst) or Markdown (md) files. Be sure to "
-                    "have pandoc installed.",
+        description="Transform feed, WordPress, Tumblr, Dotclear, Posterous, "
+                    "or Blogger files into reST (rst) or Markdown (md) files. "
+                    "Be sure to have pandoc installed.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument(dest='input', help='The input file to read')
@@ -715,6 +715,8 @@ def main():
         help='Tumblr export')
     parser.add_argument('--feed', action='store_true', dest='feed',
         help='Feed to parse')
+    parser.add_argument('--blogger', action='store_true', dest='blogger',
+        help='Blogger export')
     parser.add_argument('-o', '--output', dest='output', default='output',
         help='Output path')
     parser.add_argument('-m', '--markup', dest='markup', default='rst',
@@ -767,8 +769,10 @@ def main():
         input_type = 'tumblr'
     elif args.feed:
         input_type = 'feed'
+    elif args.blogger:
+        input_type = 'blogger'
     else:
-        error = "You must provide either --wpfile, --dotclear, --posterous, --tumblr or --feed options"
+        error = "You must provide either --wpfile, --dotclear, --posterous, --tumblr, --feed or --blogger options"
         exit(error)
 
     if not os.path.exists(args.output):
@@ -791,6 +795,8 @@ def main():
     elif input_type == 'tumblr':
         fields = tumblr2fields(args.input, args.blogname)
     elif input_type == 'feed':
+        fields = feed2fields(args.input)
+    elif input_type == 'blogger':
         fields = feed2fields(args.input)
 
     if args.wp_attach:


### PR DESCRIPTION
It's possible to export an entire Blogger blog into a single Atom XML. 

The 'feed' importer does a pretty good job at this, but it gets a few things wrong:

* comments & settings show up as posts
* slug doesn't match the blogger slug
* it encodes the 'kind' as just another tag
* it doesn't identify pages

This importer addresses those issues.

It doesn't try to clean up Blogger's (usually awful) HTML. 

I had the best results running it with `--wp-custpost` (to separate out settings, templates, and comments) and `--dir-page`, like this:

    pelican-import --blogger -m markdown -o $OUTPUT_DIR --wp-custpost --dir-page blog-08-29-2013.xml

At least on my blog, the generated rST is useless.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/getpelican/pelican/1390)
<!-- Reviewable:end -->
