### PR TITLE
Make `pelican.server` importable and use it in `fab serve`

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -61,10 +61,10 @@ Preview your site
 -----------------
 
 Open a new terminal session and run the following commands to switch to your
-``output`` directory and launch Python's built-in web server::
+``output`` directory and launch Pelican's web server::
 
     cd ~/projects/yoursite/output
-    python -m SimpleHTTPServer # -m http.server if you use python3
+    python -m pelican.server
 
 Preview your site by navigating to http://localhost:8000/ in your browser.
 

--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -3,8 +3,9 @@ import fabric.contrib.project as project
 import os
 import shutil
 import sys
-import SimpleHTTPServer
 import SocketServer
+
+from pelican.server import ComplexHTTPRequestHandler
 
 # Local path configuration (can be absolute or relative to fabfile)
 env.deploy_path = 'output'
@@ -51,7 +52,7 @@ def serve():
     class AddressReuseTCPServer(SocketServer.TCPServer):
         allow_reuse_address = True
 
-    server = AddressReuseTCPServer(('', PORT), SimpleHTTPServer.SimpleHTTPRequestHandler)
+    server = AddressReuseTCPServer(('', PORT), ComplexHTTPRequestHandler)
 
     sys.stderr.write('Serving on port {0} ...\n'.format(PORT))
     server.serve_forever()


### PR DESCRIPTION
`fab serve` and `make devserver` use different HTTP Handlers and as a
result they behave differently. This makes sure `fab serve` also uses
the Handler defined in `pelican.server` in order to get rid of the
inconsistency.