### PR TITLE
RST example in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,6 +46,21 @@ text editor to create your first article with the following content::
 Given that this example article is in Markdown format, save it as
 ``~/projects/yoursite/content/keyboard-review.md``.
 
+Alternatively, here is the same article in reStructuredText format::
+
+    ###############
+    My First Review
+    ###############
+
+    :date: 2010-12-03 10:20
+    :category: Review
+    :author: your_name
+    :summary: first review on site.
+
+    Following is a review of my favorite mechanical keyboard.
+
+Save the file as ``~/projects/yoursite/content/keyboard-review.rst``.
+
 Generate your site
 ------------------
 


### PR DESCRIPTION
The quickstart tutorial in our docs does not have any examples in reStructuredText format. This is to add it in alongside the existing Markdown one.