### PR TITLE
Clarify phrasing in quickstart documentation

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -49,7 +49,7 @@ Given that this example article is in Markdown format, save it as
 Generate your site
 ------------------
 
-From your project directory, run the ``pelican`` command to generate your site::
+From your site directory, run the ``pelican`` command to generate your site::
 
     pelican content
 


### PR DESCRIPTION
The quickstart was worded confusingly - it said "from your project directory", which implied doing a `cd ..` down to the `projects` dir, which would cause `pelican content` to fail. In fact, you need to be in the `yoursite` directory, which is the directory that has the `content` directory in it.