### PR TITLE
Test docs via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
+env:
+  - TOX_ENV=docs
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
 addons:
   apt_packages:
     - pandoc
@@ -10,13 +13,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo locale-gen fr_FR.UTF-8 tr_TR.UTF-8
 install:
-  - pip install .
-  - pip install -r dev_requirements.txt
-  - pip install nose-cov
-script: nosetests -sv --with-coverage --cover-package=pelican pelican
-after_success:
-  - pip install coveralls
-  - coveralls
+  - pip install tox
+script: tox -e $TOX_ENV
 notifications:
   irc:
     channels:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -10,6 +10,3 @@ typogrify
 # To perform release
 bumpr==0.2.0
 wheel
-
-# For docs theme
-sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,28 @@
-# This tests the unified codebase (py27, py33) of Pelican.
-# depends on some external libraries that aren't released yet.
-
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,docs
 
 [testenv]
-commands =
-    python -m unittest discover
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+usedevelop=True
 deps =
     -rdev_requirements.txt
+    nose
+    nose-cov
+    coveralls
+
+commands =
+    {envpython} --version
+    nosetests -sv --with-coverage --cover-package=pelican pelican
+    coveralls
+
+[testenv:docs]
+basepython = python2.7
+deps =
+    sphinx
+    sphinx_rtd_theme
+changedir = docs
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
this is a followup PR to the issue I raised earlier this week #1688

to handle the additional environment we have to utilize tox more than we did until now and let travis only do the main container spawning.

* move build environment into tox
* add new environment installing sphinx and testing for doc errors
* reorganize dependency installs for easier management

TODO:
-   [x] check for build errors in docs
-   [x] ~~check if docs need an update~~ -> no additions needed in my opinion
-   [x] ~~include move to container based travis testing (http://docs.travis-ci.com/user/workers/container-based-infrastructure/)~~ -> would need move of importer to pelican tools repo first