### PR TITLE
Ignore empty metadata

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -28,14 +28,20 @@ from pelican.contents import Page, Category, Tag, Author
 from pelican.utils import get_date, pelican_open, FileStampDataCacher, SafeDatetime
 
 
+def strip_split(text, sep=','):
+    """Return a list of stripped, non-empty substrings, delimited by sep."""
+    items = [x.strip() for x in text.split(sep)]
+    return [x for x in items if x]
+
+
 METADATA_PROCESSORS = {
-    'tags': lambda x, y: [Tag(tag, y) for tag in x.split(',')],
+    'tags': lambda x, y: [Tag(tag, y) for tag in strip_split(x)],
     'date': lambda x, y: get_date(x),
     'modified': lambda x, y: get_date(x),
     'status': lambda x, y: x.strip(),
     'category': Category,
     'author': Author,
-    'authors': lambda x, y: [Author(author.strip(), y) for author in x.split(',')],
+    'authors': lambda x, y: [Author(author, y) for author in strip_split(x)],
 }
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
I originally set out to stop Pelican from creating files named `.html` when an empty `Slug:` line appeared in a Markdown file. While reading the code, I saw more opportunities for empty metadata to slip in, and noticed that someone had already reported a similar problem with `Tags:`. Since I don't know of any metadata that would make sense as empty strings, I decided to generalize my fix.

I essentially made two changes:
- `read_file()` now filters out metadata with non-true, non-numeric values. This takes care of of empty strings and lists without being destructive to `0` or `False` values that might be allowed some day. (It would also work with a class like `Category` if it grew a `__bool__()` method to indicate the presence of a real value.)
- The `Tags:` and `Authors:` metadata processors now omit empty values when creating their lists. If all their values are empty, they will return empty lists, which will be filtered out by `read_file()`.
