### PR TITLE
Fix for stopping devserver

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -92,8 +92,7 @@ else
 endif
 
 stopserver:
-	kill -9 `cat pelican.pid`
-	kill -9 `cat srv.pid`
+	$(BASEDIR)/develop_server.sh stop
 	@echo 'Stopped Pelican and SimpleHTTPServer processes running in background.'
 
 publish:


### PR DESCRIPTION
When running `make devserver` and then running `make stopserver` it doesn't stop the server. This patch fixes that.