### PR TITLE
Make generating various content optional.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -220,6 +220,10 @@ Setting name (followed by default value, if any)                                
                                                                                  :ref:`writing_only_selected_content`.
 ``FORMATTED_FIELDS = ['summary']``                                               A list of metadata fields containing reST/Markdown content to be
                                                                                  parsed and translated to HTML.
+``GENERATE_TAGS = True``                                                         If ``False``, Tags pages won't be generated.
+``GENERATE_CATEGORIES = True``                                                   If ``False``, category pages won't be generated.
+``GENERATE_AUTHORS = True``                                                      If ``False``, Author pages won't be generated.
+``GENERATE_ARCHIVES = True``                                                     If ``False``, archive pages won't be generated.
 ===============================================================================  =====================================================================
 
 .. [#] Default is the system locale.
@@ -796,8 +800,8 @@ can be invoked by passing the ``--archive`` flag).
 
 The cache files are Python pickles, so they may not be readable by
 different versions of Python as the pickle format often changes. If
-such an error is encountered, it is caught and the cache file is 
-rebuilt automatically in the new format. The cache files will also be 
+such an error is encountered, it is caught and the cache file is
+rebuilt automatically in the new format. The cache files will also be
 rebuilt after the ``GZIP_CACHE`` setting has been changed.
 
 The ``--ignore-cache`` command-line option is useful when the

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -484,13 +484,21 @@ class ArticlesGenerator(CachingGenerator):
         # to minimize the number of relative path stuff modification
         # in writer, articles pass first
         self.generate_articles(write)
-        self.generate_period_archives(write)
+
+        if self.settings.get('GENERATE_ARCHIVES'):
+            self.generate_period_archives(write)
         self.generate_direct_templates(write)
 
         # and subfolders after that
-        self.generate_tags(write)
-        self.generate_categories(write)
-        self.generate_authors(write)
+        if self.settings.get('GENERATE_TAGS'):
+            self.generate_tags(write)
+
+        if self.settings.get('GENERATE_CATEGORIES'):
+            self.generate_categories(write)
+
+        if self.settings.get('GENERATE_AUTHORS'):
+            self.generate_authors(write)
+
         self.generate_drafts(write)
 
     def generate_context(self):

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -131,7 +131,11 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': False,
     'WRITE_SELECTED': [],
     'FORMATTED_FIELDS': ['summary'],
-    }
+    'GENERATE_TAGS': True,
+    'GENERATE_CATEGORIES': True,
+    'GENERATE_AUTHORS': True,
+    'GENERATE_ARCHIVES': True
+}
 
 PYGMENTS_RST_OPTIONS = None
 


### PR DESCRIPTION
In some cases, I'd rather not generate archives, tags, categories or
authors. This patch provides flags for turning their generation off
selectively.