### PR TITLE
[DOCS] fix broken refs

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -367,7 +367,7 @@ source_path             Full system path of the article source file.
 status                  The article status, can be any of 'published' or
                         'draft'.
 summary                 Rendered summary content.
-tags                    List of :ref:`Tag <object-author_cat_tab>`
+tags                    List of :ref:`Tag <object-author_cat_tag>`
                         objects.
 template                Template name to use for rendering.
 title                   Title of the article.
@@ -422,7 +422,7 @@ source_path             Full system path of the page source file.
 status                  The page status, can be any of 'published' or
                         'draft'.
 summary                 Rendered summary content.
-tags                    List of :ref:`Tag <object-author_cat_tab>`
+tags                    List of :ref:`Tag <object-author_cat_tag>`
                         objects.
 template                Template name to use for rendering.
 title                   Title of the page.


### PR DESCRIPTION
/home/winlu/gitrepos/pelican/docs/themes.rst:374: WARNING: undefined label: object-author_cat_tab (if the link has no caption the label must precede a section header)
/home/winlu/gitrepos/pelican/docs/themes.rst:429: WARNING: undefined label: object-author_cat_tab (if the link has no caption the label must precede a section header)

Another case of PR + merge without even trying to build the docs.