### PR TITLE
Add missing feed variables to theme docs

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -341,6 +341,8 @@ Here is a complete list of the feed variables::
     FEED_ALL_RSS
     CATEGORY_FEED_ATOM
     CATEGORY_FEED_RSS
+    AUTHOR_FEED_ATOM
+    AUTHOR_FEED_RSS
     TAG_FEED_ATOM
     TAG_FEED_RSS
     TRANSLATION_FEED_ATOM


### PR DESCRIPTION
`AUTHOR_FEED_ATOM` and `AUTHOR_FEED_RSS` are listed in `settings.rst` but not in `themes.rst`. This PR adds them in `themes.rst` too.
