### PR TITLE
Remove PAGES; use pages instead

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -250,3 +250,16 @@ moved out of the pelican core and into a separate `plugin
 <https://github.com/getpelican/pelican-plugins/tree/master/tag_cloud>`_.
 See the :ref:`plugins` documentation further information about the
 Pelican plugin system.
+
+Since I upgraded Pelican my Pages are no longer rendered
+========================================================
+Pages were available to Themes as lowercase ``pages`` and uppercase
+``PAGES``. To bring this inline with the :ref:`templates-variables` section,
+``PAGES`` has been removed. This is quickly resolved by updating your theme
+to iterate over ``pages`` instead of ``PAGES``. Just replace::
+
+    {% for pg in PAGES %}
+
+with something like::
+
+    {% for pg in pages %}

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -47,6 +47,8 @@ To make your own theme, you must follow the following structure::
   if it helps you keep things organized while creating your theme.
 
 
+.. _templates-variables:
+
 Templates and variables
 =======================
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -644,7 +644,6 @@ class PagesGenerator(CachingGenerator):
             process_translations(hidden_pages))
 
         self._update_context(('pages', 'hidden_pages'))
-        self.context['PAGES'] = self.pages
 
         self.save_cache()
         self.readers.save_cache()

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -25,7 +25,7 @@
                     <li><a href="{{ link }}">{{ title }}</a></li>
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU -%}
-                {% for pg in PAGES %}
+                {% for pg in pages %}
                     <li{% if pg == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
                 {% endfor %}
                 {% endif %}

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -40,7 +40,7 @@
             <li><a href="{{ link }}">{{ title }}</a></li>
         {% endfor %}
         {% if DISPLAY_PAGES_ON_MENU %}
-          {% for p in PAGES %}
+          {% for p in pages %}
             <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
           {% endfor %}
         {% else %}


### PR DESCRIPTION
* remove PAGES from context as pages is available
* add section to FAQ to provide guidance

as discussed in #1760 this removes `PAGES` and adds a FAQ entry explaining the issue.