### PR TITLE
Add optional override_output to write_feed

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -79,7 +79,8 @@ class Writer(object):
         self._written_files.add(filename)
         return open(filename, 'w', encoding=encoding)
 
-    def write_feed(self, elements, context, path=None, feed_type='atom'):
+    def write_feed(self, elements, context, path=None, feed_type='atom',
+                   override_output=False):
         """Generate a feed with the list of articles provided
 
         Return the feed. If no path or output_path is specified, just
@@ -89,6 +90,9 @@ class Writer(object):
         :param context: the context to get the feed metadata.
         :param path: the path to output.
         :param feed_type: the feed type to use (atom or rss)
+        :param override_output: boolean telling if we can override previous
+            output with the same name (and if next files written with the same
+            name should be skipped to keep that one)
         """
         if not is_selected_for_writing(self.settings, path):
             return
@@ -115,7 +119,7 @@ class Writer(object):
                 pass
 
             encoding = 'utf-8' if six.PY3 else None
-            with self._open_w(complete_path, encoding) as fp:
+            with self._open_w(complete_path, encoding, override_output) as fp:
                 feed.write(fp, 'utf-8')
                 logger.info('Writing %s', complete_path)
 


### PR DESCRIPTION
The write_feed function now takes an override_output parameter that does the same thing as override_output does to write_file. Implemented for custom generators.

This is a very minor change; all the unit tests still pass as no surface behavior was changed.

As for why I wanted/needed this... I was working a plugin that implemented a custom generator (that fetches articles from mailboxes, which is why it had to be implemented as a generator and not a reader). I ran into an interesting potential issue: among other things, author names could potentially collide between articles in ```content/``` and "articles" produced from the mailbox. It was easy enough to fix this by passing ```override_output=True``` to ```write_file```, but since such an option didn't exist for ```write_feed``` it wasn't possible to overwrite the feeds.

I could imagine other plugin developers potentially needing or wanting this functionality too.