### PR TITLE
Unify bottom margins of lists and paragraphs

### DIFF
--- a/pelican/tests/output/basic/theme/css/main.css
+++ b/pelican/tests/output/basic/theme/css/main.css
@@ -84,7 +84,8 @@ ol {
 	margin: 0em 0 0 1.5em;
 }
 
-li { margin-top: 0.5em;}
+li { margin-top: 0.5em;
+     margin-bottom: 1em; }
 
 .post-info {
     float:right;

--- a/pelican/tests/output/custom/theme/css/main.css
+++ b/pelican/tests/output/custom/theme/css/main.css
@@ -84,7 +84,8 @@ ol {
 	margin: 0em 0 0 1.5em;
 }
 
-li { margin-top: 0.5em;}
+li { margin-top: 0.5em;
+     margin-bottom: 1em; }
 
 .post-info {
     float:right;

--- a/pelican/tests/output/custom_locale/theme/css/main.css
+++ b/pelican/tests/output/custom_locale/theme/css/main.css
@@ -84,7 +84,8 @@ ol {
 	margin: 0em 0 0 1.5em;
 }
 
-li { margin-top: 0.5em;}
+li { margin-top: 0.5em;
+     margin-bottom: 1em; }
 
 .post-info {
     float:right;

--- a/pelican/themes/notmyidea/static/css/main.css
+++ b/pelican/themes/notmyidea/static/css/main.css
@@ -84,7 +84,8 @@ ol {
 	margin: 0em 0 0 1.5em;
 }
 
-li { margin-top: 0.5em;}
+li { margin-top: 0.5em;
+     margin-bottom: 1em; }
 
 .post-info {
     float:right;


### PR DESCRIPTION
Only considering bottom margins, we currently have:

    p { margin-bottom: 1em }
    ul { margin-bottom: 0 }
    li { margin-bottom: 0}

However, when a list is followed by a title (which has no `top-margin`), the list and the title are not separated. This pull request changes the bottom margin to `1em`, as is done with paragraphs.