### PR TITLE
Add MD_OUTPUT_FORMAT setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -31,9 +31,9 @@ Here is a list of settings for Pelican:
 Basic settings
 ==============
 
-===============================================================================  =====================================================================
+===============================================================================  ==============================================================================
 Setting name (followed by default value, if any)                                 What does it do?
-===============================================================================  =====================================================================
+===============================================================================  ==============================================================================
 ``AUTHOR``                                                                       Default author (put your name)
 ``DATE_FORMATS = {}``                                                            If you manage multiple languages, you can set the date formatting
                                                                                  here. See the "Date format and locale" section below for details.
@@ -107,6 +107,10 @@ Setting name (followed by default value, if any)                                
                                                                                  to the default values for this setting, you'll need to
                                                                                  include them explicitly and enumerate the full list of
                                                                                  desired Markdown extensions.)
+``MD_OUTPUT_FORMAT = 'xhtml1'``                                                  The output format that the Markdown processor will use.  Refer to the
+                                                                                 Python Markdown documentation's
+                                                                                 `Library Reference section <http://pythonhosted.org/Markdown/reference.html>`_
+                                                                                 for a complete list of supported formats.
 ``OUTPUT_PATH = 'output/'``                                                      Where to output the generated files.
 ``PATH``                                                                         Path to content directory to be processed by Pelican. If undefined,
                                                                                  and content path is not specified via an argument to the ``pelican``
@@ -191,7 +195,7 @@ Setting name (followed by default value, if any)                                
                                                                                  in this list are written. Paths should be either absolute or relative
                                                                                  to the current Pelican working directory. For possible use cases see
                                                                                  :ref:`writing_only_selected_content`.
-===============================================================================  =====================================================================
+===============================================================================  ==============================================================================
 
 .. [#] Default is the system locale.
 

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -199,6 +199,7 @@ class MarkdownReader(BaseReader):
     def __init__(self, *args, **kwargs):
         super(MarkdownReader, self).__init__(*args, **kwargs)
         self.extensions = list(self.settings['MD_EXTENSIONS'])
+        self.output_format = self.settings['MD_OUTPUT_FORMAT']
         if 'meta' not in self.extensions:
             self.extensions.append('meta')
 
@@ -226,7 +227,7 @@ class MarkdownReader(BaseReader):
     def read(self, source_path):
         """Parse content and metadata of markdown files"""
 
-        self._md = Markdown(extensions=self.extensions)
+        self._md = Markdown(extensions=self.extensions, output_format=self.output_format)
         with pelican_open(source_path) as text:
             content = self._md.convert(text)
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -99,6 +99,7 @@ DEFAULT_CONFIG = {
     'DEFAULT_DATE_FORMAT': '%a %d %B %Y',
     'DATE_FORMATS': {},
     'MD_EXTENSIONS': ['codehilite(css_class=highlight)', 'extra'],
+    'MD_OUTPUT_FORMAT': 'xhtml1',
     'JINJA_EXTENSIONS': [],
     'JINJA_FILTERS': {},
     'LOG_FILTER': [],


### PR DESCRIPTION
This adds the MD_OUTPUT_FORMAT setting to keep Markdown from generating non-valid code.  See issue #1024.  Defaults to Markdown's current default of xhtml1.