### PR TITLE
Add feed_written signal

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -101,6 +101,7 @@ static_generator_init               static_generator               invoked in th
 static_generator_finalized          static_generator               invoked at the end of StaticGenerator.generate_context
 content_object_init                 content_object                 invoked at the end of Content.__init__ (see note below)
 content_written                     path, context                  invoked each time a content file is written.
+feed_written                        path, context, feed            invoked each time a feed file is written.
 =================================   ============================   ===========================================================================
 
 The list is currently small, so don't hesitate to add signals and make a pull

--- a/pelican/signals.py
+++ b/pelican/signals.py
@@ -44,3 +44,4 @@ content_object_init = signal('content_object_init')
 
 # Writers signals
 content_written = signal('content_written')
+feed_written = signal('feed_written')

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -121,6 +121,8 @@ class Writer(object):
                 with self._open_w(complete_path, encoding) as fp:
                     feed.write(fp, 'utf-8')
                     logger.info('Writing %s', complete_path)
+
+                signals.feed_written.send(complete_path, context=context, feed=feed)
             return feed
         finally:
             locale.setlocale(locale.LC_ALL, old_locale)


### PR DESCRIPTION
Current set of signals does not allow plugins to work with feeds. I want to add a feed_written signal which is triggered every time a feed file is written, similarly to content_written.

This change will enable touch plugin to set proper timestamp to feed files too (getpelican/pelican-plugins#241)
