### PR TITLE
Export hidden pages in context

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -77,11 +77,13 @@ articles        The list of articles, ordered descending by date.
                 in the `all_articles` variable.
 dates           The same list of articles, but ordered by date,
                 ascending.
+drafts          The list of draft articles
 tags            A list of (tag, articles) tuples, containing all
                 the tags.
 categories      A list of (category, articles) tuples, containing
                 all the categories and corresponding articles (values)
 pages           The list of pages
+hidden_pages    The list of hidden pages
 =============   ===================================================
 
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -577,7 +577,7 @@ class ArticlesGenerator(CachingGenerator):
         self.authors.sort()
 
         self._update_context(('articles', 'dates', 'tags', 'categories',
-                              'authors', 'related_posts'))
+                              'authors', 'related_posts', 'drafts'))
         self.save_cache()
         self.readers.save_cache()
         signals.article_generator_finalized.send(self)
@@ -643,7 +643,7 @@ class PagesGenerator(CachingGenerator):
         self.hidden_pages, self.hidden_translations = (
             process_translations(hidden_pages))
 
-        self._update_context(('pages', ))
+        self._update_context(('pages', 'hidden_pages'))
         self.context['PAGES'] = self.pages
 
         self.save_cache()

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -491,7 +491,13 @@ class TestPageGenerator(unittest.TestCase):
         ]
 
         self.assertEqual(sorted(pages_expected), sorted(pages))
+        self.assertEqual(
+            sorted(pages_expected),
+            sorted(self.distill_pages(generator.context['pages'])))
         self.assertEqual(sorted(hidden_pages_expected), sorted(hidden_pages))
+        self.assertEqual(
+            sorted(hidden_pages_expected),
+            sorted(self.distill_pages(generator.context['hidden_pages'])))
 
     def test_generate_sorted(self):
         settings = get_settings(filenames={})


### PR DESCRIPTION
The `PageGenerator` was building hidden pages, but not making them
available in the context. This makes it difficult for other plugins to
operate on hidden pages.

This patch updates `PageGenerator` to export the hidden pages it finds
in the context as `hidden_pages`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/getpelican/pelican/1760)
<!-- Reviewable:end -->
