### PR TITLE
Format custom metadata fields.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -214,6 +214,7 @@ Setting name (followed by default value, if any)                                
                                                                                  in this list are written. Paths should be either absolute or relative
                                                                                  to the current Pelican working directory. For possible use cases see
                                                                                  :ref:`writing_only_selected_content`.
+``FORMATTED_FIELDS = ['summary']``                                               A list of metadata fields to be parsed and translated to HTML.
 ===============================================================================  =====================================================================
 
 .. [#] Default is the system locale.

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -136,13 +136,15 @@ class RstReader(BaseReader):
 
     def _parse_metadata(self, document):
         """Return the dict containing document metadata"""
+        formatted_fields = self.settings['FORMATTED_FIELDS']
+
         output = {}
         for docinfo in document.traverse(docutils.nodes.docinfo):
             for element in docinfo.children:
                 if element.tagname == 'field':  # custom fields (e.g. summary)
                     name_elem, body_elem = element.children
                     name = name_elem.astext()
-                    if name == 'summary':
+                    if name in formatted_fields:
                         value = render_node_to_html(document, body_elem)
                     else:
                         value = body_elem.astext()
@@ -205,10 +207,12 @@ class MarkdownReader(BaseReader):
 
     def _parse_metadata(self, meta):
         """Return the dict containing document metadata"""
+        formatted_fields = self.settings['FORMATTED_FIELDS']
+
         output = {}
         for name, value in meta.items():
             name = name.lower()
-            if name == "summary":
+            if name in formatted_fields:
                 # handle summary metadata as markdown
                 # summary metadata is special case and join all list values
                 summary_values = "\n".join(value)
@@ -333,7 +337,7 @@ class HTMLReader(BaseReader):
             if name is None:
                 attr_serialized = ', '.join(['{}="{}"'.format(k, v) for k, v in attrs])
                 logger.warning("Meta tag in file %s does not have a 'name' "
-                               "attribute, skipping. Attributes: %s", 
+                               "attribute, skipping. Attributes: %s",
                                self._filename, attr_serialized)
                 return
             name = name.lower()

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -133,6 +133,7 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': True,
     'AUTORELOAD_IGNORE_CACHE': False,
     'WRITE_SELECTED': [],
+    'FORMATTED_FIELDS': ['summary'],
     }
 
 PYGMENTS_RST_OPTIONS = None

--- a/pelican/tests/content/article_with_markdown_and_summary_metadata_multi.md
+++ b/pelican/tests/content/article_with_markdown_and_summary_metadata_multi.md
@@ -3,5 +3,8 @@ Date: 2012-10-31
 Summary:
     A multi-line summary should be supported
     as well as **inline markup**.
+custom_formatted_field:
+    Multi-line metadata should also be supported
+    as well as *inline markup* and stuff to "typogrify"...
 
 This is some content.

--- a/pelican/tests/content/article_with_metadata.rst
+++ b/pelican/tests/content/article_with_metadata.rst
@@ -11,3 +11,6 @@ This is a super article !
     Multi-line metadata should be supported
     as well as **inline markup** and stuff to "typogrify"...
 :custom_field: http://notmyidea.org
+:custom_formatted_field:
+    Multi-line metadata should also be supported
+    as well as *inline markup* and stuff to "typogrify"...

--- a/pelican/tests/default_conf.py
+++ b/pelican/tests/default_conf.py
@@ -39,6 +39,9 @@ STATIC_PATHS = [
     'extra/robots.txt',
     ]
 
+FORMATTED_FIELDS = ['summary', 'custom_formatted_field']
+
 # foobar will not be used, because it's not in caps. All configuration keys
 # have to be in caps
 foobar = "barbaz"
+


### PR DESCRIPTION
This patch allows the use of reStructuredText or Markdown content in metadata fields other than "summary".