### PR TITLE
Fixes #1068, #1572: template page navigation bugs

### DIFF
--- a/pelican/tests/output/custom/category/bar.html
+++ b/pelican/tests/output/custom/category/bar.html
@@ -51,9 +51,6 @@ YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 <p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/category/cat1.html
+++ b/pelican/tests/output/custom/category/cat1.html
@@ -120,9 +120,6 @@
 <p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -131,9 +131,6 @@ pelican.conf, it ...</p></div>
 <p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/category/yeah.html
+++ b/pelican/tests/output/custom/category/yeah.html
@@ -59,9 +59,6 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 <p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -110,9 +110,6 @@ YEAH !</p>
 <p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -80,9 +80,6 @@ as well as <strong>inline markup</strong>.</p>
 <p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
             </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/tag/foobar.html
+++ b/pelican/tests/output/custom/tag/foobar.html
@@ -59,9 +59,6 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 <p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom/tag/yeah.html
+++ b/pelican/tests/output/custom/tag/yeah.html
@@ -51,9 +51,6 @@ YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 <p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/category/bar.html
+++ b/pelican/tests/output/custom_locale/category/bar.html
@@ -51,9 +51,6 @@ YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 <p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/category/cat1.html
+++ b/pelican/tests/output/custom_locale/category/cat1.html
@@ -120,9 +120,6 @@
 <p>There are <a href="../posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
                 </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -131,9 +131,6 @@ pelican.conf, it ...</p></div>
 <p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
                 </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/category/yeah.html
+++ b/pelican/tests/output/custom_locale/category/yeah.html
@@ -59,9 +59,6 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 <p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/tag/bar.html
+++ b/pelican/tests/output/custom_locale/tag/bar.html
@@ -110,9 +110,6 @@ YEAH !</p>
 <p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
                 </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/tag/foo.html
+++ b/pelican/tests/output/custom_locale/tag/foo.html
@@ -80,9 +80,6 @@ as well as <strong>inline markup</strong>.</p>
 <p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>
                 </ol><!-- /#posts-list -->
-<p class="paginator">
-    Page 1 / 1
-</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/tag/foobar.html
+++ b/pelican/tests/output/custom_locale/tag/foobar.html
@@ -59,9 +59,6 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 <p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/tests/output/custom_locale/tag/yeah.html
+++ b/pelican/tests/output/custom_locale/tag/yeah.html
@@ -51,9 +51,6 @@ YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 <p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </article>
-<p class="paginator">
-    Page 1 / 1
-</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">

--- a/pelican/themes/notmyidea/templates/index.html
+++ b/pelican/themes/notmyidea/templates/index.html
@@ -11,9 +11,6 @@
                     <h1 class="entry-title"><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
                     {% include 'article_infos.html' %}{{ article.content }}{% include 'comments.html' %}
                 </article>
-                {% if loop.length == 1 %}
-                    {% include 'pagination.html' %}
-                {% endif %}
             </aside><!-- /#featured -->
             {% if loop.length > 1 %}
                 <section id="content" class="body">
@@ -42,13 +39,11 @@
             </article></li>
         {% endif %}
         {% if loop.last %}
-            {% if loop.length > 1 %}
+            {% if loop.length > 1 or articles_page.has_other_pages() %}
                 </ol><!-- /#posts-list -->
-            {% endif %}
-            {% if articles_page.has_previous() or loop.length > 1 %}
-                {% include 'pagination.html' %}
-            {% endif %}
-            {% if loop.length > 1 %}
+                {% if articles_page.has_other_pages() %}
+                    {% include 'pagination.html' %}
+                {% endif %}
                 </section><!-- /#content -->
             {% endif %}
         {% endif %}

--- a/pelican/themes/simple/templates/index.html
+++ b/pelican/themes/simple/templates/index.html
@@ -21,6 +21,8 @@
         </article></li>
 {% endfor %}
 </ol><!-- /#posts-list -->
-{% include 'pagination.html' %}
+{% if articles_page.has_other_pages() %}
+    {% include 'pagination.html' %}
+{% endif %}
 </section><!-- /#content -->
 {% endblock content %}


### PR DESCRIPTION
Updates the template logic for when page navigation is included in the
generated HTML, fixing:

* Issue #1068: useless pagination controls should not be displayed when a
  single page is generated (i.e. "Page 1/1"). New logic prevents the
  generation of these superfluous page navigation controls. Tests updated
  accordingly.

* Issue #1572: when multiple pages are generated and the last page contains
  only one item, the closing </ol> and </section> tags are not generated,
  resulting in page breakage. We need to check if
  articles_page.has_other_pages(); if it does, a list has been generated per
  line 19 or 25 and the tags must be closed.