### PR TITLE
Add new MD_OUTPUT_FORMAT setting to customize Markdown output format

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -249,6 +249,7 @@ class MarkdownReader(BaseReader):
         if 'meta' not in self.extensions:
             self.extensions.append('meta')
         self._source_path = None
+        self.output_format = self.settings['MD_OUTPUT_FORMAT']
 
     def _parse_metadata(self, meta):
         """Return the dict containing document metadata"""
@@ -282,7 +283,9 @@ class MarkdownReader(BaseReader):
         """Parse content and metadata of markdown files"""
 
         self._source_path = source_path
-        self._md = Markdown(extensions=self.extensions)
+        self._md = Markdown(
+            extensions=self.extensions,
+            output_format=self.output_format)
         with pelican_open(source_path) as text:
             content = self._md.convert(text)
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -100,6 +100,7 @@ DEFAULT_CONFIG = {
     'DEFAULT_DATE_FORMAT': '%a %d %B %Y',
     'DATE_FORMATS': {},
     'MD_EXTENSIONS': ['codehilite(css_class=highlight)', 'extra'],
+    'MD_OUTPUT_FORMAT' : 'xhtml1',
     'JINJA_EXTENSIONS': [],
     'JINJA_FILTERS': {},
     'LOG_FILTER': [],

--- a/pelican/tests/content/article_with_different_output_format.md
+++ b/pelican/tests/content/article_with_different_output_format.md
@@ -1,0 +1,5 @@
+Title: Article output format
+
+Some text[^footnote]
+
+[^footnote]: Some footnote

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -500,6 +500,43 @@ class MdReaderTest(ReaderTest):
         }
         self.assertDictHasSubset(page.metadata, expected)
 
+    def test_article_with_different_output_format(self):
+        reader = readers.MarkdownReader(settings=get_settings())
+        # test the default xhtml1 output format
+        expected = ('<p>Some text<sup id="fnref:footnote"><a class="footnote-re'
+                    'f" href="#fn:footnote" rel="footnote">1</a></sup></p>\n'
+                    '<div class="footnote">\n'
+                    '<hr />\n'
+                    '<ol>\n'
+                    '<li id="fn:footnote">\n'
+                    '<p>Some footnote&#160;<a class="footnote-backref" href="#fn'
+                    'ref:footnote" rev="footnote" title="Jump back to footnote 1'
+                    ' in the text">&#8617;</a></p>\n'
+                    '</li>\n'
+                    '</ol>\n'
+                    '</div>')
+        content, metadata = reader.read(
+            _path('article_with_different_output_format.md'))
+        self.assertEqual(content, expected)
+
+        # test html5 output format
+        reader = readers.MarkdownReader(
+            settings=dict(get_settings(), MD_OUTPUT_FORMAT='html5'))
+        expected = ('<p>Some text<sup id="fnref-footnote"><a class="footnote-re'
+                    'f" href="#fn-footnote">1</a></sup></p>\n'
+                    '<div class="footnote">\n'
+                    '<hr>\n'
+                    '<ol>\n'
+                    '<li id="fn-footnote">\n'
+                    '<p>Some footnote&#160;<a class="footnote-backref" href="#fn'
+                    'ref-footnote" title="Jump back to footnote 1 in the text">'
+                    '&#8617;</a></p>\n'
+                    '</li>\n'
+                    '</ol>\n'
+                    '</div>')
+        content, metadata = reader.read(
+            _path('article_with_different_output_format.md'))
+        self.assertEqual(content, expected)
 
 class HTMLReaderTest(ReaderTest):
     def test_article_with_comments(self):


### PR DESCRIPTION
The setting `MD_OUTPUT_FORMAT` allows users to customize Markdown output format.

In the case where the template is designed to follow html5, Markdown by default will generate xhtml1 compatible tags, which will cause invalid html output as the added test case illustrates.

Reference: https://pythonhosted.org/Markdown/reference.html#output_format