### PR TITLE
fix the parameters for a logging.warning call

### DIFF
--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -70,7 +70,7 @@ class URLWrapper(object):
         setting = "%s_%s" % (self.__class__.__name__.upper(), key)
         value = self.settings[setting]
         if not isinstance(value, six.string_types):
-            logger.warning('%s is set to %s', (setting, value))
+            logger.warning('%s is set to %s', setting, value)
             return value
         else:
             if get_page_name:


### PR DESCRIPTION
Small crash 

```
CRITICAL: not enough arguments for format string
Traceback (most recent call last):
  File "/Users/stephane/.virtualenvs/pelican/bin/pelican", line 9, in <module>
    load_entry_point('pelican==3.4.0', 'console_scripts', 'pelican')()
  File "/Users/stephane/src/projects/externals/pelican/pelican/__init__.py", line 419, in main
    pelican.run()
  File "/Users/stephane/src/projects/externals/pelican/pelican/__init__.py", line 173, in run
    p.generate_output(writer)
  File "/Users/stephane/src/projects/externals/pelican/pelican/generators.py", line 572, in generate_output
    self.generate_pages(writer)
  File "/Users/stephane/src/projects/externals/pelican/pelican/generators.py", line 456, in generate_pages
    self.generate_authors(write)
  File "/Users/stephane/src/projects/externals/pelican/pelican/generators.py", line 429, in generate_authors
    write(aut.save_as, author_template, self.context,
  File "/Users/stephane/src/projects/externals/pelican/pelican/urlwrappers.py", line 73, in _from_settings
    logger.warning('%s is set to %s', (setting, value))
  File "/usr/local/Cellar/python/2.7.8_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1172, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/stephane/src/projects/externals/pelican/pelican/log.py", line 141, in _log
    exc_info=exc_info, extra=extra)
  File "/usr/local/Cellar/python/2.7.8_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1279, in _log
    self.handle(record)
  File "/usr/local/Cellar/python/2.7.8_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 1288, in handle
    if (not self.disabled) and self.filter(record):
  File "/usr/local/Cellar/python/2.7.8_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 615, in filter
    if not f.filter(record):
  File "/Users/stephane/src/projects/externals/pelican/pelican/log.py", line 108, in filter
    ignore_key = (record.levelno, record.getMessage())
  File "/usr/local/Cellar/python/2.7.8_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/logging/__init__.py", line 335, in getMessage
    msg = msg % self.args
TypeError: not enough arguments for format string
```
