### PR TITLE
separated argparse to be passed from main to prepare function

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -386,7 +386,8 @@ def main():
 
 
 def prepare(args):
-    """ preapres settings received from an argparse or mocked argparse from         different application that imports pelican.
+    """ preapres settings received from an argparse or mocked argparse
+        from different application that imports pelican.
 
     	:param args: argparse.ArgumentParser or mocked argparse Class object
 	:type args: argparse.ArgumentParser or mocked argparse

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -382,6 +382,15 @@ def get_instance(args):
 
 def main():
     args = parse_arguments()
+    prepare(args)
+
+
+def prepare(args):
+    """ preapres settings received from an argparse or mocked argparse from         different application that imports pelican.
+
+    	:param args: argparse.ArgumentParser or mocked argparse Class object
+	:type args: argparse.ArgumentParser or mocked argparse
+    """
     init(args.verbosity)
     pelican, settings = get_instance(args)
     readers = Readers(settings)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ CHANGELOG = open('docs/changelog.rst').read()
 
 setup(
     name="pelican",
-    version="3.6.1.dev",
+    version="3.7.0.dev",
     url='http://getpelican.com/',
     author='Alexis Metaireau',
     author_email='authors@getpelican.com',


### PR DESCRIPTION
To be able to post to a pelican blog one would have to import pelican but their was no straight way to pass arguments, so instead of replicating a command line action via subprocess, I have added a prepare function that accepts either argpase.ArgumentParser or mocked argparse to pass the value to variable like settings etc that are command line flags.