### PR TITLE
Tell smartypants to also process &quot; entities

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -467,6 +467,13 @@ class Readers(FileStampDataCacher):
         # eventually filter the content with typogrify if asked so
         if self.settings['TYPOGRIFY']:
             from typogrify.filters import typogrify
+            import smartypants
+
+            # Tell `smartypants` to also replace &quot; HTML entities with
+            # smart quotes. This is necessary because Docutils has already
+            # replaced double quotes with said entities by the time we run
+            # this filter.
+            smartypants.Attr.default |= smartypants.Attr.w
 
             def typogrify_wrapper(text):
                 """Ensures ignore_tags feature is backward compatible"""

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -121,7 +121,7 @@ class RstReaderTest(ReaderTest):
             page = self.read_file(path='article.rst', TYPOGRIFY=True)
             expected = (
                 '<p><span class="caps">THIS</span> is some content. '
-                'With some stuff to&nbsp;&quot;typogrify&quot;&#8230;</p>\n'
+                'With some stuff to&nbsp;&#8220;typogrify&#8221;&#8230;</p>\n'
                 '<p>Now with added support for <abbr title="three letter '
                 'acronym"><span class="caps">TLA</span></abbr>.</p>\n')
 
@@ -146,8 +146,8 @@ class RstReaderTest(ReaderTest):
                                   TYPOGRIFY=True)
             expected = ('<p class="first last">Multi-line metadata should be'
                         ' supported\nas well as <strong>inline'
-                        ' markup</strong> and stuff to&nbsp;&quot;typogrify'
-                        '&quot;&#8230;</p>\n')
+                        ' markup</strong> and stuff to&nbsp;&#8220;typogrify'
+                        '&#8221;&#8230;</p>\n')
 
             self.assertEqual(page.metadata['summary'], expected)
         except ImportError:


### PR DESCRIPTION
This is necessary because Docutils has already replaced double quotes with `&quot;` HTML entities by the time the `typogrify` filter is applied.

This topic has recently been discussed in issue #1541.