### PR TITLE
Change phrasing and formatting of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,48 +3,45 @@ Pelican |build-status| |coverage-status|
 
 Pelican is a static site generator, written in Python_.
 
-* Write your weblog entries directly with your editor of choice (vim!)
-  in reStructuredText_ or Markdown_
-* Includes a simple CLI tool to (re)generate the weblog
-* Easy to interface with DVCSes and web hooks
-* Completely static output is easy to host anywhere
+* Write content in reStructuredText_ or Markdown_ using your editor of choice.
+* Includes a simple command line tool to (re)generate site files.
+* Easy to interface with version control systems and web hooks.
+* Completely static output is simple to host anywhere.
+
 
 Features
 --------
 
 Pelican currently supports:
 
-* Blog articles and pages
-* Comments, via an external service (Disqus). (Please note that while
-  useful, Disqus is an external service, and thus the comment data will be
-  somewhat outside of your control and potentially subject to data loss.)
-* Theming support (themes are created using Jinja2_ templates)
-* PDF generation of the articles/pages (optional)
+* Blog articles and static pages
+* Integration with external services (ex. Google Analytics and Disqus)
+* Site themes (created using Jinja2_ templates)
 * Publication of articles in multiple languages
-* Atom/RSS feeds
-* Code syntax highlighting
-* Import from WordPress, Dotclear, or RSS feeds
-* Integration with external tools: Twitter, Google Analytics, etc. (optional)
-* Fast rebuild times thanks to content caching and selective output writing.
+* Generation of Atom and RSS feeds
+* Syntax highlighting via Pygments_
+* Importing existing content from WordPress, Dotclear, and more services
+* Fast rebuild times due to content caching and selective output writing
 
-Have a look at the `Pelican documentation`_ for more information.
+Check out `Pelican's documentation`_ for further information.
 
-Why the name "Pelican"?
------------------------
 
-"Pelican" is an anagram for *calepin*, which means "notebook" in French. ;)
+Frequently Asked Questions
+--------------------------
 
-Source code
------------
+    Why the name *Pelican*?
 
-You can access the source code at: https://github.com/getpelican/pelican
+"Pelican" is an anagram of *calepin*, which means "notebook" in French.
 
-If you feel hackish, have a look at the explanation of `Pelican's internals`_.
+    How does Pelican work under the hood?
 
-How to get help, contribute, or provide feedback
-------------------------------------------------
+Pelican's source code is `hosted on GitHub`_. If you're feeling hackish,
+take a look at `Pelican's internals`_.
+
+    How can I get help, contribute, or provide feedback?
 
 See our `contribution submission and feedback guidelines <CONTRIBUTING.rst>`_.
+
 
 .. Links
 
@@ -52,8 +49,10 @@ See our `contribution submission and feedback guidelines <CONTRIBUTING.rst>`_.
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Markdown: http://daringfireball.net/projects/markdown/
 .. _Jinja2: http://jinja.pocoo.org/
-.. _`Pelican documentation`: http://docs.getpelican.com/
+.. _Pygments: http://pygments.org/
+.. _`Pelican's documentation`: http://docs.getpelican.com/
 .. _`Pelican's internals`: http://docs.getpelican.com/en/latest/internals.html
+.. _`hosted on GitHub`: https://github.com/getpelican/pelican
 
 .. |build-status| image:: https://img.shields.io/travis/getpelican/pelican/master.svg
    :target: https://travis-ci.org/getpelican/pelican


### PR DESCRIPTION
There was some good discussion in #1065 about Pelican being a great general-purpose static site generator in addition to a solid blog generator. However, it feels like the README currently emphasizes Pelican's position as a blogging platform, which might be leading prospective users to assume that Pelican is only suitable for blogs.

I've made some changes to make the README a little more content-agnostic, and condensed the final sections into a singular, less disjointed "FAQ" section. Here's a [rendered version](https://github.com/iKevinY/pelican/tree/readme-changes) of these changes.