### PR TITLE
Apply autopep8 command to pelican/*.py and pelican/tests/*.py

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -152,7 +152,7 @@ class Pelican(object):
         context = self.settings.copy()
         # Share these among all the generators and content objects:
         context['filenames'] = {}  # maps source path to Content object or None
-        context['localsiteurl'] = self.settings['SITEURL'] 
+        context['localsiteurl'] = self.settings['SITEURL']
 
         generators = [
             cls(
@@ -191,22 +191,22 @@ class Pelican(object):
 
         pluralized_articles = maybe_pluralize(
             len(articles_generator.articles) +
-                len(articles_generator.translations),
+            len(articles_generator.translations),
             'article',
             'articles')
         pluralized_drafts = maybe_pluralize(
             len(articles_generator.drafts) +
-                len(articles_generator.drafts_translations),
+            len(articles_generator.drafts_translations),
             'draft',
             'drafts')
         pluralized_pages = maybe_pluralize(
             len(pages_generator.pages) +
-                len(pages_generator.translations),
+            len(pages_generator.translations),
             'page',
             'pages')
         pluralized_hidden_pages = maybe_pluralize(
             len(pages_generator.hidden_pages) +
-                len(pages_generator.hidden_translations),
+            len(pages_generator.hidden_translations),
             'hidden page',
             'hidden pages')
 
@@ -243,8 +243,8 @@ class Pelican(object):
         return generators
 
     def get_writer(self):
-        writers = [ w for (_, w) in signals.get_writer.send(self)
-                    if isinstance(w, type) ]
+        writers = [w for (_, w) in signals.get_writer.send(self)
+                   if isinstance(w, type)]
         writers_found = len(writers)
         if writers_found == 0:
             return Writer(self.output_path, settings=self.settings)
@@ -254,7 +254,7 @@ class Pelican(object):
                 logger.debug('Found writer: %s', writer)
             else:
                 logger.warning(
-                    '%s writers found, using only first one: %s', 
+                    '%s writers found, using only first one: %s',
                     writers_found, writer)
             return writer(self.output_path, settings=self.settings)
 
@@ -354,7 +354,8 @@ def get_config(args):
     # argparse returns bytes in Py2. There is no definite answer as to which
     # encoding argparse (or sys.argv) uses.
     # "Best" option seems to be locale.getpreferredencoding()
-    # ref: http://mail.python.org/pipermail/python-list/2006-October/405766.html
+    # ref:
+    # http://mail.python.org/pipermail/python-list/2006-October/405766.html
     if not six.PY3:
         enc = locale.getpreferredencoding()
         for key in config:
@@ -367,7 +368,7 @@ def get_instance(args):
 
     config_file = args.settings
     if config_file is None and os.path.isfile(DEFAULT_CONFIG_NAME):
-            config_file = DEFAULT_CONFIG_NAME
+        config_file = DEFAULT_CONFIG_NAME
 
     settings = read_settings(config_file, override=get_config(args))
 

--- a/pelican/cache.py
+++ b/pelican/cache.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class FileDataCacher(object):
+
     """Class that can cache data contained in files"""
 
     def __init__(self, settings, cache_name, caching_policy, load_policy):
@@ -77,6 +78,7 @@ class FileDataCacher(object):
 
 
 class FileStampDataCacher(FileDataCacher):
+
     """Subclass that also caches the stamp of the file"""
 
     def __init__(self, settings, cache_name, caching_policy, load_policy):

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 @python_2_unicode_compatible
 class Content(object):
+
     """Represents a content.
 
     :param content: the string to parse, containing the original content.
@@ -66,7 +67,7 @@ class Content(object):
         # also keep track of the metadata attributes available
         self.metadata = local_metadata
 
-        #default template if it's not defined in page
+        # default template if it's not defined in page
         self.template = self._get_template()
 
         # First, read the authors from "authors", if not, fallback to "author"
@@ -96,11 +97,11 @@ class Content(object):
         if not hasattr(self, 'slug'):
             if settings['SLUGIFY_SOURCE'] == 'title' and hasattr(self, 'title'):
                 self.slug = slugify(self.title,
-                                settings.get('SLUG_SUBSTITUTIONS', ()))
+                                    settings.get('SLUG_SUBSTITUTIONS', ()))
             elif settings['SLUGIFY_SOURCE'] == 'basename' and source_path != None:
                 basename = os.path.basename(os.path.splitext(source_path)[0])
                 self.slug = slugify(basename,
-                                settings.get('SLUG_SUBSTITUTIONS', ()))
+                                    settings.get('SLUG_SUBSTITUTIONS', ()))
 
         self.source_path = source_path
 
@@ -234,14 +235,14 @@ class Content(object):
                             linked_content.attach_to(self)
                         else:
                             logger.warning("%s used {attach} link syntax on a "
-                                "non-static file. Use {filename} instead.",
-                                self.get_relative_source_path())
+                                           "non-static file. Use {filename} instead.",
+                                           self.get_relative_source_path())
                     origin = '/'.join((siteurl, linked_content.url))
                     origin = origin.replace('\\', '/')  # for Windows paths.
                 else:
                     logger.warning(
                         "Unable to find `%s`, skipping url replacement.",
-                        value.geturl(), extra = {
+                        value.geturl(), extra={
                             'limit_msg': ("Other resources were not found "
                                           "and their urls not replaced")})
             elif what == 'category':
@@ -332,7 +333,8 @@ class Content(object):
 
         return posixize_path(
             os.path.relpath(
-                os.path.abspath(os.path.join(self.settings['PATH'], source_path)),
+                os.path.abspath(
+                    os.path.join(self.settings['PATH'], source_path)),
                 os.path.abspath(self.settings['PATH'])
             ))
 
@@ -366,6 +368,7 @@ class Quote(Page):
 
 @python_2_unicode_compatible
 class Static(Page):
+
     def __init__(self, *args, **kwargs):
         super(Static, self).__init__(*args, **kwargs)
         self._output_location_referenced = False
@@ -419,10 +422,10 @@ class Static(Page):
 
         def _log_reason(reason):
             logger.warning("The {attach} link in %s cannot relocate %s "
-                "because %s. Falling back to {filename} link behavior instead.",
-                content.get_relative_source_path(),
-                self.get_relative_source_path(), reason,
-                extra={'limit_msg': "More {attach} warnings silenced."})
+                           "because %s. Falling back to {filename} link behavior instead.",
+                           content.get_relative_source_path(),
+                           self.get_relative_source_path(), reason,
+                           extra={'limit_msg': "More {attach} warnings silenced."})
 
         # We never override an override, because we don't want to interfere
         # with user-defined overrides that might be in EXTRA_PATH_METADATA.
@@ -447,5 +450,6 @@ def is_valid_content(content, f):
         content.check_properties()
         return True
     except NameError as e:
-        logger.error("Skipping %s: could not find information about '%s'", f, e)
+        logger.error(
+            "Skipping %s: could not find information about '%s'", f, e)
         return False

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -31,8 +31,10 @@ logger = logging.getLogger(__name__)
 class PelicanTemplateNotFound(Exception):
     pass
 
+
 @python_2_unicode_compatible
 class Generator(object):
+
     """Baseclass generator"""
 
     def __init__(self, context, settings, path, theme, output_path,
@@ -58,7 +60,7 @@ class Generator(object):
         theme_path = os.path.dirname(os.path.abspath(__file__))
 
         simple_loader = FileSystemLoader(os.path.join(theme_path,
-                                         "themes", "simple", "templates"))
+                                                      "themes", "simple", "templates"))
         self.env = Environment(
             trim_blocks=True,
             lstrip_blocks=True,
@@ -91,7 +93,7 @@ class Generator(object):
                 self._templates[name] = self.env.get_template(name + '.html')
             except TemplateNotFound:
                 raise PelicanTemplateNotFound('[templates] unable to load %s.html from %s'
-                                % (name, self._templates_path))
+                                              % (name, self._templates_path))
         return self._templates[name]
 
     def _include_path(self, path, extensions=None):
@@ -105,7 +107,7 @@ class Generator(object):
             extensions = tuple(self.readers.extensions)
         basename = os.path.basename(path)
 
-        #check IGNORE_FILES
+        # check IGNORE_FILES
         ignores = self.settings['IGNORE_FILES']
         if any(fnmatch.fnmatch(basename, ignore) for ignore in ignores):
             return False
@@ -123,7 +125,7 @@ class Generator(object):
             extensions are allowed)
         """
         if isinstance(paths, six.string_types):
-            paths = [paths] # backward compatibility for older generators
+            paths = [paths]  # backward compatibility for older generators
 
         # group the exclude dir names by parent path, for use with os.walk()
         exclusions_by_dirpath = {}
@@ -196,6 +198,7 @@ class Generator(object):
 
 
 class CachingGenerator(Generator, FileStampDataCacher):
+
     '''Subclass of Generator and FileStampDataCacher classes
 
     enables content caching, either at the generator or reader level
@@ -211,7 +214,8 @@ class CachingGenerator(Generator, FileStampDataCacher):
                            readers_cache_name=(cls_name + '-Readers'),
                            **kwargs)
 
-        cache_this_level = self.settings['CONTENT_CACHING_LAYER'] == 'generator'
+        cache_this_level = self.settings[
+            'CONTENT_CACHING_LAYER'] == 'generator'
         caching_policy = cache_this_level and self.settings['CACHE_CONTENT']
         load_policy = cache_this_level and self.settings['LOAD_CONTENT_CACHE']
         FileStampDataCacher.__init__(self, self.settings, cls_name,
@@ -255,6 +259,7 @@ class TemplatePagesGenerator(Generator):
 
 
 class ArticlesGenerator(CachingGenerator):
+
     """Generate blog articles"""
 
     def __init__(self, *args, **kwargs):
@@ -266,7 +271,7 @@ class ArticlesGenerator(CachingGenerator):
         self.categories = defaultdict(list)
         self.related_posts = []
         self.authors = defaultdict(list)
-        self.drafts = [] # only drafts in default language
+        self.drafts = []  # only drafts in default language
         self.drafts_translations = []
         super(ArticlesGenerator, self).__init__(*args, **kwargs)
         signals.article_generator_init.send(self)
@@ -472,9 +477,9 @@ class ArticlesGenerator(CachingGenerator):
         """Generate drafts pages."""
         for draft in chain(self.drafts_translations, self.drafts):
             write(draft.save_as, self.get_template(draft.template),
-                self.context, article=draft, category=draft.category,
-                override_output=hasattr(draft, 'override_save_as'),
-                blog=True, all_articles=self.articles)
+                  self.context, article=draft, category=draft.category,
+                  override_output=hasattr(draft, 'override_save_as'),
+                  blog=True, all_articles=self.articles)
 
     def generate_pages(self, writer):
         """Generate the pages on the disk"""
@@ -503,7 +508,8 @@ class ArticlesGenerator(CachingGenerator):
                 exclude=self.settings['ARTICLE_EXCLUDES']):
             article_or_draft = self.get_cached_data(f, None)
             if article_or_draft is None:
-            #TODO needs overhaul, maybe nomad for read_file solution, unified behaviour
+                # TODO needs overhaul, maybe nomad for read_file solution,
+                # unified behaviour
                 try:
                     article_or_draft = self.readers.read_file(
                         base_path=self.path, path=f, content_class=Article,
@@ -514,7 +520,7 @@ class ArticlesGenerator(CachingGenerator):
                         context_sender=self)
                 except Exception as e:
                     logger.error('Could not process %s\n%s', f, e,
-                        exc_info=self.settings.get('DEBUG', False))
+                                 exc_info=self.settings.get('DEBUG', False))
                     self._add_failed_source_path(f)
                     continue
 
@@ -536,7 +542,7 @@ class ArticlesGenerator(CachingGenerator):
                     all_drafts.append(article_or_draft)
                 else:
                     logger.error("Unknown status '%s' for file %s, skipping it.",
-                                   article_or_draft.status, f)
+                                 article_or_draft.status, f)
                     self._add_failed_source_path(f)
                     continue
 
@@ -544,9 +550,8 @@ class ArticlesGenerator(CachingGenerator):
 
             self.add_source_path(article_or_draft)
 
-
         self.articles, self.translations = process_translations(all_articles,
-                order_by=self.settings['ARTICLE_ORDER_BY'])
+                                                                order_by=self.settings['ARTICLE_ORDER_BY'])
         self.drafts, self.drafts_translations = \
             process_translations(all_drafts)
 
@@ -589,6 +594,7 @@ class ArticlesGenerator(CachingGenerator):
 
 
 class PagesGenerator(CachingGenerator):
+
     """Generate pages"""
 
     def __init__(self, *args, **kwargs):
@@ -616,7 +622,7 @@ class PagesGenerator(CachingGenerator):
                         context_sender=self)
                 except Exception as e:
                     logger.error('Could not process %s\n%s', f, e,
-                        exc_info=self.settings.get('DEBUG', False))
+                                 exc_info=self.settings.get('DEBUG', False))
                     self._add_failed_source_path(f)
                     continue
 
@@ -630,7 +636,7 @@ class PagesGenerator(CachingGenerator):
                     hidden_pages.append(page)
                 else:
                     logger.error("Unknown status '%s' for file %s, skipping it.",
-                                   page.status, f)
+                                 page.status, f)
                     self._add_failed_source_path(f)
                     continue
 
@@ -639,7 +645,7 @@ class PagesGenerator(CachingGenerator):
             self.add_source_path(page)
 
         self.pages, self.translations = process_translations(all_pages,
-                order_by=self.settings['PAGE_ORDER_BY'])
+                                                             order_by=self.settings['PAGE_ORDER_BY'])
         self.hidden_pages, self.hidden_translations = (
             process_translations(hidden_pages))
 
@@ -662,6 +668,7 @@ class PagesGenerator(CachingGenerator):
 
 
 class StaticGenerator(Generator):
+
     """copy static paths (what you want to copy, like images, medias etc.
     to output"""
 

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -14,13 +14,16 @@ from collections import defaultdict, Mapping
 
 import six
 
+
 class BaseFormatter(logging.Formatter):
+
     def __init__(self, fmt=None, datefmt=None):
         FORMAT = '%(customlevelname)s %(message)s'
         super(BaseFormatter, self).__init__(fmt=FORMAT, datefmt=datefmt)
 
     def format(self, record):
-        record.__dict__['customlevelname'] = self._get_levelname(record.levelname)
+        record.__dict__['customlevelname'] = self._get_levelname(
+            record.levelname)
         # format multiline messages 'nicely' to make it clear they are together
         record.msg = record.msg.replace('\n', '\n  | ')
         return super(BaseFormatter, self).format(record)
@@ -69,6 +72,7 @@ class ANSIFormatter(BaseFormatter):
 
 
 class TextFormatter(BaseFormatter):
+
     """
     Convert a `logging.LogRecord' object into text.
     """
@@ -81,6 +85,7 @@ class TextFormatter(BaseFormatter):
 
 
 class LimitFilter(logging.Filter):
+
     """
     Remove duplicates records, and limit the number of records in the same
     group.
@@ -124,6 +129,7 @@ class LimitFilter(logging.Filter):
 
 
 class SafeLogger(logging.Logger):
+
     """
     Base Logger which properly encodes Exceptions in Py2
     """
@@ -132,13 +138,13 @@ class SafeLogger(logging.Logger):
     def _log(self, level, msg, args, exc_info=None, extra=None):
         # if the only argument is a Mapping, Logger uses that for formatting
         # format values for that case
-        if args and len(args)==1 and isinstance(args[0], Mapping):
+        if args and len(args) == 1 and isinstance(args[0], Mapping):
             args = ({k: self._decode_arg(v) for k, v in args[0].items()},)
         # otherwise, format each arg
         else:
             args = tuple(self._decode_arg(arg) for arg in args)
         super(SafeLogger, self)._log(level, msg, args,
-            exc_info=exc_info, extra=extra)
+                                     exc_info=exc_info, extra=extra)
 
     def _decode_arg(self, arg):
         '''
@@ -158,6 +164,7 @@ class SafeLogger(logging.Logger):
 
 
 class LimitLogger(SafeLogger):
+
     """
     A logger which adds LimitFilter automatically
     """

--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -20,6 +20,7 @@ PaginationRule = namedtuple(
 
 
 class Paginator(object):
+
     def __init__(self, name, object_list, settings):
         self.name = name
         self.object_list = object_list
@@ -68,6 +69,7 @@ class Paginator(object):
 
 
 class Page(object):
+
     def __init__(self, name, object_list, number, paginator, settings):
         self.name, self.extension = os.path.splitext(name)
         self.object_list = object_list

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -28,6 +28,7 @@ from pelican.cache import FileStampDataCacher
 from pelican.contents import Page, Category, Tag, Author
 from pelican.utils import get_date, pelican_open, SafeDatetime, posixize_path
 
+
 def ensure_metadata_list(text):
     """Canonicalize the format of a list of authors or tags.  This works
        the same way as Docutils' "authors" field: if it's already a list,
@@ -86,7 +87,9 @@ def _filter_discardable_metadata(metadata):
 
 logger = logging.getLogger(__name__)
 
+
 class BaseReader(object):
+
     """Base class to read files.
 
     This class is used to process static files, and it can be inherited for
@@ -159,12 +162,14 @@ class PelicanHTMLTranslator(HTMLTranslator):
 
 
 class RstReader(BaseReader):
+
     """Reader for reStructuredText files"""
 
     enabled = bool(docutils)
     file_extensions = ['rst']
 
     class FileInput(docutils.io.FileInput):
+
         """Patch docutils.io.FileInput to remove "U" mode in py3.
 
         Universal newlines is enabled by default and "U" mode is deprecated
@@ -238,6 +243,7 @@ class RstReader(BaseReader):
 
 
 class MarkdownReader(BaseReader):
+
     """Reader for Markdown files"""
 
     enabled = bool(Markdown)
@@ -268,7 +274,7 @@ class MarkdownReader(BaseReader):
             elif name in METADATA_PROCESSORS:
                 if len(value) > 1:
                     logger.warning('Duplicate definition of `%s` '
-                        'for %s. Using first one.', name, self._source_path)
+                                   'for %s. Using first one.', name, self._source_path)
                 output[name] = self.process_metadata(name, value[0])
             elif len(value) > 1:
                 # handle list metadata as list of string
@@ -291,12 +297,14 @@ class MarkdownReader(BaseReader):
 
 
 class HTMLReader(BaseReader):
+
     """Parses HTML files as input, looking for meta, title, and body tags"""
 
     file_extensions = ['htm', 'html']
     enabled = True
 
     class _HTMLParser(HTMLParser):
+
         def __init__(self, settings, filename):
             try:
                 # Python 3.4+
@@ -380,7 +388,8 @@ class HTMLReader(BaseReader):
         def _handle_meta_tag(self, attrs):
             name = self._attr_value(attrs, 'name')
             if name is None:
-                attr_serialized = ', '.join(['{}="{}"'.format(k, v) for k, v in attrs])
+                attr_serialized = ', '.join(
+                    ['{}="{}"'.format(k, v) for k, v in attrs])
                 logger.warning("Meta tag in file %s does not have a 'name' "
                                "attribute, skipping. Attributes: %s",
                                self._filename, attr_serialized)
@@ -420,6 +429,7 @@ class HTMLReader(BaseReader):
 
 
 class Readers(FileStampDataCacher):
+
     """Interface for all readers.
 
     This class contains a mapping of file extensions / Reader classes, to know
@@ -475,7 +485,7 @@ class Readers(FileStampDataCacher):
         path = os.path.abspath(os.path.join(base_path, path))
         source_path = posixize_path(os.path.relpath(path, base_path))
         logger.debug('Read file %s -> %s',
-            source_path, content_class.__name__)
+                     source_path, content_class.__name__)
 
         if not fmt:
             _, ext = os.path.splitext(os.path.basename(path))
@@ -487,7 +497,7 @@ class Readers(FileStampDataCacher):
 
         if preread_signal:
             logger.debug('Signal %s.send(%s)',
-                preread_signal.name, preread_sender)
+                         preread_signal.name, preread_sender)
             preread_signal.send(preread_sender)
 
         reader = self.readers[fmt]
@@ -540,7 +550,7 @@ class Readers(FileStampDataCacher):
 
         if context_signal:
             logger.debug('Signal %s.send(%s, <metadata>)',
-                context_signal.name, context_sender)
+                         context_signal.name, context_sender)
             context_signal.send(context_sender, metadata=metadata)
 
         return content_class(content=content, metadata=metadata,

--- a/pelican/rstdirectives.py
+++ b/pelican/rstdirectives.py
@@ -12,6 +12,7 @@ import pelican.settings as pys
 
 
 class Pygments(Directive):
+
     """ Source code syntax highlighting.
     """
     required_arguments = 1

--- a/pelican/server.py
+++ b/pelican/server.py
@@ -54,11 +54,11 @@ if __name__ == '__main__':
 
     socketserver.TCPServer.allow_reuse_address = True
     try:
-        httpd = socketserver.TCPServer((SERVER, PORT), ComplexHTTPRequestHandler)
+        httpd = socketserver.TCPServer(
+            (SERVER, PORT), ComplexHTTPRequestHandler)
     except OSError as e:
         logging.error("Could not listen on port %s, server %s.", PORT, SERVER)
         sys.exit(getattr(e, 'exitcode', 1))
-
 
     logging.info("Serving at port %s, server %s.", PORT, SERVER)
     try:

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -131,7 +131,7 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': False,
     'WRITE_SELECTED': [],
     'FORMATTED_FIELDS': ['summary'],
-    }
+}
 
 PYGMENTS_RST_OPTIONS = None
 
@@ -158,8 +158,8 @@ def read_settings(path=None, override=None):
                            "has been deprecated (should be a list)")
             local_settings['PLUGIN_PATHS'] = [local_settings['PLUGIN_PATHS']]
         elif local_settings['PLUGIN_PATHS'] is not None:
-                local_settings['PLUGIN_PATHS'] = [os.path.abspath(os.path.normpath(os.path.join(os.path.dirname(path), pluginpath)))
-                                    if not isabs(pluginpath) else pluginpath for pluginpath in local_settings['PLUGIN_PATHS']]
+            local_settings['PLUGIN_PATHS'] = [os.path.abspath(os.path.normpath(os.path.join(os.path.dirname(path), pluginpath)))
+                                              if not isabs(pluginpath) else pluginpath for pluginpath in local_settings['PLUGIN_PATHS']]
     else:
         local_settings = copy.deepcopy(DEFAULT_CONFIG)
 
@@ -205,7 +205,7 @@ def configure_settings(settings):
 
     # specify the log messages to be ignored
     LimitFilter._ignore.update(set(settings.get('LOG_FILTER',
-                                               DEFAULT_CONFIG['LOG_FILTER'])))
+                                                DEFAULT_CONFIG['LOG_FILTER'])))
 
     # lookup the theme in "pelican/themes" if the given one doesn't exist
     if not os.path.isdir(settings['THEME']):
@@ -223,19 +223,19 @@ def configure_settings(settings):
     settings['WRITE_SELECTED'] = [
         os.path.abspath(path) for path in
         settings.get('WRITE_SELECTED', DEFAULT_CONFIG['WRITE_SELECTED'])
-        ]
+    ]
 
     # standardize strings to lowercase strings
     for key in [
             'DEFAULT_LANG',
-            ]:
+    ]:
         if key in settings:
             settings[key] = settings[key].lower()
 
     # standardize strings to lists
     for key in [
             'LOCALE',
-            ]:
+    ]:
         if key in settings and isinstance(settings[key], six.string_types):
             settings[key] = [settings[key]]
 
@@ -243,12 +243,12 @@ def configure_settings(settings):
     for key, types in [
             ('OUTPUT_SOURCES_EXTENSION', six.string_types),
             ('FILENAME_METADATA', six.string_types),
-            ]:
+    ]:
         if key in settings and not isinstance(settings[key], types):
             value = settings.pop(key)
             logger.warn('Detected misconfigured %s (%s), '
                         'falling back to the default (%s)',
-                    key, value, DEFAULT_CONFIG[key])
+                        key, value, DEFAULT_CONFIG[key])
 
     # try to set the different locales, fallback on the default.
     locales = settings.get('LOCALE', DEFAULT_CONFIG['LOCALE'])
@@ -275,11 +275,11 @@ def configure_settings(settings):
 
     # check content caching layer and warn of incompatibilities
     if (settings.get('CACHE_CONTENT', False) and
-        settings.get('CONTENT_CACHING_LAYER', '') == 'generator' and
-        settings.get('WITH_FUTURE_DATES', DEFAULT_CONFIG['WITH_FUTURE_DATES'])):
+            settings.get('CONTENT_CACHING_LAYER', '') == 'generator' and
+            settings.get('WITH_FUTURE_DATES', DEFAULT_CONFIG['WITH_FUTURE_DATES'])):
         logger.warning('WITH_FUTURE_DATES conflicts with '
-                        "CONTENT_CACHING_LAYER set to 'generator', "
-                        "use 'reader' layer instead")
+                       "CONTENT_CACHING_LAYER set to 'generator', "
+                       "use 'reader' layer instead")
 
     # Warn if feeds are generated with both SITEURL & FEED_DOMAIN undefined
     feed_keys = [
@@ -322,7 +322,7 @@ def configure_settings(settings):
         new_key = key + '_PATHS'
         if old_key in settings:
             logger.warning('Deprecated setting %s, moving it to %s list',
-                old_key, new_key)
+                           old_key, new_key)
             settings[new_key] = [settings[old_key]]   # also make a list
             del settings[old_key]
 
@@ -366,7 +366,7 @@ def configure_settings(settings):
             ('LESS_GENERATOR', 'the Webassets plugin', None),
             ('FILES_TO_COPY', 'STATIC_PATHS and EXTRA_PATH_METADATA',
              'https://github.com/getpelican/pelican/blob/master/docs/settings.rst#path-metadata'),
-            ]:
+    ]:
         if old in settings:
             message = 'The {} setting has been removed in favor of {}'.format(
                 old, new)

--- a/pelican/tests/default_conf.py
+++ b/pelican/tests/default_conf.py
@@ -31,17 +31,16 @@ DEFAULT_METADATA = {'yeah': 'it is'}
 # path-specific metadata
 EXTRA_PATH_METADATA = {
     'extra/robots.txt': {'path': 'robots.txt'},
-    }
+}
 
 # static paths will be copied without parsing their contents
 STATIC_PATHS = [
     'pictures',
     'extra/robots.txt',
-    ]
+]
 
 FORMATTED_FIELDS = ['summary', 'custom_formatted_field']
 
 # foobar will not be used, because it's not in caps. All configuration keys
 # have to be in caps
 foobar = "barbaz"
-

--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -167,12 +167,13 @@ def get_settings(**kwargs):
     Set keyword arguments to override specific settings.
     """
     settings = DEFAULT_CONFIG.copy()
-    for key,value in kwargs.items():
+    for key, value in kwargs.items():
         settings[key] = value
     return settings
 
 
 class LogCountHandler(BufferingHandler):
+
     """Capturing and counting logged messages."""
 
     def __init__(self, capacity=1000):
@@ -180,12 +181,13 @@ class LogCountHandler(BufferingHandler):
 
     def count_logs(self, msg=None, level=None):
         return len([l for l in self.buffer
-            if (msg is None or re.match(msg, l.getMessage()))
-            and (level is None or l.levelno == level)
-            ])
+                    if (msg is None or re.match(msg, l.getMessage()))
+                    and (level is None or l.levelno == level)
+                    ])
 
 
 class LoggedTestCase(unittest.TestCase):
+
     """A test case that captures log messages."""
 
     def setUp(self):

--- a/pelican/tests/test_cache.py
+++ b/pelican/tests/test_cache.py
@@ -35,7 +35,6 @@ class TestCache(unittest.TestCase):
         settings['CACHE_PATH'] = self.temp_cache
         return settings
 
-
     @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_article_object_caching(self):
         """Test Article objects caching at the generator level"""
@@ -43,7 +42,6 @@ class TestCache(unittest.TestCase):
         settings['CONTENT_CACHING_LAYER'] = 'generator'
         settings['DEFAULT_DATE'] = (1970, 1, 1)
         settings['READERS'] = {'asc': None}
-
 
         generator = ArticlesGenerator(
             context=settings.copy(), settings=settings,
@@ -108,7 +106,8 @@ class TestCache(unittest.TestCase):
             path=CONTENT_DIR, theme=settings['THEME'], output_path=None)
         generator.readers.read_file = MagicMock()
         generator.generate_context()
-        self.assertEqual(generator.readers.read_file.call_count, orig_call_count)
+        self.assertEqual(
+            generator.readers.read_file.call_count, orig_call_count)
 
     @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_page_object_caching(self):
@@ -181,5 +180,5 @@ class TestCache(unittest.TestCase):
             path=CUR_DIR, theme=settings['THEME'], output_path=None)
         generator.readers.read_file = MagicMock()
         generator.generate_context()
-        self.assertEqual(generator.readers.read_file.call_count, orig_call_count)
-
+        self.assertEqual(
+            generator.readers.read_file.call_count, orig_call_count)

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -48,7 +48,7 @@ class TestPage(unittest.TestCase):
         # them to initialise object's attributes.
         metadata = {'foo': 'bar', 'foobar': 'baz', 'title': 'foobar', }
         page = Page(TEST_CONTENT, metadata=metadata,
-                context={'localsiteurl': ''})
+                    context={'localsiteurl': ''})
         for key, value in metadata.items():
             self.assertTrue(hasattr(page, key))
             self.assertEqual(value, getattr(page, key))
@@ -138,14 +138,15 @@ class TestPage(unittest.TestCase):
         page = Page(**page_kwargs)
 
         # page.locale_date is a unicode string in both python2 and python3
-        dt_date = dt.strftime(DEFAULT_CONFIG['DEFAULT_DATE_FORMAT']) 
+        dt_date = dt.strftime(DEFAULT_CONFIG['DEFAULT_DATE_FORMAT'])
         # dt_date is a byte string in python2, and a unicode string in python3
-        # Let's make sure it is a unicode string (relies on python 3.3 supporting the u prefix)
+        # Let's make sure it is a unicode string (relies on python 3.3
+        # supporting the u prefix)
         if type(dt_date) != type(u''):
             # python2:
             dt_date = unicode(dt_date, 'utf8')
 
-        self.assertEqual(page.locale_date, dt_date )
+        self.assertEqual(page.locale_date, dt_date)
         page_kwargs['settings'] = get_settings()
 
         # I doubt this can work on all platforms ...
@@ -389,6 +390,7 @@ class TestPage(unittest.TestCase):
 
 
 class TestArticle(TestPage):
+
     def test_template(self):
         # Articles default to article, metadata overwrites
         default_article = Article(**self.page_kwargs)
@@ -400,17 +402,19 @@ class TestArticle(TestPage):
 
     def test_slugify_category_author(self):
         settings = get_settings()
-        settings['SLUG_SUBSTITUTIONS'] = [ ('C#', 'csharp') ]
+        settings['SLUG_SUBSTITUTIONS'] = [('C#', 'csharp')]
         settings['ARTICLE_URL'] = '{author}/{category}/{slug}/'
         settings['ARTICLE_SAVE_AS'] = '{author}/{category}/{slug}/index.html'
         article_kwargs = self._copy_page_kwargs()
         article_kwargs['metadata']['author'] = Author("O'Brien", settings)
-        article_kwargs['metadata']['category'] = Category('C# & stuff', settings)
+        article_kwargs['metadata'][
+            'category'] = Category('C# & stuff', settings)
         article_kwargs['metadata']['title'] = 'fnord'
         article_kwargs['settings'] = settings
         article = Article(**article_kwargs)
         self.assertEqual(article.url, 'obrien/csharp-stuff/fnord/')
-        self.assertEqual(article.save_as, 'obrien/csharp-stuff/fnord/index.html')
+        self.assertEqual(
+            article.save_as, 'obrien/csharp-stuff/fnord/index.html')
 
 
 class TestStatic(unittest.TestCase):
@@ -425,7 +429,7 @@ class TestStatic(unittest.TestCase):
         self.context = self.settings.copy()
 
         self.static = Static(content=None, metadata={}, settings=self.settings,
-            source_path=posix_join('dir', 'foo.jpg'), context=self.context)
+                             source_path=posix_join('dir', 'foo.jpg'), context=self.context)
 
         self.context['filenames'] = {self.static.source_path: self.static}
 
@@ -436,8 +440,8 @@ class TestStatic(unittest.TestCase):
         """attach_to() overrides a static file's save_as and url.
         """
         page = Page(content="fake page",
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'fakepage.md'))
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'fakepage.md'))
         self.static.attach_to(page)
 
         expected_save_as = os.path.join('outpages', 'foo.jpg')
@@ -448,7 +452,7 @@ class TestStatic(unittest.TestCase):
         """attach_to() preserves dirs inside the linking document dir.
         """
         page = Page(content="fake page", metadata={'title': 'fakepage'},
-            settings=self.settings, source_path='fakepage.md')
+                    settings=self.settings, source_path='fakepage.md')
         self.static.attach_to(page)
 
         expected_save_as = os.path.join('outpages', 'dir', 'foo.jpg')
@@ -459,8 +463,8 @@ class TestStatic(unittest.TestCase):
         """attach_to() ignores dirs outside the linking document dir.
         """
         page = Page(content="fake page",
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'otherdir', 'fakepage.md'))
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'otherdir', 'fakepage.md'))
         self.static.attach_to(page)
 
         expected_save_as = os.path.join('outpages', 'foo.jpg')
@@ -471,8 +475,8 @@ class TestStatic(unittest.TestCase):
         """attach_to() does nothing when called a second time.
         """
         page = Page(content="fake page",
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'fakepage.md'))
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'fakepage.md'))
 
         self.static.attach_to(page)
 
@@ -481,8 +485,8 @@ class TestStatic(unittest.TestCase):
             PAGE_SAVE_AS=os.path.join('otherpages', '{slug}.html'),
             PAGE_URL='otherpages/{slug}.html'))
         otherdir_page = Page(content="other page",
-            metadata={'title': 'otherpage'}, settings=otherdir_settings,
-            source_path=os.path.join('dir', 'otherpage.md'))
+                             metadata={'title': 'otherpage'}, settings=otherdir_settings,
+                             source_path=os.path.join('dir', 'otherpage.md'))
 
         self.static.attach_to(otherdir_page)
 
@@ -497,8 +501,8 @@ class TestStatic(unittest.TestCase):
         original_save_as = self.static.save_as
 
         page = Page(content="fake page",
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'fakepage.md'))
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'fakepage.md'))
         self.static.attach_to(page)
 
         self.assertEqual(self.static.save_as, original_save_as)
@@ -511,8 +515,8 @@ class TestStatic(unittest.TestCase):
         original_url = self.static.url
 
         page = Page(content="fake page",
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'fakepage.md'))
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'fakepage.md'))
         self.static.attach_to(page)
 
         self.assertEqual(self.static.save_as, self.static.source_path)
@@ -523,14 +527,15 @@ class TestStatic(unittest.TestCase):
         (For example, by the user with EXTRA_PATH_METADATA)
         """
         customstatic = Static(content=None,
-            metadata=dict(save_as='customfoo.jpg', url='customfoo.jpg'),
-            settings=self.settings,
-            source_path=os.path.join('dir', 'foo.jpg'),
-            context=self.settings.copy())
+                              metadata=dict(
+                                  save_as='customfoo.jpg', url='customfoo.jpg'),
+                              settings=self.settings,
+                              source_path=os.path.join('dir', 'foo.jpg'),
+                              context=self.settings.copy())
 
         page = Page(content="fake page",
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'fakepage.md'))
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'fakepage.md'))
 
         customstatic.attach_to(page)
 
@@ -542,13 +547,13 @@ class TestStatic(unittest.TestCase):
         """
         html = '<a href="{attach}../foo.jpg">link</a>'
         page = Page(content=html,
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'otherdir', 'fakepage.md'),
-            context=self.context)
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'otherdir', 'fakepage.md'),
+                    context=self.context)
         content = page.get_content('')
 
         self.assertNotEqual(content, html,
-            "{attach} link syntax did not trigger URL replacement.")
+                            "{attach} link syntax did not trigger URL replacement.")
 
         expected_save_as = os.path.join('outpages', 'foo.jpg')
         self.assertEqual(self.static.save_as, expected_save_as)
@@ -572,9 +577,9 @@ class TestStatic(unittest.TestCase):
 
         html = '<a href="{category}foo">link</a>'
         page = Page(content=html,
-            metadata={'title': 'fakepage'}, settings=self.settings,
-            source_path=os.path.join('dir', 'otherdir', 'fakepage.md'),
-            context=self.context)
+                    metadata={'title': 'fakepage'}, settings=self.settings,
+                    source_path=os.path.join('dir', 'otherdir', 'fakepage.md'),
+                    context=self.context)
         content = page.get_content('')
 
         self.assertNotEqual(content, html)

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -24,6 +24,7 @@ CONTENT_DIR = os.path.join(CUR_DIR, 'content')
 
 
 class TestGenerator(unittest.TestCase):
+
     def setUp(self):
         self.old_locale = locale.setlocale(locale.LC_ALL)
         locale.setlocale(locale.LC_ALL, str('C'))
@@ -34,7 +35,6 @@ class TestGenerator(unittest.TestCase):
 
     def tearDown(self):
         locale.setlocale(locale.LC_ALL, self.old_locale)
-
 
     def test_include_path(self):
         self.settings['IGNORE_FILES'] = {'ignored1.rst', 'ignored2.rst'}
@@ -53,40 +53,41 @@ class TestGenerator(unittest.TestCase):
         """
         # We use our own Generator so we can give it our own content path
         generator = Generator(context=self.settings.copy(),
-            settings=self.settings,
-            path=os.path.join(CUR_DIR, 'nested_content'),
-            theme=self.settings['THEME'], output_path=None)
+                              settings=self.settings,
+                              path=os.path.join(CUR_DIR, 'nested_content'),
+                              theme=self.settings['THEME'], output_path=None)
 
         filepaths = generator.get_files(paths=['maindir'])
         found_files = {os.path.basename(f) for f in filepaths}
         expected_files = {'maindir.md', 'subdir.md'}
         self.assertFalse(expected_files - found_files,
-            "get_files() failed to find one or more files")
+                         "get_files() failed to find one or more files")
 
         # Test string as `paths` argument rather than list
         filepaths = generator.get_files(paths='maindir')
         found_files = {os.path.basename(f) for f in filepaths}
         expected_files = {'maindir.md', 'subdir.md'}
         self.assertFalse(expected_files - found_files,
-            "get_files() failed to find one or more files")
+                         "get_files() failed to find one or more files")
 
         filepaths = generator.get_files(paths=[''], exclude=['maindir'])
         found_files = {os.path.basename(f) for f in filepaths}
         self.assertNotIn('maindir.md', found_files,
-            "get_files() failed to exclude a top-level directory")
+                         "get_files() failed to exclude a top-level directory")
         self.assertNotIn('subdir.md', found_files,
-            "get_files() failed to exclude a subdir of an excluded directory")
+                         "get_files() failed to exclude a subdir of an excluded directory")
 
         filepaths = generator.get_files(paths=[''],
-            exclude=[os.path.join('maindir', 'subdir')])
+                                        exclude=[os.path.join('maindir', 'subdir')])
         found_files = {os.path.basename(f) for f in filepaths}
         self.assertNotIn('subdir.md', found_files,
-            "get_files() failed to exclude a subdirectory")
+                         "get_files() failed to exclude a subdirectory")
 
         filepaths = generator.get_files(paths=[''], exclude=['subdir'])
         found_files = {os.path.basename(f) for f in filepaths}
         self.assertIn('subdir.md', found_files,
-            "get_files() excluded a subdirectory by name, ignoring its path")
+                      "get_files() excluded a subdirectory by name, ignoring its path")
+
 
 class TestArticlesGenerator(unittest.TestCase):
 
@@ -96,7 +97,8 @@ class TestArticlesGenerator(unittest.TestCase):
         settings['DEFAULT_CATEGORY'] = 'Default'
         settings['DEFAULT_DATE'] = (1970, 1, 1)
         settings['READERS'] = {'asc': None}
-        settings['CACHE_CONTENT'] = False   # cache not needed for this logic tests
+        # cache not needed for this logic tests
+        settings['CACHE_CONTENT'] = False
 
         cls.generator = ArticlesGenerator(
             context=settings.copy(), settings=settings,
@@ -152,23 +154,28 @@ class TestArticlesGenerator(unittest.TestCase):
             ['Test mkd File', 'published', 'test', 'article'],
             ['This is a super article !', 'published', 'Yeah', 'article'],
             ['This is a super article !', 'published', 'Yeah', 'article'],
-            ['Article with Nonconformant HTML meta tags', 'published', 'Default', 'article'],
+            ['Article with Nonconformant HTML meta tags',
+                'published', 'Default', 'article'],
             ['This is a super article !', 'published', 'yeah', 'article'],
             ['This is a super article !', 'published', 'yeah', 'article'],
             ['This is a super article !', 'published', 'yeah', 'article'],
             ['This is a super article !', 'published', 'Default', 'article'],
             ['This is an article with category !', 'published', 'yeah',
              'article'],
-            ['This is an article with multiple authors!', 'published', 'Default', 'article'],
-            ['This is an article with multiple authors!', 'published', 'Default', 'article'],
-            ['This is an article with multiple authors in list format!', 'published', 'Default', 'article'],
-            ['This is an article with multiple authors in lastname, firstname format!', 'published', 'Default', 'article'],
+            ['This is an article with multiple authors!',
+                'published', 'Default', 'article'],
+            ['This is an article with multiple authors!',
+                'published', 'Default', 'article'],
+            ['This is an article with multiple authors in list format!',
+                'published', 'Default', 'article'],
+            ['This is an article with multiple authors in lastname, firstname format!',
+                'published', 'Default', 'article'],
             ['This is an article without category !', 'published', 'Default',
              'article'],
             ['This is an article without category !', 'published',
              'TestCategory', 'article'],
             ['An Article With Code Block To Test Typogrify Ignore',
-              'published', 'Default', 'article'],
+             'published', 'Default', 'article'],
             ['マックOS X 10.8でパイソンとVirtualenvをインストールと設定', 'published',
              '指導書', 'article'],
         ]
@@ -292,7 +299,7 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_period_archives(write)
         dates = [d for d in generator.dates if d.date.year == 1970]
         self.assertEqual(len(dates), 1)
-        #among other things it must have at least been called with this
+        # among other things it must have at least been called with this
         settings["period"] = (1970,)
         write.assert_called_with("posts/1970/index.html",
                                  generator.get_template("period_archives"),
@@ -300,7 +307,8 @@ class TestArticlesGenerator(unittest.TestCase):
                                  blog=True, dates=dates)
 
         del settings["period"]
-        settings['MONTH_ARCHIVE_SAVE_AS'] = 'posts/{date:%Y}/{date:%b}/index.html'
+        settings[
+            'MONTH_ARCHIVE_SAVE_AS'] = 'posts/{date:%Y}/{date:%b}/index.html'
         generator = ArticlesGenerator(
             context=settings, settings=settings,
             path=CONTENT_DIR, theme=settings['THEME'], output_path=None)
@@ -308,17 +316,18 @@ class TestArticlesGenerator(unittest.TestCase):
         write = MagicMock()
         generator.generate_period_archives(write)
         dates = [d for d in generator.dates if d.date.year == 1970
-                                            and d.date.month == 1]
+                 and d.date.month == 1]
         self.assertEqual(len(dates), 1)
         settings["period"] = (1970, "January")
-        #among other things it must have at least been called with this
+        # among other things it must have at least been called with this
         write.assert_called_with("posts/1970/Jan/index.html",
                                  generator.get_template("period_archives"),
                                  settings,
                                  blog=True, dates=dates)
 
         del settings["period"]
-        settings['DAY_ARCHIVE_SAVE_AS'] = 'posts/{date:%Y}/{date:%b}/{date:%d}/index.html'
+        settings[
+            'DAY_ARCHIVE_SAVE_AS'] = 'posts/{date:%Y}/{date:%b}/{date:%d}/index.html'
         generator = ArticlesGenerator(
             context=settings, settings=settings,
             path=CONTENT_DIR, theme=settings['THEME'], output_path=None)
@@ -326,11 +335,11 @@ class TestArticlesGenerator(unittest.TestCase):
         write = MagicMock()
         generator.generate_period_archives(write)
         dates = [d for d in generator.dates if d.date.year == 1970
-                                            and d.date.month == 1
-                                            and d.date.day == 1]
+                 and d.date.month == 1
+                 and d.date.day == 1]
         self.assertEqual(len(dates), 1)
         settings["period"] = (1970, "January", 1)
-        #among other things it must have at least been called with this
+        # among other things it must have at least been called with this
         write.assert_called_with("posts/1970/Jan/01/index.html",
                                  generator.get_template("period_archives"),
                                  settings,
@@ -347,11 +356,13 @@ class TestArticlesGenerator(unittest.TestCase):
     def test_generate_authors(self):
         """Check authors generation."""
         authors = [author.name for author, _ in self.generator.authors]
-        authors_expected = sorted(['Alexis Métaireau', 'Author, First', 'Author, Second', 'First Author', 'Second Author'])
+        authors_expected = sorted(
+            ['Alexis Métaireau', 'Author, First', 'Author, Second', 'First Author', 'Second Author'])
         self.assertEqual(sorted(authors), authors_expected)
         # test for slug
         authors = [author.slug for author, _ in self.generator.authors]
-        authors_expected = ['alexis-metaireau', 'author-first', 'author-second', 'first-author', 'second-author']
+        authors_expected = ['alexis-metaireau', 'author-first',
+                            'author-second', 'first-author', 'second-author']
         self.assertEqual(sorted(authors), sorted(authors_expected))
 
     def test_standard_metadata_in_default_metadata(self):
@@ -391,7 +402,8 @@ class TestArticlesGenerator(unittest.TestCase):
         settings = get_settings(filenames={})
         settings['DEFAULT_CATEGORY'] = 'Default'
         settings['DEFAULT_DATE'] = (1970, 1, 1)
-        settings['CACHE_CONTENT'] = False   # cache not needed for this logic tests
+        # cache not needed for this logic tests
+        settings['CACHE_CONTENT'] = False
         settings['ARTICLE_ORDER_BY'] = 'title'
 
         generator = ArticlesGenerator(
@@ -435,7 +447,8 @@ class TestArticlesGenerator(unittest.TestCase):
         settings = get_settings(filenames={})
         settings['DEFAULT_CATEGORY'] = 'Default'
         settings['DEFAULT_DATE'] = (1970, 1, 1)
-        settings['CACHE_CONTENT'] = False   # cache not needed for this logic tests
+        # cache not needed for this logic tests
+        settings['CACHE_CONTENT'] = False
         settings['ARTICLE_ORDER_BY'] = 'reversed-title'
 
         generator = ArticlesGenerator(
@@ -561,7 +574,7 @@ class TestPageGenerator(unittest.TestCase):
         are generated correctly on pages
         """
         settings = get_settings(filenames={})
-        settings['PAGE_PATHS'] = ['TestPages'] # relative to CUR_DIR
+        settings['PAGE_PATHS'] = ['TestPages']  # relative to CUR_DIR
         settings['CACHE_PATH'] = self.temp_cache
         settings['DEFAULT_DATE'] = (1970, 1, 1)
 
@@ -585,7 +598,6 @@ class TestTemplatePagesGenerator(unittest.TestCase):
         self.temp_output = mkdtemp(prefix='pelicantests.')
         self.old_locale = locale.setlocale(locale.LC_ALL)
         locale.setlocale(locale.LC_ALL, str('C'))
-
 
     def tearDown(self):
         rmtree(self.temp_content)
@@ -633,21 +645,21 @@ class TestStaticGenerator(unittest.TestCase):
         """Test that StaticGenerator respects STATIC_EXCLUDES.
         """
         settings = get_settings(STATIC_EXCLUDES=['subdir'],
-            PATH=self.content_path, STATIC_PATHS=[''])
+                                PATH=self.content_path, STATIC_PATHS=[''])
         context = settings.copy()
         context['filenames'] = {}
 
         StaticGenerator(context=context, settings=settings,
-            path=settings['PATH'], output_path=None,
-            theme=settings['THEME']).generate_context()
+                        path=settings['PATH'], output_path=None,
+                        theme=settings['THEME']).generate_context()
 
         staticnames = [os.path.basename(c.source_path)
-            for c in context['staticfiles']]
+                       for c in context['staticfiles']]
 
         self.assertNotIn('subdir_fake_image.jpg', staticnames,
-            "StaticGenerator processed a file in a STATIC_EXCLUDES directory")
+                         "StaticGenerator processed a file in a STATIC_EXCLUDES directory")
         self.assertIn('fake_image.jpg', staticnames,
-            "StaticGenerator skipped a file that it should have included")
+                      "StaticGenerator skipped a file that it should have included")
 
     def test_static_exclude_sources(self):
         """Test that StaticGenerator respects STATIC_EXCLUDE_SOURCES.
@@ -655,21 +667,21 @@ class TestStaticGenerator(unittest.TestCase):
         # Test STATIC_EXCLUDE_SOURCES=True
 
         settings = get_settings(STATIC_EXCLUDE_SOURCES=True,
-            PATH=self.content_path, PAGE_PATHS=[''], STATIC_PATHS=[''],
-            CACHE_CONTENT=False)
+                                PATH=self.content_path, PAGE_PATHS=[''], STATIC_PATHS=[''],
+                                CACHE_CONTENT=False)
         context = settings.copy()
         context['filenames'] = {}
 
         for generator_class in (PagesGenerator, StaticGenerator):
             generator_class(context=context, settings=settings,
-                path=settings['PATH'], output_path=None,
-                theme=settings['THEME']).generate_context()
+                            path=settings['PATH'], output_path=None,
+                            theme=settings['THEME']).generate_context()
 
         staticnames = [os.path.basename(c.source_path)
-            for c in context['staticfiles']]
+                       for c in context['staticfiles']]
 
         self.assertFalse(any(name.endswith(".md") for name in staticnames),
-            "STATIC_EXCLUDE_SOURCES=True failed to exclude a markdown file")
+                         "STATIC_EXCLUDE_SOURCES=True failed to exclude a markdown file")
 
         # Test STATIC_EXCLUDE_SOURCES=False
 
@@ -679,12 +691,11 @@ class TestStaticGenerator(unittest.TestCase):
 
         for generator_class in (PagesGenerator, StaticGenerator):
             generator_class(context=context, settings=settings,
-                path=settings['PATH'], output_path=None,
-                theme=settings['THEME']).generate_context()
+                            path=settings['PATH'], output_path=None,
+                            theme=settings['THEME']).generate_context()
 
         staticnames = [os.path.basename(c.source_path)
-            for c in context['staticfiles']]
+                       for c in context['staticfiles']]
 
         self.assertTrue(any(name.endswith(".md") for name in staticnames),
-            "STATIC_EXCLUDE_SOURCES=False failed to include a markdown file")
-
+                        "STATIC_EXCLUDE_SOURCES=False failed to include a markdown file")

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -32,7 +32,6 @@ except ImportError:
     LXML = False
 
 
-
 @skipIfNoExecutable(['pandoc', '--version'])
 @unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')
 class TestWordpressXmlImporter(unittest.TestCase):
@@ -67,7 +66,8 @@ class TestWordpressXmlImporter(unittest.TestCase):
         silent_f2p = mute(True)(fields2pelican)
         test_post = filter(lambda p: p[0].startswith("Empty Page"), self.posts)
         with temporary_folder() as temp:
-            fname = list(silent_f2p(test_post, 'markdown', temp, dirpage=True))[0]
+            fname = list(
+                silent_f2p(test_post, 'markdown', temp, dirpage=True))[0]
             self.assertTrue(fname.endswith('pages%sempty.md' % os.path.sep))
 
     def test_dircat(self):
@@ -75,10 +75,11 @@ class TestWordpressXmlImporter(unittest.TestCase):
         test_posts = []
         for post in self.posts:
             # check post kind
-            if len(post[5]) > 0: # Has a category
+            if len(post[5]) > 0:  # Has a category
                 test_posts.append(post)
         with temporary_folder() as temp:
-            fnames = list(silent_f2p(test_posts, 'markdown', temp, dircat=True))
+            fnames = list(
+                silent_f2p(test_posts, 'markdown', temp, dircat=True))
         index = 0
         for post in test_posts:
             name = post[2]
@@ -108,9 +109,12 @@ class TestWordpressXmlImporter(unittest.TestCase):
             else:
                 cust_data.append((title, kind))
         self.assertEqual(3, len(cust_data))
-        self.assertEqual(('A custom post in category 4', 'custom1'), cust_data[0])
-        self.assertEqual(('A custom post in category 5', 'custom1'), cust_data[1])
-        self.assertEqual(('A 2nd custom post type also in category 5', 'custom2'), cust_data[2])
+        self.assertEqual(
+            ('A custom post in category 4', 'custom1'), cust_data[0])
+        self.assertEqual(
+            ('A custom post in category 5', 'custom1'), cust_data[1])
+        self.assertEqual(
+            ('A 2nd custom post type also in category 5', 'custom2'), cust_data[2])
 
     def test_custom_posts_put_in_own_dir(self):
         silent_f2p = mute(True)(fields2pelican)
@@ -122,7 +126,8 @@ class TestWordpressXmlImporter(unittest.TestCase):
             else:
                 test_posts.append(post)
         with temporary_folder() as temp:
-            fnames = list(silent_f2p(test_posts, 'markdown', temp, wp_custpost = True))
+            fnames = list(
+                silent_f2p(test_posts, 'markdown', temp, wp_custpost=True))
         index = 0
         for post in test_posts:
             name = post[2]
@@ -144,7 +149,7 @@ class TestWordpressXmlImporter(unittest.TestCase):
                 test_posts.append(post)
         with temporary_folder() as temp:
             fnames = list(silent_f2p(test_posts, 'markdown', temp,
-                wp_custpost=True, dircat=True))
+                                     wp_custpost=True, dircat=True))
         index = 0
         for post in test_posts:
             name = post[2]
@@ -157,7 +162,7 @@ class TestWordpressXmlImporter(unittest.TestCase):
             index += 1
 
     def test_wp_custpost_true_dirpage_false(self):
-        #pages should only be put in their own directory when dirpage = True
+        # pages should only be put in their own directory when dirpage = True
         silent_f2p = mute(True)(fields2pelican)
         test_posts = []
         for post in self.custposts:
@@ -166,7 +171,7 @@ class TestWordpressXmlImporter(unittest.TestCase):
                 test_posts.append(post)
         with temporary_folder() as temp:
             fnames = list(silent_f2p(test_posts, 'markdown', temp,
-                wp_custpost=True, dirpage=False))
+                                     wp_custpost=True, dirpage=False))
         index = 0
         for post in test_posts:
             name = post[2]
@@ -174,7 +179,6 @@ class TestWordpressXmlImporter(unittest.TestCase):
             filename = os.path.join('pages', name)
             out_name = fnames[index]
             self.assertFalse(out_name.endswith(filename))
-
 
     def test_can_toggle_raw_html_code_parsing(self):
         def r(f):
@@ -184,20 +188,22 @@ class TestWordpressXmlImporter(unittest.TestCase):
 
         with temporary_folder() as temp:
 
-            rst_files = (r(f) for f in silent_f2p(self.posts, 'markdown', temp))
+            rst_files = (r(f)
+                         for f in silent_f2p(self.posts, 'markdown', temp))
             self.assertTrue(any('<iframe' in rst for rst in rst_files))
             rst_files = (r(f) for f in silent_f2p(self.posts, 'markdown', temp,
-                         strip_raw=True))
+                                                  strip_raw=True))
             self.assertFalse(any('<iframe' in rst for rst in rst_files))
             # no effect in rst
             rst_files = (r(f) for f in silent_f2p(self.posts, 'rst', temp))
             self.assertFalse(any('<iframe' in rst for rst in rst_files))
             rst_files = (r(f) for f in silent_f2p(self.posts, 'rst', temp,
-                         strip_raw=True))
+                                                  strip_raw=True))
             self.assertFalse(any('<iframe' in rst for rst in rst_files))
 
     def test_decode_html_entities_in_titles(self):
-        test_posts = [post for post in self.posts if post[2] == 'html-entity-test']
+        test_posts = [
+            post for post in self.posts if post[2] == 'html-entity-test']
         self.assertEqual(len(test_posts), 1)
 
         post = test_posts[0]
@@ -216,14 +222,16 @@ class TestWordpressXmlImporter(unittest.TestCase):
             encoded_content = encoded_file.read()
             with open(WORDPRESS_DECODED_CONTENT_SAMPLE, 'r') as decoded_file:
                 decoded_content = decoded_file.read()
-                self.assertEqual(decode_wp_content(encoded_content, br=False), decoded_content)
+                self.assertEqual(
+                    decode_wp_content(encoded_content, br=False), decoded_content)
 
     def test_preserve_verbatim_formatting(self):
         def r(f):
             with open(f, encoding='utf-8') as infile:
                 return infile.read()
         silent_f2p = mute(True)(fields2pelican)
-        test_post = filter(lambda p: p[0].startswith("Code in List"), self.posts)
+        test_post = filter(
+            lambda p: p[0].startswith("Code in List"), self.posts)
         with temporary_folder() as temp:
             md = [r(f) for f in silent_f2p(test_post, 'markdown', temp)][0]
             self.assertTrue(re.search(r'\s+a = \[1, 2, 3\]', md))
@@ -231,14 +239,16 @@ class TestWordpressXmlImporter(unittest.TestCase):
 
             for_line = re.search(r'\s+for i in zip\(a, b\):', md).group(0)
             print_line = re.search(r'\s+print i', md).group(0)
-            self.assertTrue(for_line.rindex('for') < print_line.rindex('print'))
+            self.assertTrue(
+                for_line.rindex('for') < print_line.rindex('print'))
 
     def test_code_in_list(self):
         def r(f):
             with open(f, encoding='utf-8') as infile:
                 return infile.read()
         silent_f2p = mute(True)(fields2pelican)
-        test_post = filter(lambda p: p[0].startswith("Code in List"), self.posts)
+        test_post = filter(
+            lambda p: p[0].startswith("Code in List"), self.posts)
         with temporary_folder() as temp:
             md = [r(f) for f in silent_f2p(test_post, 'markdown', temp)][0]
             sample_line = re.search(r'-   This is a code sample', md).group(0)
@@ -247,6 +257,7 @@ class TestWordpressXmlImporter(unittest.TestCase):
 
 
 class TestBuildHeader(unittest.TestCase):
+
     def test_build_header(self):
         header = build_header('test', None, None, None, None, None)
         self.assertEqual(header, 'test\n####\n\n')
@@ -285,31 +296,31 @@ class TestBuildHeader(unittest.TestCase):
         self.assertEqual(build_header(*header_data), expected_docutils)
         self.assertEqual(build_markdown_header(*header_data), expected_md)
 
-
     def test_build_header_with_east_asian_characters(self):
         header = build_header('これは広い幅の文字だけで構成されたタイトルです',
-                None, None, None, None, None)
+                              None, None, None, None, None)
 
         self.assertEqual(header,
-                'これは広い幅の文字だけで構成されたタイトルです\n' +
-                '##############################################\n\n')
+                         'これは広い幅の文字だけで構成されたタイトルです\n' +
+                         '##############################################\n\n')
 
     def test_galleries_added_to_header(self):
         header = build_header('test', None, None, None, None,
-                None, attachments=['output/test1', 'output/test2'])
+                              None, attachments=['output/test1', 'output/test2'])
         self.assertEqual(header, 'test\n####\n' + ':attachments: output/test1, '
-                + 'output/test2\n\n')
+                         + 'output/test2\n\n')
 
     def test_galleries_added_to_markdown_header(self):
         header = build_markdown_header('test', None, None, None, None, None,
-            attachments=['output/test1', 'output/test2'])
+                                       attachments=['output/test1', 'output/test2'])
         self.assertEqual(header, 'Title: test\n' + 'Attachments: output/test1, '
-                + 'output/test2\n\n')
+                         + 'output/test2\n\n')
 
 
 @unittest.skipUnless(BeautifulSoup, 'Needs BeautifulSoup module')
 @unittest.skipUnless(LXML, 'Needs lxml module')
 class TestWordpressXMLAttachements(unittest.TestCase):
+
     def setUp(self):
         self.old_locale = locale.setlocale(locale.LC_ALL)
         locale.setlocale(locale.LC_ALL, str('C'))
@@ -326,14 +337,19 @@ class TestWordpressXMLAttachements(unittest.TestCase):
         self.assertTrue(self.attachments)
         for post in self.attachments.keys():
             if post is None:
-                self.assertTrue(self.attachments[post][0] == 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Pelican_lakes_entrance02.jpg/240px-Pelican_lakes_entrance02.jpg')
+                self.assertTrue(self.attachments[post][
+                                0] == 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Pelican_lakes_entrance02.jpg/240px-Pelican_lakes_entrance02.jpg')
             elif post == 'with-excerpt':
-                self.assertTrue(self.attachments[post][0] == 'http://thisurlisinvalid.notarealdomain/not_an_image.jpg')
-                self.assertTrue(self.attachments[post][1] == 'http://en.wikipedia.org/wiki/File:Pelikan_Walvis_Bay.jpg')
+                self.assertTrue(self.attachments[post][
+                                0] == 'http://thisurlisinvalid.notarealdomain/not_an_image.jpg')
+                self.assertTrue(self.attachments[post][
+                                1] == 'http://en.wikipedia.org/wiki/File:Pelikan_Walvis_Bay.jpg')
             elif post == 'with-tags':
-                self.assertTrue(self.attachments[post][0] == 'http://thisurlisinvalid.notarealdomain')
+                self.assertTrue(
+                    self.attachments[post][0] == 'http://thisurlisinvalid.notarealdomain')
             else:
-                self.fail('all attachments should match to a filename or None, {}'.format(post))
+                self.fail(
+                    'all attachments should match to a filename or None, {}'.format(post))
 
     def test_download_attachments(self):
         real_file = os.path.join(CUR_DIR, 'content/article.rst')
@@ -344,4 +360,5 @@ class TestWordpressXMLAttachements(unittest.TestCase):
             locations = list(silent_da(temp, [good_url, bad_url]))
             self.assertEqual(1, len(locations))
             directory = locations[0]
-            self.assertTrue(directory.endswith(os.path.join('content', 'article.rst')), directory)
+            self.assertTrue(
+                directory.endswith(os.path.join('content', 'article.rst')), directory)

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -13,7 +13,9 @@ from jinja2.utils import generate_lorem_ipsum
 TEST_CONTENT = str(generate_lorem_ipsum(n=1))
 TEST_SUMMARY = generate_lorem_ipsum(n=1, html=False)
 
+
 class TestPage(unittest.TestCase):
+
     def setUp(self):
         super(TestPage, self).setUp()
         self.old_locale = locale.setlocale(locale.LC_ALL)
@@ -49,7 +51,8 @@ class TestPage(unittest.TestCase):
         )
 
         self.page_kwargs['metadata']['author'] = Author('Blogger', settings)
-        object_list = [Article(**self.page_kwargs), Article(**self.page_kwargs)]
+        object_list = [
+            Article(**self.page_kwargs), Article(**self.page_kwargs)]
         paginator = Paginator('foobar.foo', object_list, settings)
         page = paginator.page(1)
         self.assertEqual(page.save_as, 'foobar.foo')

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -17,7 +17,7 @@ from pelican.tests.support import LoggedTestCase, mute, locale_available, unitte
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 SAMPLES_PATH = os.path.abspath(os.path.join(
-        CURRENT_DIR, os.pardir, os.pardir, 'samples'))
+    CURRENT_DIR, os.pardir, os.pardir, 'samples'))
 OUTPUT_PATH = os.path.abspath(os.path.join(CURRENT_DIR, 'output'))
 
 INPUT_PATH = os.path.join(SAMPLES_PATH, "content")
@@ -27,13 +27,13 @@ SAMPLE_FR_CONFIG = os.path.join(SAMPLES_PATH, "pelican.conf_FR.py")
 
 def recursiveDiff(dcmp):
     diff = {
-            'diff_files': [os.path.join(dcmp.right, f)
-                for f in dcmp.diff_files],
-            'left_only': [os.path.join(dcmp.right, f)
-                for f in dcmp.left_only],
-            'right_only': [os.path.join(dcmp.right, f)
-                for f in dcmp.right_only],
-            }
+        'diff_files': [os.path.join(dcmp.right, f)
+                       for f in dcmp.diff_files],
+        'left_only': [os.path.join(dcmp.right, f)
+                      for f in dcmp.left_only],
+        'right_only': [os.path.join(dcmp.right, f)
+                       for f in dcmp.right_only],
+    }
     for sub_dcmp in dcmp.subdirs.values():
         for k, v in recursiveDiff(sub_dcmp).items():
             diff[k] += v
@@ -60,9 +60,11 @@ class TestPelican(LoggedTestCase):
 
     def assertDirsEqual(self, left_path, right_path):
         out, err = subprocess.Popen(
-            ['git', 'diff', '--no-ext-diff', '--exit-code', '-w', left_path, right_path],
+            ['git', 'diff', '--no-ext-diff', '--exit-code',
+                '-w', left_path, right_path],
             env={str('PAGER'): str('')}, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).communicate()
+
         def ignorable_git_crlf_errors(line):
             # Work around for running tests on Windows
             for msg in [
@@ -86,9 +88,9 @@ class TestPelican(LoggedTestCase):
         generator_classes = pelican.get_generator_classes()
 
         self.assertTrue(generator_classes[-1] is StaticGenerator,
-            "StaticGenerator must be the last generator, but it isn't!")
+                        "StaticGenerator must be the last generator, but it isn't!")
         self.assertIsInstance(generator_classes, collections.Sequence,
-            "get_generator_classes() must return a Sequence to preserve order")
+                              "get_generator_classes() must return a Sequence to preserve order")
 
     def test_basic_generation_works(self):
         # when running pelican without settings, it should pick up the default
@@ -98,10 +100,11 @@ class TestPelican(LoggedTestCase):
             'OUTPUT_PATH': self.temp_path,
             'CACHE_PATH': self.temp_cache,
             'LOCALE': locale.normalize('en_US'),
-            })
+        })
         pelican = Pelican(settings=settings)
         mute(True)(pelican.run)()
-        self.assertDirsEqual(self.temp_path, os.path.join(OUTPUT_PATH, 'basic'))
+        self.assertDirsEqual(
+            self.temp_path, os.path.join(OUTPUT_PATH, 'basic'))
         self.assertLogCountEqual(
             count=3,
             msg="Unable to find.*skipping url replacement",
@@ -114,10 +117,11 @@ class TestPelican(LoggedTestCase):
             'OUTPUT_PATH': self.temp_path,
             'CACHE_PATH': self.temp_cache,
             'LOCALE': locale.normalize('en_US'),
-            })
+        })
         pelican = Pelican(settings=settings)
         mute(True)(pelican.run)()
-        self.assertDirsEqual(self.temp_path, os.path.join(OUTPUT_PATH, 'custom'))
+        self.assertDirsEqual(
+            self.temp_path, os.path.join(OUTPUT_PATH, 'custom'))
 
     @unittest.skipUnless(locale_available('fr_FR.UTF-8') or
                          locale_available('French'), 'French locale needed')
@@ -133,10 +137,11 @@ class TestPelican(LoggedTestCase):
             'OUTPUT_PATH': self.temp_path,
             'CACHE_PATH': self.temp_cache,
             'LOCALE': our_locale,
-            })
+        })
         pelican = Pelican(settings=settings)
         mute(True)(pelican.run)()
-        self.assertDirsEqual(self.temp_path, os.path.join(OUTPUT_PATH, 'custom_locale'))
+        self.assertDirsEqual(
+            self.temp_path, os.path.join(OUTPUT_PATH, 'custom_locale'))
 
     def test_theme_static_paths_copy(self):
         # the same thing with a specified set of settings should work
@@ -147,7 +152,7 @@ class TestPelican(LoggedTestCase):
             'THEME_STATIC_PATHS': [os.path.join(SAMPLES_PATH, 'very'),
                                    os.path.join(SAMPLES_PATH, 'kinda'),
                                    os.path.join(SAMPLES_PATH, 'theme_standard')]
-            })
+        })
         pelican = Pelican(settings=settings)
         mute(True)(pelican.run)()
         theme_output = os.path.join(self.temp_path, 'theme')
@@ -166,7 +171,7 @@ class TestPelican(LoggedTestCase):
             'OUTPUT_PATH': self.temp_path,
             'CACHE_PATH': self.temp_cache,
             'THEME_STATIC_PATHS': [os.path.join(SAMPLES_PATH, 'theme_standard')]
-            })
+        })
 
         pelican = Pelican(settings=settings)
         mute(True)(pelican.run)()
@@ -184,9 +189,9 @@ class TestPelican(LoggedTestCase):
             'WRITE_SELECTED': [
                 os.path.join(self.temp_path, 'oh-yeah.html'),
                 os.path.join(self.temp_path, 'categories.html'),
-                ],
+            ],
             'LOCALE': locale.normalize('en_US'),
-            })
+        })
         pelican = Pelican(settings=settings)
         logger = logging.getLogger()
         orig_level = logger.getEffectiveLevel()

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -32,19 +32,21 @@ class ReaderTest(unittest.TestCase):
                     'Expected %s to have value %s, but was %s' % (key, value, real_value))
             else:
                 self.fail(
-                   'Expected %s to have value %s, but was not in Dict' % (key, value))
+                    'Expected %s to have value %s, but was not in Dict' % (key, value))
+
 
 class TestAssertDictHasSubset(ReaderTest):
+
     def setUp(self):
         self.dictionary = {
-        'key-a' : 'val-a',
-        'key-b' : 'val-b'}
+            'key-a': 'val-a',
+            'key-b': 'val-b'}
 
     def tearDown(self):
         self.dictionary = None
 
     def test_subset(self):
-        self.assertDictHasSubset(self.dictionary, {'key-a':'val-a'})
+        self.assertDictHasSubset(self.dictionary, {'key-a': 'val-a'})
 
     def test_equal(self):
         self.assertDictHasSubset(self.dictionary, self.dictionary)
@@ -54,18 +56,19 @@ class TestAssertDictHasSubset(ReaderTest):
             AssertionError,
             'Expected.*key-c.*to have value.*val-c.*but was not in Dict',
             self.assertDictHasSubset,
-                self.dictionary,
-                {'key-c':'val-c'}
-            )
+            self.dictionary,
+            {'key-c': 'val-c'}
+        )
 
     def test_fail_wrong_val(self):
         self.assertRaisesRegexp(
             AssertionError,
             'Expected .*key-a.* to have value .*val-b.* but was .*val-a.*',
             self.assertDictHasSubset,
-                self.dictionary,
-                {'key-a':'val-b'}
-            )
+            self.dictionary,
+            {'key-a': 'val-b'}
+        )
+
 
 class DefaultReaderTest(ReaderTest):
 
@@ -153,17 +156,17 @@ class RstReaderTest(ReaderTest):
                 '(?P<date>\d{4}-\d{2}-\d{2})'
                 '_(?P<Slug>.*)'
                 '#(?P<MyMeta>.*)-(?P<author>.*)'
-                ),
+            ),
             EXTRA_PATH_METADATA={
                 input_with_metadata: {
                     'key-1a': 'value-1a',
                     'key-1b': 'value-1b'
-                    }
                 }
-            )
+            }
+        )
         expected_metadata = {
             'category': 'yeah',
-            'author' : 'Alexis Métaireau',
+            'author': 'Alexis Métaireau',
             'title': 'Rst with filename metadata',
             'date': SafeDatetime(2012, 11, 29),
             'slug': 'rst_w_filename_meta',
@@ -180,21 +183,21 @@ class RstReaderTest(ReaderTest):
             EXTRA_PATH_METADATA={
                 input_file_path_without_metadata: {
                     'author': 'Charlès Overwrite'}
-                }
-            )
+            }
+        )
         expected_without_metadata = {
-            'category' : 'misc',
-            'author'   : 'Charlès Overwrite',
-            'title'    : 'Article title',
-            'reader'   : 'rst',
+            'category': 'misc',
+            'author': 'Charlès Overwrite',
+            'title': 'Article title',
+            'reader': 'rst',
         }
         self.assertDictHasSubset(
             page_without_metadata.metadata,
             expected_without_metadata)
 
     def test_article_extra_path_metadata_dont_overwrite(self):
-        #EXTRA_PATH_METADATA['author'] should get ignored
-        #since we don't overwrite already set values
+        # EXTRA_PATH_METADATA['author'] should get ignored
+        # since we don't overwrite already set values
         input_file_path = '2012-11-29_rst_w_filename_meta#foo-bar.rst'
         page = self.read_file(
             path=input_file_path,
@@ -206,11 +209,11 @@ class RstReaderTest(ReaderTest):
                 input_file_path: {
                     'author': 'Charlès Overwrite',
                     'key-1b': 'value-1b'}
-                }
-            )
+            }
+        )
         expected = {
             'category': 'yeah',
-            'author' : 'Alexis Métaireau',
+            'author': 'Alexis Métaireau',
             'title': 'Rst with filename metadata',
             'date': SafeDatetime(2012, 11, 29),
             'slug': 'rst_w_filename_meta',
@@ -273,7 +276,7 @@ class RstReaderTest(ReaderTest):
             # typogrify should be able to ignore user specified tags,
             # but tries to be clever with widont extension
             page = self.read_file(path='article.rst', TYPOGRIFY=True,
-                                  TYPOGRIFY_IGNORE_TAGS = ['p'])
+                                  TYPOGRIFY_IGNORE_TAGS=['p'])
             expected = ('<p>THIS is some content. With some stuff to&nbsp;'
                         '&quot;typogrify&quot;...</p>\n<p>Now with added '
                         'support for <abbr title="three letter acronym">'
@@ -284,7 +287,7 @@ class RstReaderTest(ReaderTest):
             # typogrify should ignore code blocks by default because
             # code blocks are composed inside the pre tag
             page = self.read_file(path='article_with_code_block.rst',
-                                 TYPOGRIFY=True)
+                                  TYPOGRIFY=True)
 
             expected = ('<p>An article with some&nbsp;code</p>\n'
                         '<div class="highlight"><pre><span class="n">x</span>'
@@ -298,7 +301,7 @@ class RstReaderTest(ReaderTest):
 
             # instruct typogrify to also ignore blockquotes
             page = self.read_file(path='article_with_code_block.rst',
-                                 TYPOGRIFY=True, TYPOGRIFY_IGNORE_TAGS = ['blockquote'])
+                                  TYPOGRIFY=True, TYPOGRIFY_IGNORE_TAGS=['blockquote'])
 
             expected = ('<p>An article with some&nbsp;code</p>\n'
                         '<div class="highlight"><pre><span class="n">x</span>'
@@ -338,6 +341,7 @@ class RstReaderTest(ReaderTest):
         }
 
         self.assertDictHasSubset(page.metadata, expected)
+
 
 @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
 class MdReaderTest(ReaderTest):
@@ -502,6 +506,7 @@ class MdReaderTest(ReaderTest):
 
 
 class HTMLReaderTest(ReaderTest):
+
     def test_article_with_comments(self):
         page = self.read_file(path='article_with_comments.html')
 

--- a/pelican/tests/test_rstdirectives.py
+++ b/pelican/tests/test_rstdirectives.py
@@ -9,8 +9,10 @@ except ImportError:
         Mock = False
 from pelican.tests.support import unittest
 
+
 @unittest.skipUnless(Mock, 'Needs Mock module')
 class Test_abbr_role(unittest.TestCase):
+
     def call_it(self, text):
         from pelican.rstdirectives import abbr_role
         rawtext = text

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -12,10 +12,12 @@ from pelican.tests.support import unittest
 
 
 class TestSettingsConfiguration(unittest.TestCase):
+
     """Provided a file, it should read it, replace the default values,
     append new values to the settings (if any), and apply basic settings
     optimizations.
     """
+
     def setUp(self):
         self.old_locale = locale.setlocale(locale.LC_ALL)
         locale.setlocale(locale.LC_ALL, str('C'))
@@ -29,12 +31,12 @@ class TestSettingsConfiguration(unittest.TestCase):
     def test_overwrite_existing_settings(self):
         self.assertEqual(self.settings.get('SITENAME'), "Alexis' log")
         self.assertEqual(self.settings.get('SITEURL'),
-                'http://blog.notmyidea.org')
+                         'http://blog.notmyidea.org')
 
     def test_keep_default_settings(self):
         # Keep default settings if not defined.
         self.assertEqual(self.settings.get('DEFAULT_CATEGORY'),
-            DEFAULT_CONFIG['DEFAULT_CATEGORY'])
+                         DEFAULT_CONFIG['DEFAULT_CATEGORY'])
 
     def test_dont_copy_small_keys(self):
         # Do not copy keys not in caps.
@@ -70,27 +72,27 @@ class TestSettingsConfiguration(unittest.TestCase):
     def test_static_path_settings_safety(self):
         # Disallow static paths from being strings
         settings = {'STATIC_PATHS': 'foo/bar',
-                'THEME_STATIC_PATHS': 'bar/baz',
-                # These 4 settings are required to run configure_settings
-                'PATH': '.',
-                'THEME': DEFAULT_THEME,
-                'SITEURL': 'http://blog.notmyidea.org/',
-                'LOCALE': '',
-                }
+                    'THEME_STATIC_PATHS': 'bar/baz',
+                    # These 4 settings are required to run configure_settings
+                    'PATH': '.',
+                    'THEME': DEFAULT_THEME,
+                    'SITEURL': 'http://blog.notmyidea.org/',
+                    'LOCALE': '',
+                    }
         configure_settings(settings)
         self.assertEqual(settings['STATIC_PATHS'],
-                DEFAULT_CONFIG['STATIC_PATHS'])
+                         DEFAULT_CONFIG['STATIC_PATHS'])
         self.assertEqual(settings['THEME_STATIC_PATHS'],
-                DEFAULT_CONFIG['THEME_STATIC_PATHS'])
+                         DEFAULT_CONFIG['THEME_STATIC_PATHS'])
 
     def test_configure_settings(self):
         # Manipulations to settings should be applied correctly.
         settings = {
-                'SITEURL': 'http://blog.notmyidea.org/',
-                'LOCALE': '',
-                'PATH': os.curdir,
-                'THEME': DEFAULT_THEME,
-                }
+            'SITEURL': 'http://blog.notmyidea.org/',
+            'LOCALE': '',
+            'PATH': os.curdir,
+            'THEME': DEFAULT_THEME,
+        }
         configure_settings(settings)
 
         # SITEURL should not have a trailing slash
@@ -154,7 +156,7 @@ class TestSettingsConfiguration(unittest.TestCase):
         settings['PATH'] = ''
         self.assertRaises(Exception, configure_settings, settings)
 
-        # Test nonexistent THEME 
+        # Test nonexistent THEME
         settings['PATH'] = os.curdir
         settings['THEME'] = 'foo'
 

--- a/pelican/tests/test_urlwrappers.py
+++ b/pelican/tests/test_urlwrappers.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 from pelican.urlwrappers import URLWrapper, Tag, Category
 from pelican.tests.support import unittest
 
+
 class TestURLWrapper(unittest.TestCase):
+
     def test_ordering(self):
         # URLWrappers are sorted by name
         wrapper_a = URLWrapper(name='first', settings={})

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -72,7 +72,7 @@ class TestUtils(LoggedTestCase):
             '2012-11-22T22:11:10Z': date_hour_sec_z,
             '2012-11-22T22:11:10-0500': date_hour_sec_est,
             '2012-11-22T22:11:10.123Z': date_hour_sec_frac_z,
-            }
+        }
 
         # examples from http://www.w3.org/TR/NOTE-datetime
         iso_8601_date = utils.SafeDatetime(year=1997, month=7, day=16)
@@ -94,7 +94,6 @@ class TestUtils(LoggedTestCase):
 
         # invalid ones
         invalid_dates = ['2010-110-12', 'yay']
-
 
         for value, expected in dates.items():
             self.assertEqual(utils.get_date(value), expected, value)
@@ -264,7 +263,8 @@ class TestUtils(LoggedTestCase):
         self.assertEqual(utils.strftime(d, '%d/%m/%Y'), '29/08/2012')
 
         # RFC 3339
-        self.assertEqual(utils.strftime(d, '%Y-%m-%dT%H:%M:%SZ'),'2012-08-29T00:00:00Z')
+        self.assertEqual(
+            utils.strftime(d, '%Y-%m-%dT%H:%M:%SZ'), '2012-08-29T00:00:00Z')
 
         # % escaped
         self.assertEqual(utils.strftime(d, '%d%%%m%%%y'), '29%08%12')
@@ -290,7 +290,6 @@ class TestUtils(LoggedTestCase):
         d = utils.SafeDatetime(2012, 8, 9)
         self.assertEqual(utils.strftime(d, '%-d/%-m/%y'), '9/8/12')
 
-
     # test the output of utils.strftime in a different locale
     # Turkish locale
     @unittest.skipUnless(locale_available('tr_TR.UTF-8') or
@@ -314,15 +313,14 @@ class TestUtils(LoggedTestCase):
 
         # with text
         self.assertEqual(utils.strftime(d, 'Yayınlanma tarihi: %A, %d %B %Y'),
-            'Yayınlanma tarihi: Çarşamba, 29 Ağustos 2012')
+                         'Yayınlanma tarihi: Çarşamba, 29 Ağustos 2012')
 
         # non-ascii format candidate (someone might pass it... for some reason)
         self.assertEqual(utils.strftime(d, '%Y yılında %üretim artışı'),
-            '2012 yılında %üretim artışı')
+                         '2012 yılında %üretim artışı')
 
         # restore locale back
         locale.setlocale(locale.LC_ALL, old_locale)
-
 
     # test the output of utils.strftime in a different locale
     # French locale
@@ -348,23 +346,26 @@ class TestUtils(LoggedTestCase):
 
         # with text
         self.assertEqual(utils.strftime(d, 'Écrit le %d %B %Y'),
-            'Écrit le 29 août 2012')
+                         'Écrit le 29 août 2012')
 
         # non-ascii format candidate (someone might pass it... for some reason)
         self.assertEqual(utils.strftime(d, '%écrits en %Y'),
-            '%écrits en 2012')
+                         '%écrits en 2012')
 
         # restore locale back
         locale.setlocale(locale.LC_ALL, old_locale)
 
-
     def test_maybe_pluralize(self):
-        self.assertEqual(utils.maybe_pluralize(0, 'Article', 'Articles'), '0 Articles')
-        self.assertEqual(utils.maybe_pluralize(1, 'Article', 'Articles'), '1 Article')
-        self.assertEqual(utils.maybe_pluralize(2, 'Article', 'Articles'), '2 Articles')
+        self.assertEqual(
+            utils.maybe_pluralize(0, 'Article', 'Articles'), '0 Articles')
+        self.assertEqual(
+            utils.maybe_pluralize(1, 'Article', 'Articles'), '1 Article')
+        self.assertEqual(
+            utils.maybe_pluralize(2, 'Article', 'Articles'), '2 Articles')
 
 
 class TestCopy(unittest.TestCase):
+
     '''Tests the copy utility'''
 
     def setUp(self):
@@ -449,6 +450,7 @@ class TestCopy(unittest.TestCase):
 
 
 class TestDateFormatter(unittest.TestCase):
+
     '''Tests that the output of DateFormatter jinja filter is same as
     utils.strftime'''
 
@@ -465,35 +467,36 @@ class TestDateFormatter(unittest.TestCase):
             template_file.write('date = {{ date|strftime("%A, %d %B %Y") }}')
         self.date = utils.SafeDatetime(2012, 8, 29)
 
-
     def tearDown(self):
         shutil.rmtree(self.temp_content)
         shutil.rmtree(self.temp_output)
         # reset locale to default
         locale.setlocale(locale.LC_ALL, '')
 
-
     @unittest.skipUnless(locale_available('fr_FR.UTF-8') or
                          locale_available('French'),
                          'French locale needed')
     def test_french_strftime(self):
-        # This test tries to reproduce an issue that occurred with python3.3 under macos10 only
+        # This test tries to reproduce an issue that occurred with python3.3
+        # under macos10 only
         if platform == 'win32':
             locale.setlocale(locale.LC_ALL, str('French'))
         else:
             locale.setlocale(locale.LC_ALL, str('fr_FR.UTF-8'))
-        date = utils.SafeDatetime(2014,8,14)
-        # we compare the lower() dates since macos10 returns "Jeudi" for %A whereas linux reports "jeudi"
-        self.assertEqual( u'jeudi, 14 août 2014', utils.strftime(date, date_format="%A, %d %B %Y").lower() )
+        date = utils.SafeDatetime(2014, 8, 14)
+        # we compare the lower() dates since macos10 returns "Jeudi" for %A
+        # whereas linux reports "jeudi"
+        self.assertEqual(u'jeudi, 14 août 2014', utils.strftime(
+            date, date_format="%A, %d %B %Y").lower())
         df = utils.DateFormatter()
-        self.assertEqual( u'jeudi, 14 août 2014', df(date, date_format="%A, %d %B %Y").lower() )
+        self.assertEqual(
+            u'jeudi, 14 août 2014', df(date, date_format="%A, %d %B %Y").lower())
         # Let us now set the global locale to C:
         locale.setlocale(locale.LC_ALL, str('C'))
         # DateFormatter should still work as expected since it is the whole point of DateFormatter
         # (This is where pre-2014/4/15 code fails on macos10)
         df_date = df(date, date_format="%A, %d %B %Y").lower()
-        self.assertEqual( u'jeudi, 14 août 2014', df_date )
-
+        self.assertEqual(u'jeudi, 14 août 2014', df_date)
 
     @unittest.skipUnless(locale_available('fr_FR.UTF-8') or
                          locale_available('French'),
@@ -504,8 +507,8 @@ class TestDateFormatter(unittest.TestCase):
         else:
             locale_string = 'fr_FR.UTF-8'
         settings = read_settings(
-            override = {'LOCALE': locale_string,
-                        'TEMPLATE_PAGES': {'template/source.html':
+            override={'LOCALE': locale_string,
+                      'TEMPLATE_PAGES': {'template/source.html':
                                          'generated/file.html'}})
 
         generator = TemplatePagesGenerator(
@@ -517,7 +520,7 @@ class TestDateFormatter(unittest.TestCase):
         generator.generate_output(writer)
 
         output_path = os.path.join(
-                self.temp_output, 'generated', 'file.html')
+            self.temp_output, 'generated', 'file.html')
 
         # output file has been generated
         self.assertTrue(os.path.exists(output_path))
@@ -526,7 +529,6 @@ class TestDateFormatter(unittest.TestCase):
         with utils.pelican_open(output_path) as output_file:
             self.assertEqual(output_file,
                              utils.strftime(self.date, 'date = %A, %d %B %Y'))
-
 
     @unittest.skipUnless(locale_available('tr_TR.UTF-8') or
                          locale_available('Turkish'),
@@ -537,9 +539,9 @@ class TestDateFormatter(unittest.TestCase):
         else:
             locale_string = 'tr_TR.UTF-8'
         settings = read_settings(
-            override = {'LOCALE': locale_string,
-                        'TEMPLATE_PAGES': {'template/source.html':
-                                           'generated/file.html'}})
+            override={'LOCALE': locale_string,
+                      'TEMPLATE_PAGES': {'template/source.html':
+                                         'generated/file.html'}})
 
         generator = TemplatePagesGenerator(
             {'date': self.date}, settings,
@@ -550,7 +552,7 @@ class TestDateFormatter(unittest.TestCase):
         generator.generate_output(writer)
 
         output_path = os.path.join(
-                self.temp_output, 'generated', 'file.html')
+            self.temp_output, 'generated', 'file.html')
 
         # output file has been generated
         self.assertTrue(os.path.exists(output_path))

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 @python_2_unicode_compatible
 @functools.total_ordering
 class URLWrapper(object):
+
     def __init__(self, name, settings):
         self.settings = settings
         self._name = name
@@ -105,7 +106,7 @@ class URLWrapper(object):
                 return value.format(**self.as_dict())
 
     page_name = property(functools.partial(_from_settings, key='URL',
-                         get_page_name=True))
+                                           get_page_name=True))
     url = property(functools.partial(_from_settings, key='URL'))
     save_as = property(functools.partial(_from_settings, key='SAVE_AS'))
 
@@ -115,6 +116,7 @@ class Category(URLWrapper):
 
 
 class Tag(URLWrapper):
+
     def __init__(self, name, *args, **kwargs):
         super(Tag, self).__init__(name.strip(), *args, **kwargs)
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -91,6 +91,7 @@ def strftime(date, date_format):
 
 
 class SafeDatetime(datetime.datetime):
+
     '''Subclass of datetime that works with utf-8 format strings on PY2'''
 
     def strftime(self, fmt, safe=True):
@@ -102,6 +103,7 @@ class SafeDatetime(datetime.datetime):
 
 
 class DateFormatter(object):
+
     '''A date formatter object used as a jinja filter
 
     Uses the `strftime` implementation and makes sure jinja uses the locale
@@ -144,12 +146,14 @@ def python_2_unicode_compatible(klass):
 
 
 class memoized(object):
+
     """Function decorator to cache return values.
 
     If called later with the same arguments, the cached value is returned
     (not reevaluated).
 
     """
+
     def __init__(self, func):
         self.func = func
         self.cache = {}
@@ -200,7 +204,7 @@ def deprecated_attribute(old, new, since=None, remove=None, doc=None):
         message.append('.  Use {} instead.'.format(new))
         logger.warning(''.join(message))
         logger.debug(''.join(
-                six.text_type(x) for x in traceback.format_stack()))
+            six.text_type(x) for x in traceback.format_stack()))
 
     def fget(self):
         _warn()
@@ -223,7 +227,7 @@ def get_date(string):
     """
     string = re.sub(' +', ' ', string)
     default = SafeDatetime.now().replace(hour=0, minute=0,
-                                        second=0, microsecond=0)
+                                         second=0, microsecond=0)
     try:
         return dateutil.parser.parse(string, default=default)
     except (TypeError, ValueError):
@@ -318,12 +322,12 @@ def copy(source, destination, ignores=None):
 
         for src_dir, subdirs, others in os.walk(source_):
             dst_dir = os.path.join(destination_,
-                                    os.path.relpath(src_dir, source_))
+                                   os.path.relpath(src_dir, source_))
 
             subdirs[:] = (s for s in subdirs if not any(fnmatch.fnmatch(s, i)
                                                         for i in ignores))
-            others[:] =  (o for o in others  if not any(fnmatch.fnmatch(o, i)
-                                                        for i in ignores))
+            others[:] = (o for o in others if not any(fnmatch.fnmatch(o, i)
+                                                      for i in ignores))
 
             if not os.path.isdir(dst_dir):
                 logger.info('Creating directory %s', dst_dir)
@@ -339,6 +343,7 @@ def copy(source, destination, ignores=None):
                 else:
                     logger.warning('Skipped copy %s (not a file or directory) to %s',
                                    src_path, dst_path)
+
 
 def clean_output_dir(path, retention):
     """Remove all files from output directory except those in retention list"""
@@ -365,8 +370,8 @@ def clean_output_dir(path, retention):
                 shutil.rmtree(file)
                 logger.debug("Deleted directory %s", file)
             except Exception as e:
-                logger.error("Unable to delete directory %s; %s", 
-                        file, e)
+                logger.error("Unable to delete directory %s; %s",
+                             file, e)
         elif os.path.isfile(file) or os.path.islink(file):
             try:
                 os.remove(file)
@@ -500,9 +505,9 @@ def process_translations(content_list, order_by=None):
         items = list(items)
         # items with `translation` metadata will be used as translations…
         default_lang_items = list(filter(
-                lambda i: i.metadata.get('translation', 'false').lower()
-                        == 'false',
-                items))
+            lambda i: i.metadata.get('translation', 'false').lower()
+            == 'false',
+            items))
         # …unless all items with that slug are translations
         if not default_lang_items:
             default_lang_items = items
@@ -513,13 +518,13 @@ def process_translations(content_list, order_by=None):
             len_ = len(lang_items)
             if len_ > 1:
                 logger.warning('There are %s variants of "%s" with lang %s',
-                    len_, slug, lang)
+                               len_, slug, lang)
                 for x in lang_items:
                     logger.warning('\t%s', x.source_path)
 
         # find items with default language
         default_lang_items = list(filter(attrgetter('in_default_lang'),
-                default_lang_items))
+                                         default_lang_items))
 
         # if there is no article with default language, take an other one
         if not default_lang_items:
@@ -527,10 +532,10 @@ def process_translations(content_list, order_by=None):
 
         if not slug:
             logger.warning(
-                    'empty slug for %s. '
-                    'You can fix this by adding a title or a slug to your '
-                    'content',
-                    default_lang_items[0].source_path)
+                'empty slug for %s. '
+                'You can fix this by adding a title or a slug to your '
+                'content',
+                default_lang_items[0].source_path)
         index.extend(default_lang_items)
         translations.extend([x for x in items if x not in default_lang_items])
         for a in items:
@@ -559,10 +564,10 @@ def process_translations(content_list, order_by=None):
                                reverse=order_reversed)
                 except AttributeError:
                     logger.warning('There is no "%s" attribute in the item '
-                        'metadata. Defaulting to slug order.', order_by)
+                                   'metadata. Defaulting to slug order.', order_by)
         else:
             logger.warning('Invalid *_ORDER_BY setting (%s).'
-                'Valid options are strings and functions.', order_by)
+                           'Valid options are strings and functions.', order_by)
 
     return index, translations
 
@@ -581,7 +586,7 @@ def folder_watcher(path, extensions, ignores=[]):
 
             for f in files:
                 if (f.endswith(tuple(extensions)) and
-                    not any(fnmatch.fnmatch(f, ignore) for ignore in ignores)):
+                        not any(fnmatch.fnmatch(f, ignore) for ignore in ignores)):
                     try:
                         yield os.stat(os.path.join(root, f)).st_mtime
                     except OSError as e:

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -119,9 +119,9 @@ class Writer(object):
                 feed.write(fp, 'utf-8')
                 logger.info('Writing %s', complete_path)
 
-            signals.feed_written.send(complete_path, context=context, feed=feed)
+            signals.feed_written.send(
+                complete_path, context=context, feed=feed)
         return feed
-
 
     def write_file(self, name, template, context, relative_urls=False,
                    paginated=None, override_output=False, **kwargs):
@@ -140,8 +140,8 @@ class Writer(object):
         """
 
         if name is False or name == "" or\
-           not is_selected_for_writing(self.settings,\
-               os.path.join(self.output_path, name)):
+           not is_selected_for_writing(self.settings,
+                                       os.path.join(self.output_path, name)):
             return
         elif not name:
             # other stuff, just return for now
@@ -169,7 +169,8 @@ class Writer(object):
 
         def _get_localcontext(context, name, kwargs, relative_urls):
             localcontext = context.copy()
-            localcontext['localsiteurl'] = localcontext.get('localsiteurl', None)
+            localcontext['localsiteurl'] = localcontext.get(
+                'localsiteurl', None)
             if relative_urls:
                 relative_url = path_to_url(get_relative_path(name))
                 localcontext['SITEURL'] = relative_url
@@ -201,11 +202,13 @@ class Writer(object):
                          '%s_previous_page' % key: previous_page,
                          '%s_next_page' % key: next_page})
 
-                localcontext = _get_localcontext(context, page.save_as, paginated_kwargs, relative_urls)
+                localcontext = _get_localcontext(
+                    context, page.save_as, paginated_kwargs, relative_urls)
                 _write_file(template, localcontext, self.output_path,
                             page.save_as, override_output)
         else:
             # no pagination
-            localcontext = _get_localcontext(context, name, kwargs, relative_urls)
+            localcontext = _get_localcontext(
+                context, name, kwargs, relative_urls)
             _write_file(template, localcontext, self.output_path, name,
                         override_output)


### PR DESCRIPTION
I fixed pep8 violations in peilcan/*.py and pelican/tests/*.py by using autopep8 command version 1.1.1. Fixes #1752.