### PR TITLE
[WIP] cache versioning

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -25,7 +25,7 @@ from pelican.settings import read_settings
 from pelican.utils import clean_output_dir, folder_watcher, file_watcher
 from pelican.writers import Writer
 
-__version__ = "3.5.0"
+__version__ = "3.6.0.dev"
 
 DEFAULT_CONFIG_NAME = 'pelicanconf.py'
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -375,3 +375,22 @@ def configure_settings(settings):
             logger.warning(message)
 
     return settings
+
+def settings_check_equal(s1, s2, ignored_keys=set(['filenames'])):
+    '''
+    checks if two configurations are equal
+
+    used to determine if cache needs to be invalidated
+    '''
+    s1_keys = set(s1.keys()) - ignored_keys
+    s2_keys = set(s2.keys()) - ignored_keys
+    intersect_keys = s1_keys.intersection(s2_keys)
+
+    if not s1_keys == s2_keys:
+        return False
+
+    for o in intersect_keys:
+        if not s1[o] == s2[o]:
+            return False
+
+    return True


### PR DESCRIPTION
if pelican is updated, the cache should be invalidated automatically


# Todo
- [x] ~~break out caching from utils into seperate module~~
      - [x] ~~break out caching classes into `cache.py`~~
      - [x] ~~move caching tests to `test_cache.py`~~
      - [x] ~~cleanup unneeded / duplicate code after move~~
- [x] ~~fix existing cache tests and remove `assert_called_count` which does not seem to be part of mock anymore~~
- [x] ~~use cPickle instead of pickle for increased speed~~
- [x] ~~set pelican's version to 3.6.0.dev or something so master branch installs don't get the same treatment as 3.5.0~~
- [x] ~~invalidate 'bad' cache automatically~~
    - [x] ~~invalidate when version of pelican changes~~
    - [x] ~~invalidate when settings change~~
- [ ] redo generate_context
    - [x] ~~don't cache broken content~~
    - [x] ~~cache drafts~~
    - [ ] restructure generate_context some more to solve #1356 and produce cleaner code
- [ ] find a way to not use `import pelican` in `cache.py` to access `__version__`
- [ ] check if settings invalidation is handled correctly
- [ ] check if there is anything we can do to track if plugins changed
- [ ] make sure the introduced overhead is ok, maybe make cache invalidation optional via settings
- [ ] benchmark

# Out of Scope
* restructure caching?

  FileDataCacher is currently the top level caching instance, it might make sense to introduce a 'caching manager' which contains most of the setting, pathing logic (and then in the future keeps track of versions) and let FileDataCacher just do what the name implies

