### PR TITLE
Implements tag cloud sorting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -632,6 +632,9 @@ Setting name (followed by default value)            What does it do?
 ``TAG_CLOUD_STEPS = 4``                             Count of different font sizes in the tag
                                                     cloud.
 ``TAG_CLOUD_MAX_ITEMS = 100``                       Maximum number of tags in the cloud.
+``TAG_CLOUD_SORTING = 'random'``                    The tag cloud ordering scheme.  Valid values:
+                                                    random, alphabetically, alphabetically-rev, size and
+                                                    size-rev
 ================================================    =====================================================
 
 The default theme does not include a tag cloud, but it is pretty easy to add one::
@@ -666,6 +669,7 @@ For example::
 
     ...
 
+By default the tags in the cloud are sorted randomly, but if you prefers to have it alphabetically use the `alphabetically` (ascending) and `alphabetically-rev` (descending). Also is possible to sort the tags by it's size (number of articles with this specific tag) using the values `size` (ascending) and `size-rev` (descending).
 
 Translations
 ============

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -576,8 +576,20 @@ class ArticlesGenerator(CachingGenerator):
             )
             for tag, count in tag_cloud
         ]
-        # put words in chaos
-        random.shuffle(self.tag_cloud)
+
+        sorting = self.settings.get('TAG_CLOUD_SORTING')
+
+        if sorting == 'alphabetically':
+            self.tag_cloud.sort(key=lambda elem: elem[0].name)
+        elif sorting == 'alphabetically-rev':
+            self.tag_cloud.sort(key=lambda elem: elem[0].name, reverse=True)
+        elif sorting == 'size':
+            self.tag_cloud.sort(key=lambda elem: elem[1])
+        elif sorting == 'size-rev':
+            self.tag_cloud.sort(key=lambda elem: elem[1], reverse=True)
+        else:
+            # put words in chaos
+            random.shuffle(self.tag_cloud)
 
         # and generate the output :)
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -97,6 +97,7 @@ DEFAULT_CONFIG = {
     'DEFAULT_LANG': 'en',
     'TAG_CLOUD_STEPS': 4,
     'TAG_CLOUD_MAX_ITEMS': 100,
+    'TAG_CLOUD_SORTING': 'random',
     'DIRECT_TEMPLATES': ('index', 'tags', 'categories', 'authors', 'archives'),
     'EXTRA_TEMPLATES_PATHS': [],
     'PAGINATED_DIRECT_TEMPLATES': ('index', ),


### PR DESCRIPTION
For those (like me) who don't like the tag cloud to be randomly organized, I've implemented some sorting options:

* Alphabetically;
* Alphabetically Reverse (descending);
* Size;
* Size Reverse (descending);
* Random.