### PR TITLE
Adding ability to listen on addresses other than localhost.

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -12,7 +12,8 @@ try:
 except ImportError:
     import socketserver  # NOQA
 
-PORT = len(sys.argv) == 2 and int(sys.argv[1]) or 8000
+PORT = len(sys.argv) in (2, 3) and int(sys.argv[1]) or 8000
+SERVER = len(sys.argv) == 3 and sys.argv[2] or ""
 SUFFIXES = ['', '.html', '/index.html']
 
 
@@ -38,13 +39,13 @@ Handler = ComplexHTTPRequestHandler
 
 socketserver.TCPServer.allow_reuse_address = True
 try:
-    httpd = socketserver.TCPServer(("", PORT), Handler)
+    httpd = socketserver.TCPServer((SERVER, PORT), Handler)
 except OSError as e:
-    logging.error("Could not listen on port %s", PORT)
+    logging.error("Could not listen on port %s, server %s", PORT, SERVER)
     sys.exit(getattr(e, 'exitcode', 1))
 
 
-logging.info("Serving at port %s", PORT)
+logging.info("Serving at port %s, server %s", PORT, SERVER)
 try:
     httpd.serve_forever()
 except KeyboardInterrupt as e:

--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -32,26 +32,27 @@ ifeq ($(DEBUG), 1)
 endif
 
 help:
-	@echo 'Makefile for a pelican Web site                                        '
-	@echo '                                                                       '
-	@echo 'Usage:                                                                 '
-	@echo '   make html                        (re)generate the web site          '
-	@echo '   make clean                       remove the generated files         '
-	@echo '   make regenerate                  regenerate files upon modification '
-	@echo '   make publish                     generate using production settings '
-	@echo '   make serve [PORT=8000]           serve site at http://localhost:8000'
-	@echo '   make devserver [PORT=8000]       start/restart develop_server.sh    '
-	@echo '   make stopserver                  stop local server                  '
-	@echo '   make ssh_upload                  upload the web site via SSH        '
-	@echo '   make rsync_upload                upload the web site via rsync+ssh  '
-	@echo '   make dropbox_upload              upload the web site via Dropbox    '
-	@echo '   make ftp_upload                  upload the web site via FTP        '
-	@echo '   make s3_upload                   upload the web site via S3         '
-	@echo '   make cf_upload                   upload the web site via Cloud Files'
-	@echo '   make github                      upload the web site via gh-pages   '
-	@echo '                                                                       '
-	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html'
-	@echo '                                                                       '
+	@echo 'Makefile for a pelican Web site                                           '
+	@echo '                                                                          '
+	@echo 'Usage:                                                                    '
+	@echo '   make html                           (re)generate the web site          '
+	@echo '   make clean                          remove the generated files         '
+	@echo '   make regenerate                     regenerate files upon modification '
+	@echo '   make publish                        generate using production settings '
+	@echo '   make serve [PORT=8000]              serve site at http://localhost:8000'
+	@echo '   make serve-global [SERVER=0.0.0.0]  serve (as root) to $(SERVER):80    '
+	@echo '   make devserver [PORT=8000]          start/restart develop_server.sh    '
+	@echo '   make stopserver                     stop local server                  '
+	@echo '   make ssh_upload                     upload the web site via SSH        '
+	@echo '   make rsync_upload                   upload the web site via rsync+ssh  '
+	@echo '   make dropbox_upload                 upload the web site via Dropbox    '
+	@echo '   make ftp_upload                     upload the web site via FTP        '
+	@echo '   make s3_upload                      upload the web site via S3         '
+	@echo '   make cf_upload                      upload the web site via Cloud Files'
+	@echo '   make github                         upload the web site via gh-pages   '
+	@echo '                                                                          '
+	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
+	@echo '                                                                          '
 
 html:
 	$$(PELICAN) $$(INPUTDIR) -o $$(OUTPUTDIR) -s $$(CONFFILE) $$(PELICANOPTS)
@@ -68,6 +69,14 @@ ifdef PORT
 else
 	cd $$(OUTPUTDIR) && $(PY) -m pelican.server
 endif
+
+serve-global:
+ifdef SERVER
+	cd $$(OUTPUTDIR) && $(PY) -m pelican.server 80 $$(SERVER)
+else
+	cd $$(OUTPUTDIR) && $(PY) -m pelican.server 80 0.0.0.0
+endif
+
 
 devserver:
 ifdef PORT
@@ -106,4 +115,4 @@ github: publish
 	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) $$(OUTPUTDIR)
 	git push origin $(GITHUB_PAGES_BRANCH)
 
-.PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github
+.PHONY: html help clean regenerate serve serve-global devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github


### PR DESCRIPTION
This is helpful for mobile testing of Pelican sites by allowing broadcasting on the local network.

Using port 80 requires running as root on most machines.