### PR TITLE
Correct render of article description meta

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -5,9 +5,9 @@
     <meta name="keywords" content="{{keyword}}" />
   {% endfor %}
 
-  {% for description in article.description %}
-    <meta name="description" content="{{description}}" />
-  {% endfor %}
+  {% if article.description %}
+    <meta name="description" content="{{article.description}}" />
+  {% endif %}
 
   {% for tag in article.tags %}
     <meta name="tags" content="{{tag}}" />


### PR DESCRIPTION
in the simple theme: the template incorrectly assumed that the source
metadata is made available as a list of strings. Fixes #1792.