### PR TITLE
Import drafts from WordPress XML

### DIFF
--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -254,13 +254,13 @@ class TestBuildHeader(unittest.TestCase):
 
     def test_galleries_added_to_header(self):
         header = build_header('test', None, None, None, None,
-                None, ['output/test1', 'output/test2'])
+                None, attachments=['output/test1', 'output/test2'])
         self.assertEqual(header, 'test\n####\n' + ':attachments: output/test1, '
                 + 'output/test2\n\n')
 
     def test_galleries_added_to_markdown_header(self):
         header = build_markdown_header('test', None, None, None, None, None,
-            ['output/test1', 'output/test2'])
+            attachments=['output/test1', 'output/test2'])
         self.assertEqual(header, 'Title: test\n' + 'Attachments: output/test1, '
                 + 'output/test2\n\n')
 


### PR DESCRIPTION
The fix for accepting draft post while importing from wordpress xml file. The correct meta also added in the generated `.rst` or `.md` file.

The meta for `draft` is look like

```
Build environment for flex with eclipse
#######################################
:date: 2010-10-03 04:16
:author: admin
:category: Uncategorized
:slug: build-environment-for-flex-with-eclipse
:status: draft
```

The meta for `published` is look like

```
About
#####
:date: 2009-04-03 13:22
:author: admin
:slug: about
:status: published
```

Currently its only works with wordpress. Other import also will not break because of `status=None` in line no 452