### PR TITLE
Replace underscores in dates with spaces before parsing

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -30,7 +30,7 @@ from pelican.utils import get_date, pelican_open, FileStampDataCacher, SafeDatet
 
 METADATA_PROCESSORS = {
     'tags': lambda x, y: [Tag(tag, y) for tag in x.split(',')],
-    'date': lambda x, y: get_date(x),
+    'date': lambda x, y: get_date(x.replace('_', ' ')),
     'modified': lambda x, y: get_date(x),
     'status': lambda x, y: x.strip(),
     'category': Category,


### PR DESCRIPTION
This allows for parsing date, and time, from the filename
```
FILENAME_METADATA = '(?P<date>\d{4}-\d{2}-\d{2}(_\d{2}:\d{2})?)_(?P<slug>.*)'
```
The format version with `_` is somewhat nicer on Unix and more readable than the one with a `T`.
It's an edgy use case but the drawbacks are few, if any.