### PR TITLE
remove tag_cloud from core

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -241,3 +241,12 @@ purposes. This can be achieved by explicitly specifying only the
 filenames of those articles in ``ARTICLE_PATHS``. A list of such
 filenames could be found using a command similar to ``cd content;
 find -name '*.md' | head -n 10``.
+
+My tag-cloud is missing/broken since I upgraded Pelican
+=======================================================
+
+In an ongoing effort to steamline Pelican, `tag_cloud` generation has been
+moved out of the pelican core and into a separate `plugin
+<https://github.com/getpelican/pelican-plugins/tree/master/tag_cloud>`_.
+See the :ref:`plugins` documentation further information about the
+Pelican plugin system.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -620,53 +620,6 @@ This would cause the first page to be written to
 ``page/{number}`` directories.
 
 
-Tag cloud
-=========
-
-If you want to generate a tag cloud with all your tags, you can do so using the
-following settings.
-
-================================================    =====================================================
-Setting name (followed by default value)            What does it do?
-================================================    =====================================================
-``TAG_CLOUD_STEPS = 4``                             Count of different font sizes in the tag
-                                                    cloud.
-``TAG_CLOUD_MAX_ITEMS = 100``                       Maximum number of tags in the cloud.
-================================================    =====================================================
-
-The default theme does not include a tag cloud, but it is pretty easy to add one::
-
-    <ul class="tagcloud">
-        {% for tag in tag_cloud %}
-            <li class="tag-{{ tag.1 }}"><a href="{{ SITEURL }}/{{ tag.0.url }}">{{ tag.0 }}</a></li>
-        {% endfor %}
-    </ul>
-
-You should then also define CSS styles with appropriate classes (tag-1 to tag-N,
-where N matches ``TAG_CLOUD_STEPS``), tag-1 being the most frequent, and
-define a ``ul.tagcloud`` class with appropriate list-style to create the cloud.
-For example::
-
-    ul.tagcloud {
-      list-style: none;
-        padding: 0;
-    }
-
-    ul.tagcloud li {
-        display: inline-block;
-    }
-
-    li.tag-1 {
-        font-size: 150%;
-    }
-
-    li.tag-2 {
-        font-size: 120%;
-    }
-
-    ...
-
-
 Translations
 ============
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals, print_function
 
 import os
 import six
-import math
-import random
 import logging
 import shutil
 import fnmatch
@@ -14,7 +12,7 @@ from codecs import open
 from collections import defaultdict
 from functools import partial
 from itertools import chain, groupby
-from operator import attrgetter, itemgetter
+from operator import attrgetter
 
 from jinja2 import (Environment, FileSystemLoader, PrefixLoader, ChoiceLoader,
                     BaseLoader, TemplateNotFound)
@@ -552,32 +550,6 @@ class ArticlesGenerator(CachingGenerator):
         self.dates.sort(key=attrgetter('date'),
                         reverse=self.context['NEWEST_FIRST_ARCHIVES'])
 
-        # create tag cloud
-        tag_cloud = defaultdict(int)
-        for article in self.articles:
-            for tag in getattr(article, 'tags', []):
-                tag_cloud[tag] += 1
-
-        tag_cloud = sorted(tag_cloud.items(), key=itemgetter(1), reverse=True)
-        tag_cloud = tag_cloud[:self.settings.get('TAG_CLOUD_MAX_ITEMS')]
-
-        tags = list(map(itemgetter(1), tag_cloud))
-        if tags:
-            max_count = max(tags)
-        steps = self.settings.get('TAG_CLOUD_STEPS')
-
-        # calculate word sizes
-        self.tag_cloud = [
-            (
-                tag,
-                int(math.floor(steps - (steps - 1) * math.log(count)
-                    / (math.log(max_count)or 1)))
-            )
-            for tag, count in tag_cloud
-        ]
-        # put words in chaos
-        random.shuffle(self.tag_cloud)
-
         # and generate the output :)
 
         # order the categories per name
@@ -589,7 +561,7 @@ class ArticlesGenerator(CachingGenerator):
         self.authors.sort()
 
         self._update_context(('articles', 'dates', 'tags', 'categories',
-                              'tag_cloud', 'authors', 'related_posts'))
+                              'authors', 'related_posts'))
         self.save_cache()
         self.readers.save_cache()
         signals.article_generator_finalized.send(self)

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -93,8 +93,6 @@ DEFAULT_CONFIG = {
     'DAY_ARCHIVE_SAVE_AS': '',
     'RELATIVE_URLS': False,
     'DEFAULT_LANG': 'en',
-    'TAG_CLOUD_STEPS': 4,
-    'TAG_CLOUD_MAX_ITEMS': 100,
     'DIRECT_TEMPLATES': ['index', 'tags', 'categories', 'authors', 'archives'],
     'EXTRA_TEMPLATES_PATHS': [],
     'PAGINATED_DIRECT_TEMPLATES': ['index'],


### PR DESCRIPTION
As discussed in #1598 and #1566 this breaks out tag cloud creation into a plugin, for which there is a PR in the [pelican-plugins repo](https://github.com/getpelican/pelican-plugins/pull/470).

- [x] remove tag_cloud from core
- [x] add tag_cloud to pelican-plugins
- [x] add deprecation warnings that tag clouds are not available without plugin



