### PR TITLE
Extends #1148: article modification date from FS.

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -218,6 +218,8 @@ Variable        Description
 =============   ===================================================
 article         The article object to be displayed
 category        The name of the category for the current article
+mdate           The article modification date and time as it
+                appears in the filesystem
 =============   ===================================================
 
 Any metadata that you put in the header of the article source file

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -333,7 +333,7 @@ class HTMLReader(BaseReader):
             if name is None:
                 attr_serialized = ', '.join(['{}="{}"'.format(k, v) for k, v in attrs])
                 logger.warning("Meta tag in file %s does not have a 'name' "
-                               "attribute, skipping. Attributes: %s", 
+                               "attribute, skipping. Attributes: %s",
                                self._filename, attr_serialized)
                 return
             name = name.lower()
@@ -544,6 +544,8 @@ def path_metadata(full_path, source_path, settings=None):
                 os.stat(full_path).st_ctime)
         metadata.update(settings.get('EXTRA_PATH_METADATA', {}).get(
             source_path, {}))
+    metadata['mdate'] = SafeDatetime.fromtimestamp(
+        os.stat(full_path).st_mtime)
     return metadata
 
 


### PR DESCRIPTION
  - This pull request adds a new attribute to the `article` object: `mdate`.

  - `article.mdate` retrives the article file last modification date from the
    filesystem (`os.stat(full_path)`), thus providing article modification date
    automatically.

  - This extends #1148 in the sense that an author doesn't have to add the
    `:modified:` metadata to each article, as she can just edit the template
    files to display the new article attribute.

  - Documentation updated to describe the new feature.