### PR TITLE
Add warning for unknown replacement indicators

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -248,6 +248,11 @@ class Content(object):
                 origin = '/'.join((siteurl, Category(path, self.settings).url))
             elif what == 'tag':
                 origin = '/'.join((siteurl, Tag(path, self.settings).url))
+            else:
+                logger.warning(
+                        "Replacement Indicator '%s' not recognized, "
+                        "skipping replacement",
+                        what)
 
             # keep all other parts, such as query, fragment, etc.
             parts = list(value)


### PR DESCRIPTION
If an unknown replacement indicator {bla} was used, it was ignored
silently. This commit adds a warning when an unmatched indicator occurs
to help identify the issue.

closes #1794