### PR TITLE
Allows Typogrify to ignore user specified tags. Refs #1407

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -147,6 +147,9 @@ Setting name (followed by default value, if any)                                
                                                                                  incorporated into the generated HTML via the `Typogrify
                                                                                  <https://pypi.python.org/pypi/typogrify>`_ library,
                                                                                  which can be installed via: ``pip install typogrify``
+``TYPOGRIFY_IGNORE_TAGS = []``                                                   A list of tags for Typogrify to ignore. By default
+                                                                                 Typogrify will ignore ``pre`` and ``code`` tags. This
+                                                                                 requires that Typogrify version 2.0.4 or later is installed
 ``DIRECT_TEMPLATES =`` ``('index', 'categories', 'authors', 'archives')``        List of templates that are used directly to render
                                                                                  content. Typically direct templates are used to generate
                                                                                  index pages for collections of content (e.g., tags and

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -456,11 +456,20 @@ class Readers(FileStampDataCacher):
         # eventually filter the content with typogrify if asked so
         if self.settings['TYPOGRIFY']:
             from typogrify.filters import typogrify
+
+            def typogrify_wrapper(text):
+                """Ensures ignore_tags feature is backward compatible"""
+                try:
+                    return typogrify(text, self.settings['TYPOGRIFY_IGNORE_TAGS'])
+                except TypeError:
+                    return typogrify(text)
+
             if content:
-                content = typogrify(content)
-                metadata['title'] = typogrify(metadata['title'])
+                content = typogrify_wrapper(content)
+                metadata['title'] = typogrify_wrapper(metadata['title'])
+
             if 'summary' in metadata:
-                metadata['summary'] = typogrify(metadata['summary'])
+                metadata['summary'] = typogrify_wrapper(metadata['summary'])
 
         if context_signal:
             logger.debug('signal {}.send({}, <metadata>)'.format(

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -112,6 +112,7 @@ DEFAULT_CONFIG = {
     'DEFAULT_STATUS': 'published',
     'ARTICLE_PERMALINK_STRUCTURE': '',
     'TYPOGRIFY': False,
+    'TYPOGRIFY_IGNORE_TAGS': [],
     'SUMMARY_MAX_LENGTH': 50,
     'PLUGIN_PATHS': [],
     'PLUGINS': [],

--- a/pelican/tests/content/article_with_code_block.rst
+++ b/pelican/tests/content/article_with_code_block.rst
@@ -1,0 +1,15 @@
+An Article With Code Block To Test Typogrify Ignore
+###################################################
+
+An article with some code
+
+.. code-block:: python
+
+   x & y
+
+A block quote:
+
+   x & y
+
+Normal:
+x & y

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -114,6 +114,8 @@ class TestArticlesGenerator(unittest.TestCase):
              'article'],
             ['This is an article without category !', 'published',
              'TestCategory', 'article'],
+            ['An Article With Code Block To Test Typogrify Ignore',
+              'published', 'Default', 'article'],
             ['マックOS X 10.8でパイソンとVirtualenvをインストールと設定', 'published',
              '指導書', 'article'],
         ]

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -153,6 +153,52 @@ class RstReaderTest(ReaderTest):
         except ImportError:
             return unittest.skip('need the typogrify distribution')
 
+    def test_typogrify_ignore_tags(self):
+        try:
+            # typogrify should be able to ignore user specified tags,
+            # but tries to be clever with widont extension
+            page = self.read_file(path='article.rst', TYPOGRIFY=True,
+                                  TYPOGRIFY_IGNORE_TAGS = ['p'])
+            expected = ('<p>THIS is some content. With some stuff to&nbsp;'
+                        '&quot;typogrify&quot;...</p>\n<p>Now with added '
+                        'support for <abbr title="three letter acronym">'
+                        'TLA</abbr>.</p>\n')
+
+            self.assertEqual(page.content, expected)
+
+            # typogrify should ignore code blocks by default because
+            # code blocks are composed inside the pre tag
+            page = self.read_file(path='article_with_code_block.rst',
+                                 TYPOGRIFY=True)
+
+            expected = ('<p>An article with some&nbsp;code</p>\n'
+                        '<div class="highlight"><pre><span class="n">x</span>'
+                        ' <span class="o">&amp;</span>'
+                        ' <span class="n">y</span>\n</pre></div>\n'
+                        '<p>A block&nbsp;quote:</p>\n<blockquote>\nx '
+                        '<span class="amp">&amp;</span> y</blockquote>\n'
+                        '<p>Normal:\nx <span class="amp">&amp;</span>&nbsp;y</p>\n')
+
+            self.assertEqual(page.content, expected)
+
+            # instruct typogrify to also ignore blockquotes
+            page = self.read_file(path='article_with_code_block.rst',
+                                 TYPOGRIFY=True, TYPOGRIFY_IGNORE_TAGS = ['blockquote'])
+
+            expected = ('<p>An article with some&nbsp;code</p>\n'
+                        '<div class="highlight"><pre><span class="n">x</span>'
+                        ' <span class="o">&amp;</span>'
+                        ' <span class="n">y</span>\n</pre></div>\n'
+                        '<p>A block&nbsp;quote:</p>\n<blockquote>\nx '
+                        '&amp; y</blockquote>\n'
+                        '<p>Normal:\nx <span class="amp">&amp;</span>&nbsp;y</p>\n')
+
+            self.assertEqual(page.content, expected)
+        except ImportError:
+            return unittest.skip('need the typogrify distribution')
+        except TypeError:
+            return unittest.skip('need typogrify version 2.0.4 or later')
+
     def test_article_with_multiple_authors(self):
         page = self.read_file(path='article_with_multiple_authors.rst')
         expected = {


### PR DESCRIPTION
Typogrify interferes with certain sections of the output that it should not touch (see #1407 for more details).
This feature adds a setting called TYPOGRIFY_IGNORE_TAGS which is a list of tags for Typogrify to ignore.

The following was updated:
1. readers.py - if TYPOGRIFY_IGNORE_TAGS is present, then use it
2. contents/article_with_code_block.rst - an article with a code block for typogrify to ignore
3. updated tests
4. updated documentation
