### PR TITLE
Add support for YAML metadata in Markdown files

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -222,9 +222,16 @@ def get_date(string):
 
     If no format matches the given date, raise a ValueError.
     """
-    string = re.sub(' +', ' ', string)
     default = SafeDatetime.now().replace(hour=0, minute=0,
                                         second=0, microsecond=0)
+    if isinstance(string, datetime.datetime):
+        # Return datetime object as SafeDatetime
+        return default.replace(year=string.year, month=string.month,
+                               day=string.day, hour=string.hour,
+                               minute=string.minute, second=string.second,
+                               microsecond=string.microsecond,
+                               tzinfo=string.tzinfo)
+    string = re.sub('[ _]+', ' ', string)
     try:
         return dateutil.parser.parse(string, default=default)
     except (TypeError, ValueError):


### PR DESCRIPTION
Meta extension from Python-Markdown>=2.6 supports YAML (Jekyll-like) headers and an optional `yaml` switch which, when used, parses data with PyYAML and hence a wee bit different metadata object gets provided. This is what I came up with. I think it may work well perhaps.

Related: https://github.com/getpelican/pelican-plugins/pull/382

~~Would YAML deserve a mention in _docs/content.rst_?~~Done.

Would additional test cases be desired? :sweat_smile: 