### PR TITLE
Add signal: all_generators_finalized (see getpelican/pelican-plugins#314)

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -85,6 +85,7 @@ finalized                           pelican object                 invoked after
                                                                    - minifying js/css assets.
                                                                    - notify/ping search engines with an updated sitemap.
 generator_init                      generator                      invoked in the Generator.__init__
+all_generators_finalized            generators                     invoked after all the generators are executed and before writing output
 readers_init                        readers                        invoked in the Readers.__init__
 article_generator_context           article_generator, metadata
 article_generator_preread           article_generator              invoked before a article is read in ArticlesGenerator.generate_context;
@@ -137,6 +138,15 @@ request if you need them!
 
        def register():
                signals.content_object_init.connect(test, sender=contents.Article)
+
+.. warning::
+
+   Avoid ``content_object_init`` signal if you intend to read ``summary``
+   or ``content`` properties of the content object. That combination can
+   result in unresolved links when :ref:`ref-linking-to-internal-content`
+   (see `pelican-plugins bug #314`_). Use ``_summary`` and ``_content``
+   properties instead, or, alternatively, run your plugin at a later
+   stage (e.g. ``all_generators_finalized``).
 
 .. note::
 
@@ -222,3 +232,5 @@ Adding a new generator is also really easy. You might want to have a look at
         return MyGenerator
 
     signals.get_generators.connect(get_generators)
+
+.. _pelican-plugins bug #314: https://github.com/getpelican/pelican-plugins/issues/314

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -168,6 +168,8 @@ class Pelican(object):
             if hasattr(p, 'generate_context'):
                 p.generate_context()
 
+        signals.all_generators_finalized.send(generators)
+
         writer = self.get_writer()
 
         for p in generators:

--- a/pelican/signals.py
+++ b/pelican/signals.py
@@ -6,6 +6,7 @@ from blinker import signal
 
 initialized = signal('pelican_initialized')
 get_generators = signal('get_generators')
+all_generators_finalized = signal('all_generators_finalized')
 get_writer = signal('get_writer')
 finalized = signal('pelican_finalized')
 


### PR DESCRIPTION
Some plugins have used `content_object_init` signal and read `summary` or `content` properties of the content object. This resulted in internal (`{filename}`) links being unresolved. When used, this signal should hopefully mitigate that.

See also:
* https://github.com/getpelican/pelican-plugins/issues/314
* https://github.com/getpelican/pelican-plugins/pull/410