### PR TITLE
Fix #1405: No error message for invalid syntax in period_archives.html

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -29,6 +29,9 @@ from pelican import signals
 logger = logging.getLogger(__name__)
 
 
+class PelicanTemplateNotFound(Exception):
+    pass
+
 @python_2_unicode_compatible
 class Generator(object):
     """Baseclass generator"""
@@ -88,7 +91,7 @@ class Generator(object):
             try:
                 self._templates[name] = self.env.get_template(name + '.html')
             except TemplateNotFound:
-                raise Exception('[templates] unable to load %s.html from %s'
+                raise PelicanTemplateNotFound('[templates] unable to load %s.html from %s'
                                 % (name, self._templates_path))
         return self._templates[name]
 
@@ -330,7 +333,7 @@ class ArticlesGenerator(CachingGenerator):
         """Generate per-year, per-month, and per-day archives."""
         try:
             template = self.get_template('period_archives')
-        except Exception:
+        except PelicanTemplateNotFound:
             template = self.get_template('archives')
 
         period_save_as = {


### PR DESCRIPTION
#1405 resulted from the wrapping of TemplateNotFound in generic Exception to adjust the error message. After that it was not possible to distinguish any other exception  from TemplateNotFound exception. 

I have introduced a new PelicanTemplateNotFound exception and started using it to wrap jinja2.TemplateNotFound and to fallback from period_archives to archives.

Another possible approach is not to wrap exception in this case when we want to throw it away. This could be achieved by either parametrising get_template or by extracting get_template_without_wrapping into a separate function. Both seem to me clumsier  compared to the approach I have chosen.