### PR TITLE
Added tests for generators, settings, and pelican_import

### DIFF
--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -7,7 +7,6 @@ try:
     from unittest.mock import MagicMock
 except ImportError:
     from mock import MagicMock
-from operator import itemgetter
 from shutil import rmtree
 from tempfile import mkdtemp
 

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -34,11 +34,16 @@ class TestGenerator(unittest.TestCase):
 
 
     def test_include_path(self):
+        self.settings['IGNORE_FILES'] = {'ignored1.rst', 'ignored2.rst'}
+
         filename = os.path.join(CUR_DIR, 'content', 'article.rst')
         include_path = self.generator._include_path
         self.assertTrue(include_path(filename))
         self.assertTrue(include_path(filename, extensions=('rst',)))
         self.assertFalse(include_path(filename, extensions=('md',)))
+
+        ignored_file = os.path.join(CUR_DIR, 'content', 'ignored1.rst')
+        self.assertFalse(include_path(ignored_file))
 
     def test_get_files_exclude(self):
         """Test that Generator.get_files() properly excludes directories.
@@ -50,6 +55,13 @@ class TestGenerator(unittest.TestCase):
             theme=self.settings['THEME'], output_path=None)
 
         filepaths = generator.get_files(paths=['maindir'])
+        found_files = {os.path.basename(f) for f in filepaths}
+        expected_files = {'maindir.md', 'subdir.md'}
+        self.assertFalse(expected_files - found_files,
+            "get_files() failed to find one or more files")
+
+        # Test string as `paths` argument rather than list
+        filepaths = generator.get_files(paths='maindir')
         found_files = {os.path.basename(f) for f in filepaths}
         expected_files = {'maindir.md', 'subdir.md'}
         self.assertFalse(expected_files - found_files,
@@ -316,6 +328,14 @@ class TestArticlesGenerator(unittest.TestCase):
                                  generator.get_template("period_archives"),
                                  settings,
                                  blog=True, dates=dates)
+
+    def test_nonexistent_template(self):
+        """Attempt to load a non-existent template"""
+        settings = get_settings(filenames={})
+        generator = ArticlesGenerator(
+            context=settings, settings=settings,
+            path=None, theme=settings['THEME'], output_path=None)
+        self.assertRaises(Exception, generator.get_template, "not_a_template")
 
     def test_generate_authors(self):
         """Check authors generation."""

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -245,6 +245,41 @@ class TestBuildHeader(unittest.TestCase):
         header = build_header('test', None, None, None, None, None)
         self.assertEqual(header, 'test\n####\n\n')
 
+    def test_build_header_with_fields(self):
+        header_data = [
+            'Test Post',
+            '2014-11-04',
+            'Alexis Métaireau',
+            ['Programming'],
+            ['Pelican', 'Python'],
+            'test-post',
+        ]
+
+        expected_docutils = '\n'.join([
+            'Test Post',
+            '#########',
+            ':date: 2014-11-04',
+            ':author: Alexis Métaireau',
+            ':category: Programming',
+            ':tags: Pelican, Python',
+            ':slug: test-post',
+            '\n',
+        ])
+
+        expected_md = '\n'.join([
+            'Title: Test Post',
+            'Date: 2014-11-04',
+            'Author: Alexis Métaireau',
+            'Category: Programming',
+            'Tags: Pelican, Python',
+            'Slug: test-post',
+            '\n',
+        ])
+
+        self.assertEqual(build_header(*header_data), expected_docutils)
+        self.assertEqual(build_markdown_header(*header_data), expected_md)
+
+
     def test_build_header_with_east_asian_characters(self):
         header = build_header('これは広い幅の文字だけで構成されたタイトルです',
                 None, None, None, None, None)
@@ -264,6 +299,7 @@ class TestBuildHeader(unittest.TestCase):
             attachments=['output/test1', 'output/test2'])
         self.assertEqual(header, 'Title: test\n' + 'Attachments: output/test1, '
                 + 'output/test2\n\n')
+
 
 @unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')
 class TestWordpressXMLAttachements(unittest.TestCase):

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
-import six
 import locale
 
 from pelican.tests.support import unittest, get_settings

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -123,8 +123,6 @@ class TestPelican(LoggedTestCase):
                          locale_available('French'), 'French locale needed')
     def test_custom_locale_generation_works(self):
         '''Test that generation with fr_FR.UTF-8 locale works'''
-        old_locale = locale.setlocale(locale.LC_TIME)
-
         if sys.platform == 'win32':
             our_locale = str('French')
         else:

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -5,7 +5,7 @@ import shutil
 import os
 import time
 import locale
-from sys import platform, version_info
+from sys import platform
 from tempfile import mkdtemp
 
 import pytz


### PR DESCRIPTION
I wrote a few tests to improve Pelican's code coverage and begin to better understand the codebase. I'm not entirely sure if I've written these tests in an adequate manner, so I might need a little bit of guidance. Also, I noticed that some tests contained docstrings with a description of the test whereas others simply have commented-out descriptions. The benefit of a descriptive docstring is that the description is printed to the output of `nose` (rather than just the name of the test function); is this something that we would want to standardize?