### PR TITLE
Support last page pattern in PAGINATION_PATTERNS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1067,6 +1067,11 @@ as follows::
   )
 
 
+If you want a pattern to apply to the last page in the list, use ``-1``
+as the ``minimum_page`` value::
+
+    (-1, '{base_name}/last/', '{base_name}/last/index.html'),
+
 Translations
 ============
 

--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -118,8 +118,13 @@ class Page:
 
         # find the last matching pagination rule
         for p in self.settings['PAGINATION_PATTERNS']:
-            if p.min_page <= self.number:
-                rule = p
+            if p.min_page == -1:
+                if not self.has_next():
+                    rule = p
+                    break
+            else:
+                if p.min_page <= self.number:
+                    rule = p
 
         if not rule:
             return ''

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -76,3 +76,29 @@ class TestPage(unittest.TestCase):
         page2 = paginator.page(2)
         self.assertEqual(page2.save_as, 'blog/2/index.html')
         self.assertEqual(page2.url, '//blog.my.site/2/')
+
+    def test_custom_pagination_pattern_last_page(self):
+        from pelican.paginator import PaginationRule
+        settings = get_settings()
+        settings['PAGINATION_PATTERNS'] = [PaginationRule(*r) for r in [
+            (1, '/{url}1/', '{base_name}/1/index.html'),
+            (2, '/{url}{number}/', '{base_name}/{number}/index.html'),
+            (-1, '/{url}', '{base_name}/index.html'),
+        ]]
+
+        self.page_kwargs['metadata']['author'] = Author('Blogger', settings)
+        object_list = [Article(**self.page_kwargs),
+                       Article(**self.page_kwargs),
+                       Article(**self.page_kwargs)]
+        paginator = Paginator('blog/index.html', '//blog.my.site/',
+                              object_list, settings, 1)
+        # The URL *has to* stay absolute (with // in the front), so verify that
+        page1 = paginator.page(1)
+        self.assertEqual(page1.save_as, 'blog/1/index.html')
+        self.assertEqual(page1.url, '//blog.my.site/1/')
+        page2 = paginator.page(2)
+        self.assertEqual(page2.save_as, 'blog/2/index.html')
+        self.assertEqual(page2.url, '//blog.my.site/2/')
+        page3 = paginator.page(3)
+        self.assertEqual(page3.save_as, 'blog/index.html')
+        self.assertEqual(page3.url, '//blog.my.site/')


### PR DESCRIPTION
I want to be able to specify the URL pattern for the last page using `-1` as identifier like this: `(-1, '{base_name}/last/', '{base_name}/last/index.html')`. Currently, only special handling of the first page is possible.

Here’s the background for this feature request.

I want the page numbers to go in the different direction, so that page 1 would always contain the same set of articles: the oldest ones. The same applies to other pages as well: their content will not change over time. The original version of the PR was calling it **fixed pagination** or **static pagination**. Among other things this is good for SEO. I implemented that in my current weblog: https://blog.arty.name/. The current default on pelican and most websites on the internet is the opposite: the items on a page could be pushed to another page over time, and it is unfortunate.

Having `ARTICLE_ORDER_BY = 'date'` and `NEWEST_FIRST_ARCHIVES = True` I could use `object_list[::-1]` in `index.html` and `tag.html` of my theme to almost reach my goal. With this PR merged I can do the following: 

```python
PAGINATION_PATTERNS = (
    (1, '{base_name}/page-1/', '{base_name}/page-1/index.html'),
    (2, '{base_name}/page-{number}/', '{base_name}/page-{number}/index.html'),
    (-1, '{base_name}/', '{base_name}/index.html'),
)
```

