### PR TITLE
add missing author feeds to pelicanconf template

### DIFF
--- a/pelican/tools/templates/pelicanconf.py.in
+++ b/pelican/tools/templates/pelicanconf.py.in
@@ -16,6 +16,8 @@ DEFAULT_LANG = $lang
 FEED_ALL_ATOM = None
 CATEGORY_FEED_ATOM = None
 TRANSLATION_FEED_ATOM = None
+AUTHOR_FEED_ATOM = None
+AUTHOR_FEED_RSS = None
 
 # Blogroll
 LINKS = (('Pelican', 'http://getpelican.com/'),


### PR DESCRIPTION
feed generation in templates are disabled per quickstart conf, with the addition of the author feeds, they need to be added there as well. same story as #1473 really
