### PR TITLE
Make sure Content uses URLWrappers

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -53,7 +53,7 @@ class Content(object):
         self._context = context
         self.translations = []
 
-        local_metadata = dict(settings['DEFAULT_METADATA'])
+        local_metadata = dict()
         local_metadata.update(metadata)
 
         # set metadata as attributes
@@ -166,21 +166,13 @@ class Content(object):
         """Returns the URL, formatted with the proper values"""
         metadata = copy.copy(self.metadata)
         path = self.metadata.get('path', self.get_relative_source_path())
-        default_category = self.settings['DEFAULT_CATEGORY']
-        slug_substitutions = self.settings.get('SLUG_SUBSTITUTIONS', ())
         metadata.update({
             'path': path_to_url(path),
             'slug': getattr(self, 'slug', ''),
             'lang': getattr(self, 'lang', 'en'),
             'date': getattr(self, 'date', SafeDatetime.now()),
-            'author': slugify(
-                getattr(self, 'author', ''),
-                slug_substitutions
-            ),
-            'category': slugify(
-                getattr(self, 'category', default_category),
-                slug_substitutions
-            )
+            'author': self.author.slug if hasattr(self, 'author') else '',
+            'category': self.category.slug if hasattr(self, 'category') else ''
         })
         return metadata
 

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -537,6 +537,10 @@ def find_empty_alt(content, path):
 def default_metadata(settings=None, process=None):
     metadata = {}
     if settings:
+        for name, value in dict(settings.get('DEFAULT_METADATA', {})).items():
+            if process:
+                value = process(name, value)
+            metadata[name] = value
         if 'DEFAULT_CATEGORY' in settings:
             value = settings['DEFAULT_CATEGORY']
             if process:

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -8,7 +8,7 @@ import os.path
 
 from pelican.tests.support import unittest, get_settings
 
-from pelican.contents import Page, Article, Static, URLWrapper
+from pelican.contents import Page, Article, Static, URLWrapper, Author, Category
 from pelican.settings import DEFAULT_CONFIG
 from pelican.utils import path_to_url, truncate_html_words, SafeDatetime, posix_join
 from pelican.signals import content_object_init
@@ -33,7 +33,7 @@ class TestPage(unittest.TestCase):
             'metadata': {
                 'summary': TEST_SUMMARY,
                 'title': 'foo bar',
-                'author': 'Blogger',
+                'author': Author('Blogger', DEFAULT_CONFIG),
             },
             'source_path': '/path/to/file/foo.ext'
         }
@@ -374,7 +374,8 @@ class TestPage(unittest.TestCase):
         content = Page(**args)
         assert content.authors == [content.author]
         args['metadata'].pop('author')
-        args['metadata']['authors'] = ['First Author', 'Second Author']
+        args['metadata']['authors'] = [Author('First Author', DEFAULT_CONFIG),
+                                       Author('Second Author', DEFAULT_CONFIG)]
         content = Page(**args)
         assert content.authors
         assert content.author == content.authors[0]
@@ -396,8 +397,8 @@ class TestArticle(TestPage):
         settings['ARTICLE_URL'] = '{author}/{category}/{slug}/'
         settings['ARTICLE_SAVE_AS'] = '{author}/{category}/{slug}/index.html'
         article_kwargs = self._copy_page_kwargs()
-        article_kwargs['metadata']['author'] = "O'Brien"
-        article_kwargs['metadata']['category'] = 'C# & stuff'
+        article_kwargs['metadata']['author'] = Author("O'Brien", settings)
+        article_kwargs['metadata']['category'] = Category('C# & stuff', settings)
         article_kwargs['metadata']['title'] = 'fnord'
         article_kwargs['settings'] = settings
         article = Article(**article_kwargs)

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -5,7 +5,7 @@ import locale
 from pelican.tests.support import unittest, get_settings
 
 from pelican.paginator import Paginator
-from pelican.contents import Article
+from pelican.contents import Article, Author
 from pelican.settings import DEFAULT_CONFIG
 from jinja2.utils import generate_lorem_ipsum
 
@@ -26,7 +26,6 @@ class TestPage(unittest.TestCase):
             'metadata': {
                 'summary': TEST_SUMMARY,
                 'title': 'foo bar',
-                'author': 'Blogger',
             },
             'source_path': '/path/to/file/foo.ext'
         }
@@ -49,6 +48,7 @@ class TestPage(unittest.TestCase):
             key=lambda r: r[0],
         )
 
+        self.page_kwargs['metadata']['author'] = Author('Blogger', settings)
         object_list = [Article(**self.page_kwargs), Article(**self.page_kwargs)]
         paginator = Paginator('foobar.foo', object_list, settings)
         page = paginator.page(1)


### PR DESCRIPTION
This cleans up pre-`URLWrapper` code/logic:

 * `Content.url_format` was sluggify-ing `Author` and `Category` whereas it could've used the `.slug` attribute (see #1547). It was unnecessary computation and was causing issues if you wanted to use custom slugs (via plugins) for those. It now uses `.slug`
 * `DEFAULT_METADATA` was able to put un-processed values as metadata (see #1542).  It is now processed like any other metadata before it's used.
 * Some tests were providing plain strings in place of `URLWrapper` objects for metadata like `Author` and `Category`. They are changed to `URLWrapper` objects.

So, this fixes #1547 and #1542. And coincidentally provides a solution for #1464, because you can now do:

    DEFAULT_METADATA = {'date': '2015-03-06'}