### PR TITLE
Support semicolon-separated author/tag lists

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -35,6 +35,12 @@ this metadata in text files via the following syntax (give your file the
     :authors: Alexis Metaireau, Conan Doyle
     :summary: Short version for index and feeds
 
+Author and tag lists may be semicolon-separated instead, which allows
+you to write authors and tags containing commas::
+
+    :tags: pelican, publishing tool; pelican, bird
+    :authors: Metaireau, Alexis; Doyle, Conan
+
 Pelican implements an extension to reStructuredText to enable support for the
 ``abbr`` HTML tag. To use it, write something like this in your post::
 

--- a/pelican/tests/content/article_with_multiple_authors_list.rst
+++ b/pelican/tests/content/article_with_multiple_authors_list.rst
@@ -1,0 +1,10 @@
+This is an article with multiple authors in list format!
+########################################################
+
+:date: 2014-02-09 02:20
+:modified: 2014-02-09 02:20
+:authors: - Author, First
+          - Author, Second
+
+The author names are in last,first form to verify that
+they are not just getting split on commas.

--- a/pelican/tests/content/article_with_multiple_authors_semicolon.rst
+++ b/pelican/tests/content/article_with_multiple_authors_semicolon.rst
@@ -1,0 +1,6 @@
+This is an article with multiple authors in lastname, firstname format!
+#######################################################################
+
+:date: 2014-02-09 02:20
+:modified: 2014-02-09 02:20
+:authors: Author, First; Author, Second

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -162,6 +162,8 @@ class TestArticlesGenerator(unittest.TestCase):
              'article'],
             ['This is an article with multiple authors!', 'published', 'Default', 'article'],
             ['This is an article with multiple authors!', 'published', 'Default', 'article'],
+            ['This is an article with multiple authors in list format!', 'published', 'Default', 'article'],
+            ['This is an article with multiple authors in lastname, firstname format!', 'published', 'Default', 'article'],
             ['This is an article without category !', 'published', 'Default',
              'article'],
             ['This is an article without category !', 'published',
@@ -348,11 +350,11 @@ class TestArticlesGenerator(unittest.TestCase):
     def test_generate_authors(self):
         """Check authors generation."""
         authors = [author.name for author, _ in self.generator.authors]
-        authors_expected = sorted(['Alexis Métaireau', 'First Author', 'Second Author'])
+        authors_expected = sorted(['Alexis Métaireau', 'Author, First', 'Author, Second', 'First Author', 'Second Author'])
         self.assertEqual(sorted(authors), authors_expected)
         # test for slug
         authors = [author.slug for author, _ in self.generator.authors]
-        authors_expected = ['alexis-metaireau', 'first-author', 'second-author']
+        authors_expected = ['alexis-metaireau', 'author-first', 'author-second', 'first-author', 'second-author']
         self.assertEqual(sorted(authors), sorted(authors_expected))
 
     @unittest.skipUnless(MagicMock, 'Needs Mock module')
@@ -441,6 +443,7 @@ class TestArticlesGenerator(unittest.TestCase):
 
         authors = sorted([author.name for author, _ in generator.authors])
         authors_expected = sorted(['Alexis Métaireau', 'Blogger',
+                                   'Author, First', 'Author, Second',
                                    'First Author', 'Second Author'])
         self.assertEqual(authors, authors_expected)
 

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -324,6 +324,23 @@ class RstReaderTest(ReaderTest):
 
         self.assertDictHasSubset(page.metadata, expected)
 
+    def test_article_with_multiple_authors_semicolon(self):
+        page = self.read_file(
+            path='article_with_multiple_authors_semicolon.rst')
+        expected = {
+            'authors': ['Author, First', 'Author, Second']
+        }
+
+        self.assertDictHasSubset(page.metadata, expected)
+
+    def test_article_with_multiple_authors_list(self):
+        page = self.read_file(path='article_with_multiple_authors_list.rst')
+        expected = {
+            'authors': ['Author, First', 'Author, Second']
+        }
+
+        self.assertDictHasSubset(page.metadata, expected)
+
 @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
 class MdReaderTest(ReaderTest):
 


### PR DESCRIPTION
Idea borrowed from Docutils.  This allows one to write author lists in
lastname,firstname format.  The code change also means that readers with
fancy metadata that can natively represent lists (e.g. Docutils itself,
or MD-Yaml) don't have to merge 'em back together for process_metadata's
sake.