### PR TITLE
Ignore files not only by their basename but the whole path

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -107,6 +107,8 @@ class Generator(object):
         ignores = self.settings['IGNORE_FILES']
         if any(fnmatch.fnmatch(basename, ignore) for ignore in ignores):
             return False
+        if any(fnmatch.fnmatch(path, ignore) for ignore in ignores):
+            return False
 
         if extensions is False or basename.endswith(extensions):
             return True


### PR DESCRIPTION
I want to ignore files not only by their extensions but their path when generating. It is extremely useful while we simply want to ignore a bulk of files for later editing, etc.

With this modification you can have IGNORE_FILES like this:

```
IGNORE_FILES = ['.DS_Store', 'README.md', 'legacy/*.rst']
```

While the .DS_Store and README.md file will be ignore just like before, all .rst files under legacy directory will be ignored, too.
