### PR TITLE
Use Shields.io as source for Travis badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ See our `contribution submission and feedback guidelines <CONTRIBUTING.rst>`_.
 .. _`Pelican documentation`: http://docs.getpelican.com/
 .. _`Pelican's internals`: http://docs.getpelican.com/en/latest/internals.html
 
-.. |build-status| image:: https://travis-ci.org/getpelican/pelican.svg?branch=master
+.. |build-status| image:: https://img.shields.io/travis/getpelican/pelican/master.svg
    :target: https://travis-ci.org/getpelican/pelican
    :alt: Travis CI: continuous integration status
 .. |coverage-status| image:: https://img.shields.io/coveralls/getpelican/pelican.svg


### PR DESCRIPTION
Currently, the Travis badge is rendering using the "flat" style while the Coveralls badge uses the "plastic" style, which looks a little odd. Since the Coveralls badge already uses Shields, I think it would make sense for the Travis badge to do the same, for the sake of consistency. This way, any changes made to badge styling by the Shields team will be applied to both simultaneously.