### PR TITLE
HOTFIX #1690

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo locale-gen fr_FR.UTF-8 tr_TR.UTF-8
 install:
-  - pip install tox
+  - pip install tox==1.9.2
 script: tox -e $TOX_ENV
 notifications:
   irc:


### PR DESCRIPTION
it seems tox 2 released and breaks how ENV gets handled, this fixes #1690's build errors by specifying a tox version to install.