### PR TITLE
Badges for downloads & version from PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-Pelican |build-status| |coverage-status|
-========================================
+Pelican |build-status| |coverage-status| |pypi-version| |pypi-downloads|
+========================================================================
 
 Pelican is a static site generator, written in Python_.
 
@@ -62,4 +62,9 @@ Why the name "Pelican"?
 .. |coverage-status| image:: https://img.shields.io/coveralls/getpelican/pelican.svg
    :target: https://coveralls.io/r/getpelican/pelican
    :alt: Coveralls: code coverage status
-
+.. |pypi-version| image:: https://img.shields.io/pypi/v/pelican.svg
+   :target: https://pypi.python.org/pypi/pelican
+   :alt: PyPI: the Python Package Index
+.. |pypi-downloads| image:: https://img.shields.io/pypi/dm/pelican.svg
+   :target: https://pypi.python.org/pypi/pelican
+   :alt: PyPI: the Python Package Index


### PR DESCRIPTION
Adding badges to show-off the number of downloads Pelican has had last month from PyPI and the version available there. 

Something of a preview here (on my repo): https://github.com/abrahamvarricatt/pelican/tree/more_badges