### PR TITLE
Add S3 404 custom page to Tips documentation

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -28,6 +28,11 @@ configuration file's ``location`` block::
 For Apache::
 
     ErrorDocument 404 /404.html
+    
+For Amazon S3, first navigate to the ``Static Site Hosting`` menu in the 
+bucket settings on your AWS cosole. From there::
+
+    Error Document: 404.html
 
 Publishing to GitHub
 ====================


### PR DESCRIPTION
add 404 page instructions for amazon s3 to the docs.