### PR TITLE
Ignore empty metadata.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -460,6 +460,10 @@ class Readers(FileStampDataCacher):
             self.cache_data(path, (content, reader_metadata))
         metadata.update(reader_metadata)
 
+        # remove any metadata that might have been defined with empty values
+        metadata = dict([i for i in metadata.items()
+            if i[1] or isinstance(i, (int, bool, float))])
+
         if content:
             # find images with empty alt
             find_empty_alt(content, path)


### PR DESCRIPTION
I originally set out to stop pelican from creating files named `.html` when an empty Slug: definition appeared in a Markdown file, but after browsing the reader code, I saw there were more opportunities for empty values to slip in. Since I don't know of any metadata that would make sense with empty values, I made `read_file()` filter out any such items after it gathers the metadata.

The code filters out most non-true values, including empty strings and `None`, but it preserves numeric zero values. It runs after the cache phase, so as not to affect caching behavior when whitespace changes are made to a file.

Fixes getpelican/pelican#1469.
Might also fix getpelican/pelican#1398?
