### PR TITLE
Fabfile Improvements

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -1,6 +1,7 @@
 from fabric.api import *
 import fabric.contrib.project as project
 import os
+import shutil
 import sys
 import SimpleHTTPServer
 import SocketServer
@@ -18,26 +19,35 @@ env.cloudfiles_username = '$cloudfiles_username'
 env.cloudfiles_api_key = '$cloudfiles_api_key'
 env.cloudfiles_container = '$cloudfiles_container'
 
+# Github Pages configuration
+env.github_pages_branch = "gh-pages"
+
+# Port for `serve`
+PORT = 8000
 
 def clean():
+    """Remove generated files"""
     if os.path.isdir(DEPLOY_PATH):
-        local('rm -rf {deploy_path}'.format(**env))
-        local('mkdir {deploy_path}'.format(**env))
+        shutil.rmtree(DEPLOY_PATH)
+        os.makedirs(DEPLOY_PATH)
 
 def build():
+    """Build local version of site"""
     local('pelican -s pelicanconf.py')
 
 def rebuild():
+    """`clean` then `build`"""
     clean()
     build()
 
 def regenerate():
+    """Automatically regenerate site upon file modification"""
     local('pelican -r -s pelicanconf.py')
 
 def serve():
+    """Serve site at http://localhost:8000/"""
     os.chdir(env.deploy_path)
 
-    PORT = 8000
     class AddressReuseTCPServer(SocketServer.TCPServer):
         allow_reuse_address = True
 
@@ -47,22 +57,26 @@ def serve():
     server.serve_forever()
 
 def reserve():
+    """`build`, then `serve`"""
     build()
     serve()
 
 def preview():
+    """Build production version of site"""
     local('pelican -s publishconf.py')
 
 def cf_upload():
+    """Publish to Rackspace Cloud Files"""
     rebuild()
-    local('cd {deploy_path} && '
-          'swift -v -A https://auth.api.rackspacecloud.com/v1.0 '
-          '-U {cloudfiles_username} '
-          '-K {cloudfiles_api_key} '
-          'upload -c {cloudfiles_container} .'.format(**env))
+    with lcd(DEPLOY_PATH):
+        local('swift -v -A https://auth.api.rackspacecloud.com/v1.0 '
+              '-U {cloudfiles_username} '
+              '-K {cloudfiles_api_key} '
+              'upload -c {cloudfiles_container} .'.format(**env))
 
 @hosts(production)
 def publish():
+    """Publish to production via rsync"""
     local('pelican -s publishconf.py')
     project.rsync_project(
         remote_dir=dest_path,
@@ -71,3 +85,9 @@ def publish():
         delete=True,
         extra_opts='-c',
     )
+
+def gh_pages():
+    """Publish to GitHub Pages"""
+    rebuild()
+    local("ghp-import -b {github_pages_branch} {deploy_path}".format(**env))
+    local("git push origin {github_pages_branch}".format(**env))


### PR DESCRIPTION
- Remove gratuitous Unixisms so that fabfile will work on Windows
- Docstrings for tasks so `fab --list` is more useful.
- Add `gh_pages` task for publishing to GitHub Pages
  using [ghp-import](https://github.com/davisp/ghp-import)
