### PR TITLE
Expose tag count to theme template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,4 @@ See our `contribution submission and feedback guidelines <CONTRIBUTING.rst>`_.
 .. |coverage-status| image:: https://img.shields.io/coveralls/getpelican/pelican.svg
    :target: https://coveralls.io/r/getpelican/pelican
    :alt: Coveralls: code coverage status
+


### PR DESCRIPTION
We can expose tag count to theme template so that in the template we can show this information on the page
