### PR TITLE
Switch from Coveralls to Codecov

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,9 @@ Why the name "Pelican"?
 .. |build-status| image:: https://img.shields.io/travis/getpelican/pelican/master.svg
    :target: https://travis-ci.org/getpelican/pelican
    :alt: Travis CI: continuous integration status
-.. |coverage-status| image:: https://img.shields.io/coveralls/getpelican/pelican.svg
-   :target: https://coveralls.io/r/getpelican/pelican
-   :alt: Coveralls: code coverage status
+.. |coverage-status| image:: https://img.shields.io/codecov/c/github/getpelican/pelican.svg
+   :target: https://codecov.io/github/getpelican/pelican
+   :alt: Codecov: code coverage status
 .. |pypi-version| image:: https://img.shields.io/pypi/v/pelican.svg
    :target: https://pypi.python.org/pypi/pelican
    :alt: PyPI: the Python Package Index

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
 
 commands =
     {envpython} --version
-    nosetests -sv --with-coverage --cover-package=pelican pelican
+    nosetests -sv --with-coverage --cover-branches --cover-package=pelican pelican
     codecov
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,12 @@ deps =
     -rdev_requirements.txt
     nose
     nose-cov
-    coveralls
+    codecov
 
 commands =
     {envpython} --version
     nosetests -sv --with-coverage --cover-package=pelican pelican
-    coveralls
+    codecov
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
**Full disclosure**: I work for Codecov

A few reasons pelican should be using Codecov:
- Codecov supports branch coverage (e.g. Codecov [caught this missing else branch](https://codecov.io/github/treyhunner/pelican/pelican/tools/pelican_import.py?ref=e348964d04564d456b2ab76d3cb16cf9408c6b49#l-523) while Coveralls [did not](https://coveralls.io/builds/3183205)).
- Codecov has a browser plugin for display coverage right from GitHub ([example](http://i.imgur.com/YKW8P13.png))
- The reports are easier to navigate. [Here's an example report for pelican](https://codecov.io/github/treyhunner/pelican/pelican?ref=e348964d04564d456b2ab76d3cb16cf9408c6b49).

Branch coverage is the reason I originally started using Codecov.
