### PR TITLE
Add OS-specific path separator info to EXTRA_PATH_METADATA docs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -75,8 +75,8 @@ Setting name (followed by default value, if any)                                
                                                                                  full path relative to the content source directory.
                                                                                  See :ref:`path_metadata`.
 ``EXTRA_PATH_METADATA = {}``                                                     Extra metadata dictionaries keyed by relative path. Relative paths
-																				 require correct OS-specific directory separators (i.e. / in UNIX and
-																				 \\ in Windows) unlike some other Pelican file settings.
+                                                                                 require correct OS-specific directory separators (i.e. / in UNIX and
+                                                                                 \\ in Windows) unlike some other Pelican file settings.
                                                                                  See :ref:`path_metadata`.
 ``DELETE_OUTPUT_DIRECTORY = False``                                              Delete the output directory, and **all** of its contents, before
                                                                                  generating new files. This can be useful in preventing older,


### PR DESCRIPTION
...separators must be used as keys, unlike some other pelican variables.reference to issue #1133.
