### PR TITLE
fix outdated content_object_init refs

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -116,30 +116,10 @@ static_generator_preread            static_generator               invoked befor
                                                                    staticfiles list.
 static_generator_init               static_generator               invoked in the StaticGenerator.__init__
 static_generator_finalized          static_generator               invoked at the end of StaticGenerator.generate_context
-content_object_init                 content_object                 invoked at the end of Content.__init__ (see note below)
+content_object_init                 content_object                 invoked at the end of Content.__init__
 content_written                     path, context                  invoked each time a content file is written.
 feed_written                        path, context, feed            invoked each time a feed file is written.
 =================================   ============================   ===========================================================================
-
-The list is currently small, so don't hesitate to add signals and make a pull
-request if you need them!
-
-.. note::
-
-   The signal ``content_object_init`` can send a different type of object as
-   the argument. If you want to register only one type of object then you will
-   need to specify the sender when you are connecting to the signal.
-
-   ::
-
-       from pelican import signals
-       from pelican import contents
-
-       def test(sender, instance):
-               print "%s : %s content initialized !!" % (sender, instance)
-
-       def register():
-               signals.content_object_init.connect(test, sender=contents.Article)
 
 .. warning::
 

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -1,18 +1,20 @@
-# -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-import six
-from sys import platform
 import locale
 import os.path
+import six
 
-from pelican.tests.support import unittest, get_settings
-
-from pelican.contents import Page, Article, Static, URLWrapper, Author, Category
-from pelican.settings import DEFAULT_CONFIG
-from pelican.utils import path_to_url, truncate_html_words, SafeDatetime, posix_join
-from pelican.signals import content_object_init
 from jinja2.utils import generate_lorem_ipsum
+from sys import platform
+
+from pelican.contents import (Page, Article, Static, URLWrapper,
+                              Author, Category)
+from pelican.settings import DEFAULT_CONFIG
+from pelican.signals import content_object_init
+from pelican.tests.support import unittest, get_settings
+from pelican.utils import (path_to_url, truncate_html_words, SafeDatetime,
+                           posix_join)
+
 
 # generate one paragraph, enclosed with <p>
 TEST_CONTENT = str(generate_lorem_ipsum(n=1))
@@ -191,14 +193,19 @@ class TestPage(unittest.TestCase):
         return page_kwargs
 
     def test_signal(self):
-        # If a title is given, it should be used to generate the slug.
-
-        def receiver_test_function(sender, instance):
+        def receiver_test_function(sender):
+            receiver_test_function.has_been_called = True
             pass
+        receiver_test_function.has_been_called = False
 
-        content_object_init.connect(receiver_test_function, sender=Page)
+        content_object_init.connect(receiver_test_function)
+        self.assertIn(
+            receiver_test_function,
+            content_object_init.receivers_for(Page))
+
+        self.assertFalse(receiver_test_function.has_been_called)
         Page(**self.page_kwargs)
-        self.assertTrue(content_object_init.has_receivers_for(Page))
+        self.assertTrue(receiver_test_function.has_been_called)
 
     def test_get_content(self):
         # Test that the content is updated with the relative links to


### PR DESCRIPTION
* remove content_object_init section from docs
* improve content_object_init test

The content_object_init signal used to set its class as sender and pass
the instance as additional arg in 6100773. Commit ed907b4 removed this
behaviour to bring it inline with other signals, on the basis that
you can test for the class of the object anyway.
We also had a test in place, checking this behaviour, but it was poorly
implemented, not actually checking if the function ever got called.

closes #1711