### PR TITLE
add skips for tests relying on dev_requirements modules

### DIFF
--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -6,7 +6,10 @@ from codecs import open
 try:
     from unittest.mock import MagicMock
 except ImportError:
-    from mock import MagicMock
+    try:
+        from mock import MagicMock
+    except ImportError:
+        MagicMock = False
 from shutil import rmtree
 from tempfile import mkdtemp
 
@@ -112,6 +115,7 @@ class TestArticlesGenerator(unittest.TestCase):
         return [[article.title, article.status, article.category.name,
                  article.template] for article in articles]
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_generate_feeds(self):
         settings = get_settings()
         settings['CACHE_PATH'] = self.temp_cache
@@ -215,6 +219,7 @@ class TestArticlesGenerator(unittest.TestCase):
         categories_expected = ['default', 'yeah', 'test', 'zhi-dao-shu']
         self.assertEqual(sorted(categories), sorted(categories_expected))
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_direct_templates_save_as_default(self):
 
         settings = get_settings(filenames={})
@@ -228,6 +233,7 @@ class TestArticlesGenerator(unittest.TestCase):
                                  generator.get_template("archives"), settings,
                                  blog=True, paginated={}, page_name='archives')
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_direct_templates_save_as_modified(self):
 
         settings = get_settings()
@@ -244,6 +250,7 @@ class TestArticlesGenerator(unittest.TestCase):
                                  blog=True, paginated={},
                                  page_name='archives/index')
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_direct_templates_save_as_false(self):
 
         settings = get_settings()
@@ -268,6 +275,7 @@ class TestArticlesGenerator(unittest.TestCase):
         self.assertIn(custom_template, self.articles)
         self.assertIn(standard_template, self.articles)
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_period_in_timeperiod_archive(self):
         """
         Test that the context of a generated period_archive is passed
@@ -347,6 +355,7 @@ class TestArticlesGenerator(unittest.TestCase):
         authors_expected = ['alexis-metaireau', 'first-author', 'second-author']
         self.assertEqual(sorted(authors), sorted(authors_expected))
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_article_object_caching(self):
         """Test Article objects caching at the generator level"""
         settings = get_settings(filenames={})
@@ -367,6 +376,7 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_context()
         generator.readers.read_file.assert_called_count == 0
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_reader_content_caching(self):
         """Test raw content caching at the reader level"""
         settings = get_settings(filenames={})
@@ -389,6 +399,7 @@ class TestArticlesGenerator(unittest.TestCase):
         for reader in readers.values():
             reader.read.assert_called_count == 0
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_ignore_cache(self):
         """Test that all the articles are read again when not loading cache
 
@@ -492,6 +503,7 @@ class TestPageGenerator(unittest.TestCase):
         self.assertEqual(sorted(pages_expected), sorted(pages))
         self.assertEqual(sorted(hidden_pages_expected), sorted(hidden_pages))
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_page_object_caching(self):
         """Test Page objects caching at the generator level"""
         settings = get_settings(filenames={})
@@ -512,6 +524,7 @@ class TestPageGenerator(unittest.TestCase):
         generator.generate_context()
         generator.readers.read_file.assert_called_count == 0
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_reader_content_caching(self):
         """Test raw content caching at the reader level"""
         settings = get_settings(filenames={})
@@ -534,6 +547,7 @@ class TestPageGenerator(unittest.TestCase):
         for reader in readers.values():
             reader.read.assert_called_count == 0
 
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_ignore_cache(self):
         """Test that all the pages are read again when not loading cache
 

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -26,6 +26,12 @@ try:
 except ImportError:
     BeautifulSoup = False  # NOQA
 
+try:
+    import bs4.builder._lxml as LXML
+except ImportError:
+    LXML = False
+
+
 
 @skipIfNoExecutable(['pandoc', '--version'])
 @unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')
@@ -302,6 +308,7 @@ class TestBuildHeader(unittest.TestCase):
 
 
 @unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')
+@unittest.skipUnless(LXML, 'Needs lxml module')
 class TestWordpressXMLAttachements(unittest.TestCase):
     def setUp(self):
         self.old_locale = locale.setlocale(locale.LC_ALL)

--- a/pelican/tests/test_rstdirectives.py
+++ b/pelican/tests/test_rstdirectives.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function
-
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    try:
+        from mock import Mock
+    except ImportError:
+        Mock = False
 from pelican.tests.support import unittest
 
+@unittest.skipUnless(Mock, 'Needs Mock module')
 class Test_abbr_role(unittest.TestCase):
     def call_it(self, text):
         from pelican.rstdirectives import abbr_role


### PR DESCRIPTION
add skips for tests relying on non dependency modules in 
* test_generators.py
* test_importer.py
* test_rstdirectives.py