### PR TITLE
Fixes #1695: replace `map` with list comprehension for py3 compatibility

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -162,7 +162,7 @@ def ask(question, answer=str_compat, default=None, l=None):
 
 def ask_timezone(question, default, tzurl):
     """Prompt for time zone and validate input"""
-    lower_tz = map(str.lower, pytz.all_timezones)
+    lower_tz = [tz.lower() for tz in pytz.all_timezones]
     while True:
         r = ask(question, str_compat, default)
         r = r.strip().replace(' ', '_').lower()


### PR DESCRIPTION
`map` returns a list in Py2 but a custom object in Py3 which breaks timezone question in `pelican-quickstart` for Py3 (see #1695).