### PR TITLE
remove useless if-condition in index template

### DIFF
--- a/pelican/themes/notmyidea/templates/index.html
+++ b/pelican/themes/notmyidea/templates/index.html
@@ -23,7 +23,7 @@
             {% endif %}
         {# other items #}
         {% else %}
-            {% if loop.first and articles_page.has_previous %}
+            {% if loop.first %}
                 <section id="content" class="body">
                     <ol id="posts-list" class="hfeed" start="{{ articles_paginator.per_page -1 }}">
             {% endif %}


### PR DESCRIPTION
useless if-condition on articles_page's attribute.

in this case, if loop.first is `True`, articles_page.has_previous() is always `True`