### PR TITLE
Docs: Note how posts are published when 'draft' is default

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -505,6 +505,9 @@ publish an article before it is finished) include the status in the ``DEFAULT_ME
         'status': 'draft',
     }
 
+To publish a post when the default status is ``draft``, update the post's
+metadata to include ``Status: published``.
+
 .. _W3C ISO 8601: http://www.w3.org/TR/NOTE-datetime
 .. _AsciiDoc: http://www.methods.co.nz/asciidoc/
 .. _pelican-plugins: http://github.com/getpelican/pelican-plugins


### PR DESCRIPTION
The docs show how posts can be defaulted to "draft" mode, but not how to publish a post when your site is in this state.