### PR TITLE
add argparse argument for relative urls

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -281,6 +281,11 @@ def parse_arguments():
                         help='Relaunch pelican each time a modification occurs'
                         ' on the content files.')
 
+    parser.add_argument('--relative-urls', dest='relative_paths',
+                        action='store_true',
+                        help='Use relative urls in output, '
+                             'useful for site development')
+
     parser.add_argument('--cache-path', dest='cache_path',
                         help=('Directory in which to store cache files. '
                               'If not specified, defaults to "cache".'))
@@ -314,6 +319,7 @@ def get_config(args):
         config['CACHE_PATH'] = args.cache_path
     if args.selected_paths:
         config['WRITE_SELECTED'] = args.selected_paths.split(',')
+    config['RELATIVE_URLS'] = args.relative_paths
     config['DEBUG'] = args.verbosity == logging.DEBUG
 
     # argparse returns bytes in Py2. There is no definite answer as to which

--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -31,6 +31,11 @@ ifeq ($(DEBUG), 1)
 	PELICANOPTS += -D
 endif
 
+RELATIVE ?= 0
+ifeq ($(RELATIVE), 1)
+	PELICANOPTS += --relative-urls
+endif
+
 help:
 	@echo 'Makefile for a pelican Web site                                           '
 	@echo '                                                                          '
@@ -52,6 +57,7 @@ help:
 	@echo '   make github                         upload the web site via gh-pages   '
 	@echo '                                                                          '
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
+	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '
 	@echo '                                                                          '
 
 html:


### PR DESCRIPTION
This PR adds the `--relative-urls` option to argparse.
Useful when combined with the `-r` flag, enabling easy local development without touching the configuration files.