### PR TITLE
Make page status check case-insensitive

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -641,9 +641,9 @@ class PagesGenerator(CachingGenerator):
 
             self.add_source_path(page)
 
-            if page.status == "published":
+            if page.status.lower() == "published":
                 all_pages.append(page)
-            elif page.status == "hidden":
+            elif page.status.lower() == "hidden":
                 hidden_pages.append(page)
             else:
                 logger.error("Unknown status '%s' for file %s, skipping it.",


### PR DESCRIPTION
This PR changes `PagesGenerator` to perform a case-insensitive check for page `status` (closes #1620).