### PR TITLE
Add Org support *in* existing base readers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
-recursive-include pelican *.html *.css *png *.in *.rst *.md *.mkd *.xml *.py
+recursive-include pelican *.html *.css *png *.in *.rst *.md *.mkd *.xml *.py *.markdown
 include LICENSE THANKS docs/changelog.rst

--- a/pelican/pandoc_templates/md_org_template.markdown
+++ b/pelican/pandoc_templates/md_org_template.markdown
@@ -2,11 +2,10 @@ $if(title)$Title: $title$$endif$
 $for(author)$Author: $author$$endfor$
 $if(date)$Date: $date$$endif$
 $if(category)$Category: $category$$endif$
-$if(modified)$Modified: $modified$$endif$
-$if(slug)$Slug: $slug$$endif$
 $if(summary)$Summary: $summary$$endif$
-$if(modified)$Modified: $modified$$endif$
+$if(slug)$Slug: $slug$$endif$
 $for(tags)$Tags: $tags$$endfor$
+$if(modified)$Modified: $modified$$endif$
 $if(toc)$ $toc$$endif$
 $body$
 $for(include-after)$$include-after$$endfor$

--- a/pelican/pandoc_templates/md_org_template.markdown
+++ b/pelican/pandoc_templates/md_org_template.markdown
@@ -1,0 +1,12 @@
+$if(title)$Title: $title$$endif$
+$for(author)$Author: $author$$endfor$
+$if(date)$Date: $date$$endif$
+$if(category)$Category: $category$$endif$
+$if(modified)$Modified: $modified$$endif$
+$if(slug)$Slug: $slug$$endif$
+$if(summary)$Summary: $summary$$endif$
+$if(modified)$Modified: $modified$$endif$
+$for(tags)$Tags: $tags$$endfor$
+$if(toc)$ $toc$$endif$
+$body$
+$for(include-after)$$include-after$$endfor$

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -25,7 +25,7 @@ except ImportError:
 try:
     import pypandoc
 except ImportError:
-    pandoc = False  # NOQA
+    pypandoc = False  # NOQA
 from six.moves.html_parser import HTMLParser
 
 from pelican import signals
@@ -91,7 +91,7 @@ class _FieldBodyTranslator(HTMLTranslator):
 
     def depart_field_body(self, node):
         pass
-
+    
 
 def render_node_to_html(document, node):
     visitor = _FieldBodyTranslator(document)
@@ -246,10 +246,15 @@ class MarkdownReader(BaseReader):
         with pelican_open(source_path) as text:
             if self._source_path[-4:] == '.org' and \
                self.enable_pypandoc is True:
-                pandoc_data_dir = '='.join(['--data-dir', pkg_resources.resource_filename('pelican', 'pandoc_templates')])
+                pandoc_data_dir = '='.join(['--data-dir',
+                                            pkg_resources.resource_filename(
+                                                'pelican', 'pandoc_templates')])
+                logger.info('Using %s as pandoc_data_dir',
+                            pandoc_data_dir)
                 text = pypandoc.convert(text, 'markdown', \
                                         format='org',\
-                                        extra_args=['--template=md_org_template.markdown', pandoc_data_dir])
+                                        extra_args=['--template=md_org_template.markdown',
+                                                    pandoc_data_dir])
             content = self._md.convert(text)
 
         metadata = self._parse_metadata(self._md.Meta)

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -135,7 +135,6 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': True,
     'AUTORELOAD_IGNORE_CACHE': False,
     'WRITE_SELECTED': [],
-    'PANDOC_TEMPLATES_PATH': ['pandoc_templates'],
     }
 
 PYGMENTS_RST_OPTIONS = None

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -135,6 +135,7 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': True,
     'AUTORELOAD_IGNORE_CACHE': False,
     'WRITE_SELECTED': [],
+    'PANDOC_TEMPLATES_PATH': ['pandoc_templates'],
     }
 
 PYGMENTS_RST_OPTIONS = None

--- a/pelican/tests/content/article_with_org_extension.org
+++ b/pelican/tests/content/article_with_org_extension.org
@@ -1,0 +1,143 @@
+#+Title: test org in md reader
+#+Date: 2014-01-26
+#+Author: Joth
+#+Category: pelican
+#+Tags: pelican readers, pypandoc
+#+Slug: test-org-md-reader
+#+Summary: Testing org reader
+#+OPTIONS: H:2
+#+OPTIONS: toc:2
+#+TOC: headlines 2
+
+* Org Metadata
+
+The following metadata are exporting properly
+
+#+begin_src 
+#+Title: test org in md reader
+#+Date: 2014-01-26
+#+Author: Joth
+#+Category: pelican
+#+end_src
+
+These metadata are not exporting properly. It may be in the
+pandoc template. It may be in the pandoc convert call.
+
+#+begin_src 
+#+Tags: pelican readers, pypandoc
+#+Slug: test-org-md-reader
+#+Summary: Testing org reader
+#+OPTIONS: toc:2
+#+TOC: headlines 2
+#+end_src
+
+
+* Markup
+
+Quotes
+#+BEGIN_QUOTE
+Everything should be made as simple as possible,
+but not any simpler -- Albert Einstein
+#+END_QUOTE
+
+are included with
+#+begin_src 
+#+BEGIN_QUOTE
+...
+#+END_QUOTE
+#+end_src
+
+Centred text and verse are not working in markdown export.
+
+#+begin_src 
+#+BEGIN_CENTER
+...
+#+END_CENTER
+#+end_src
+
+
+* Fonts
+
+*bold* =*bold*=
+
+/italic/ =/italic/=
+
+_underlined_ =_underlined_=
+
+=verbatim= ~=verbatim=~
+
+ ~code~ =~code~=
+
++strike-through+ =+strike-through+=
+
+
+* Code
+
+#+begin_src python :noeval
+class BaseReader(object):
+    """Base class to read files.
+
+    This class is used to process static files, and it can be inherited for
+    other types of file. A Reader class must have the following attributes:
+
+    - enabled: (boolean) tell if the Reader class is enabled. It
+      generally depends on the import of some dependency.
+    - file_extensions: a list of file extensions that the Reader will process.
+    - extensions: a list of extensions to use in the reader (typical use is
+      Markdown).
+
+    """
+    enabled = True
+    file_extensions = ['static']
+    extensions = None
+
+    def __init__(self, settings):
+        self.settings = settings
+
+    def process_metadata(self, name, value):
+        if name in METADATA_PROCESSORS:
+            return METADATA_PROCESSORS[name](value, self.settings)
+        return value
+
+    def read(self, source_path):
+        "No-op parser"
+        content = None
+        metadata = {}
+        return content, metadata
+#+end_src
+
+
+* Tables
+
+Not working nicely. They work with pandoc to rst.
+
+| header 1 | header 2 |
+|----------+----------|
+| and      | with     |
+| a        | two      |
+| table    | columns  |
+
+
+* Misc
+
+Five or more dashes make a line 
+
+------
+
+ # lines with whitespace infront of '# ' will be treated as comments
+
+#+begin_src sh
+ # lines with whitespace infront of '# ' will be treated as comments
+#+end_src
+
+
+* Alternatives and TODOs
+  - implement as plugin?
+    - org is amazin markup language, i like it native...
+  - do the org text to html with pandoc instead of markdown
+  - use Rst/html classes
+  - dedicated org class
+  - specify in SETTINGS which reader subclass to use for org files
+  - fix tables
+  - images example
+  - tests


### PR DESCRIPTION
I wanted to throw this into the public sphere to get some feedback/thoughts.

I've been interesting in blogging using pelican and [org-mode](http://orgmode.org/). In fact, I [http://jotham-city.com/blog/2015/03/21/adding-yasnippets-snippets/](have) done so. Orgmode is a great tool for writing and I suspect it has many users who would appreciate native support for it in pelican.

I know additional readers are supposed to be implemented as plugins. One such solution has be created for [org documents](https://github.com/getpelican/pelican-plugins/blob/master/org_reader/org_reader.py). It invokes emacs to generate html from org documents. This (subjectively) strikes me as a bit breakage prone and harder to get more people started with pelican and org-mode. In contrast, I think using pandoc would be a bit more robust and accessible. The option to use various markup standards is also available, making it more flexible.  Additionally, it's not an additional reader as implemented here, but a 'helper' to the base readers, if you will. That said, the exact motivation for keeping additional readers out of the main library are not known to me.

What does the pelican dev community think about building in org support to the main library? 
Even if the thoughts are overwhelmingly, "no!"; I have a few thoughts about the implementation I'm using in this PR which would be interesting to get some feedback on.

- what if there were an option for which standard reader to use for org files, i.e. which intermediate format to convert the org files to? rst, markdown. My preference is to avoid converting it to html thinking it may results in some wierd artefacts 
- would additional tests are needed to make this implementation solid?
- ideas for improving this implentation?

Still to do:
- fix pandoc template has to be in pelican site root (i.e. at the level of content/)

Thanks!

