### PR TITLE
docs: fix table formating in importer.rst

### DIFF
--- a/docs/importer.rst
+++ b/docs/importer.rst
@@ -47,10 +47,11 @@ Usage
 
 Positional arguments
 --------------------
-
-  input                 The input file to read
-  api_token             [Posterous only] api_token can be obtained from http://posterous.com/api/
-  api_key               [Tumblr only] api_key can be obtained from http://www.tumblr.com/oauth/apps
+  =============         ============================================================================
+  ``input``             The input file to read
+  ``api_token``         (Posterous only) api_token can be obtained from http://posterous.com/api/
+  ``api_key``           (Tumblr only) api_key can be obtained from http://www.tumblr.com/oauth/apps
+  =============         ============================================================================
 
 Optional arguments
 ------------------


### PR DESCRIPTION
This table [here](http://docs.getpelican.com/en/3.5.0/importer.html#positional-arguments) isn't rendered correctly. Fixed it.
