### PR TITLE
Additional filter for TAG feed generation

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -494,6 +494,9 @@ Setting name (followed by default value, if any)    What does it do?
 ``TAG_FEED_RSS = None``, i.e. no RSS tag feed       Relative URL to output the tag RSS feed
 ``FEED_MAX_ITEMS``                                  Maximum number of items allowed in a feed. Feed item
                                                     quantity is unrestricted by default.
+``TAGS_FOR_FEED = []``, i.e. generate feed for      Use this to filter Tag feed generation only for some
+                                                    tags. Applicable only if ``TAG_FEED_ATOM`` or
+                                                    ``TAG_FEED_RSS`` is set.
 =================================================   =====================================================
 
 If you don't want to generate some or any of these feeds, set the above variables to ``None``.

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -288,7 +288,11 @@ class ArticlesGenerator(CachingGenerator):
 
         if (self.settings.get('TAG_FEED_ATOM')
                 or self.settings.get('TAG_FEED_RSS')):
+            tags_filter = self.settings.get('TAGS_FOR_FEED')
             for tag, arts in self.tags.items():
+                if tags_filter and tag.slug not in tags_filter:
+                    continue
+
                 arts.sort(key=attrgetter('date'), reverse=True)
                 if self.settings.get('TAG_FEED_ATOM'):
                     writer.write_feed(arts, self.context,

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -130,6 +130,7 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': True,
     'AUTORELOAD_IGNORE_CACHE': False,
     'WRITE_SELECTED': [],
+    'TAGS_FOR_FEED': [],
     }
 
 PYGMENTS_RST_OPTIONS = None
@@ -287,7 +288,7 @@ def configure_settings(settings):
         'CATEGORY_FEED_ATOM', 'CATEGORY_FEED_RSS',
         'AUTHOR_FEED_ATOM', 'AUTHOR_FEED_RSS',
         'TAG_FEED_ATOM', 'TAG_FEED_RSS',
-        'TRANSLATION_FEED_ATOM', 'TRANSLATION_FEED_RSS',
+        'TRANSLATION_FEED_ATOM', 'TRANSLATION_FEED_RSS', 'TAGS_FOR_FEED'
     ]
 
     if any(settings.get(k) for k in feed_keys):


### PR DESCRIPTION
New setting "TAGS_FOR_FEED" is introduced, default is []
If TAGS_FOR_FEED is set then it will generate feed only for
those tags.

Example usage
TAGS_FOR_FEED = ["thats", "awesome"]

Signed-off-by: Aravinda VK mail@aravindavk.in
