### PR TITLE
make html's IDs unique on using multiple code-blocks with 'linespans' option activate

### DIFF
--- a/pelican/rstdirectives.py
+++ b/pelican/rstdirectives.py
@@ -71,7 +71,10 @@ class Pygments(Directive):
             if flag in self.options:
                 self.options[flag] = True
 
-        self.options['linespans'] += next(code_block_id)
+        if '<id>' in self.options['linespans']:
+            self.options['linespans'] = str(self.options['linespans']).replace(
+                '<id>', next(code_block_id)
+            )
 
         # noclasses should already default to False, but just in case...
         formatter = HtmlFormatter(noclasses=False, **self.options)

--- a/pelican/rstdirectives.py
+++ b/pelican/rstdirectives.py
@@ -11,6 +11,16 @@ import six
 import pelican.settings as pys
 
 
+def integers():
+    """Infinite sequence of integers."""
+    i = 1
+    while True:
+        yield str(i)
+        i = i + 1
+
+code_block_id = integers()
+
+
 class Pygments(Directive):
     """ Source code syntax highlighting.
     """
@@ -60,6 +70,8 @@ class Pygments(Directive):
         for flag in ('nowrap', 'nobackground', 'anchorlinenos'):
             if flag in self.options:
                 self.options[flag] = True
+
+        self.options['linespans'] += next(code_block_id)
 
         # noclasses should already default to False, but just in case...
         formatter = HtmlFormatter(noclasses=False, **self.options)


### PR DESCRIPTION
Html's attribute "id" must be unique.

If you use multiple code-bocks with 'linespans' option activate, this affirmation isn't correct.
I suggest a little patch to correct this.