### PR TITLE
Add missing *.markdown files to PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
-recursive-include pelican *.html *.css *png *.in *.rst *.md *.mkd *.xml *.py
+recursive-include pelican *.html *.css *png *.in *.rst *.markdown *.md *.mkd *.xml *.py
 include LICENSE THANKS docs/changelog.rst


### PR DESCRIPTION
The following file is missing from the PyPI source distribution (sdist) due to *.markdown not being referenced in MANIFEST.in:

pelican/tests/content/article_with_markdown_extension.markdown

This missing file appears to cause a number of errors running the test suite. An alternative to this change would be to rename the file to .md so that the file is covered by the existing *.md entry.