### PR TITLE
Fix exception logging

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -444,7 +444,6 @@ def main():
 
                 except Exception as e:
                     if (args.verbosity == logging.DEBUG):
-                        logger.critical('Internal failure: %r', e, exc_info=True)
                         raise
                     logger.warning(
                         'Caught exception "%s". Reloading.', e)

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -149,7 +149,7 @@ class SafeLogger(logging.Logger):
         so convert the message to unicode with the correct encoding
         '''
         if isinstance(arg, Exception):
-            text = str(arg)
+            text = '%s: %s' % (arg.__class__.__name__, arg)
             if six.PY2:
                 text = text.decode(self._exc_encoding)
             return text


### PR DESCRIPTION
Adds exception type to the exception logging.
Removes the extra logging for autoreload in debug mode, since `raise`
will make it caught by the global `try/except` below and it'll be
logged there.

This replaces #1723 and also removes extra exception logging caused
in #1718.