### PR TITLE
Updates docs for Python 3

### DIFF
--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -36,12 +36,19 @@ HTML files directly::
 
 Because the above method may have trouble locating your CSS and other linked
 assets, running a simple web server using Python will often provide a more
-reliable previewing experience::
+reliable previewing experience. 
+
+For Python 2, run::
 
     cd output
     python -m SimpleHTTPServer
 
-Once the ``SimpleHTTPServer`` has been started, you can preview your site at
+For Python 3, run::
+
+    cd output
+    python -m http.server
+
+Once the basic server has been started, you can preview your site at
 http://localhost:8000/
 
 Deployment


### PR DESCRIPTION
In Python 3, the simpleHTTPServer has moved into the http module, so the command `python -m simpleHTTPServer no longer works. This minor change adds instructions for those of us using Python 3.
