### PR TITLE
Tox: keep docs output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ deps =
     sphinx_rtd_theme
 changedir = docs
 commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -W -b html -d {envtmpdir}/doctrees . _build/html


### PR DESCRIPTION
This modifies Tox's docs environment to keep the cache in a temporary environment (to force rebuilds), but keeps the output available under `docs/_build/html` as if you would have run `make html` in the docs directory.