### PR TITLE
When truncating, consider hyphens, apostrophes and HTML entities.

### DIFF
--- a/pelican/tests/output/basic/category/misc.html
+++ b/pelican/tests/output/basic/category/misc.html
@@ -90,7 +90,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="/unbelievable.html">read more</a>
                 </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/basic/index.html
+++ b/pelican/tests/output/basic/index.html
@@ -227,7 +227,7 @@ YEAH !</p>
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="/unbelievable.html">read more</a>
                 </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="../unbelievable.html">read more</a>
 <p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -103,7 +103,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="../unbelievable.html">read more</a>
 <p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="./unbelievable.html">read more</a>
 <p>There are <a href="./unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
 <p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -103,7 +103,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
 <p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom_locale/index3.html
+++ b/pelican/tests/output/custom_locale/index3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it ...</p></div>
+pelican.conf, it will ...</p></div>
                 <a class="readmore" href="./posts/2010/octobre/15/unbelievable/">read more</a>
 <p>There are <a href="./posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -146,30 +146,50 @@ class TestUtils(LoggedTestCase):
             self.assertEqual(utils.get_relative_path(value), expected)
 
     def test_truncate_html_words(self):
+        # Plain text.
         self.assertEqual(
             utils.truncate_html_words('short string', 20),
             'short string')
-
         self.assertEqual(
             utils.truncate_html_words('word ' * 100, 20),
             'word ' * 20 + '...')
 
+        # Words enclosed or intervaled by HTML tags.
         self.assertEqual(
             utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20),
             '<p>' + 'word ' * 20 + '...</p>')
-
         self.assertEqual(
             utils.truncate_html_words(
                 '<span\nstyle="\n...\n">' + 'word ' * 100 + '</span>', 20),
             '<span\nstyle="\n...\n">' + 'word ' * 20 + '...</span>')
-
         self.assertEqual(
             utils.truncate_html_words('<br>' + 'word ' * 100, 20),
             '<br>' + 'word ' * 20 + '...')
-
         self.assertEqual(
             utils.truncate_html_words('<!-- comment -->' + 'word ' * 100, 20),
             '<!-- comment -->' + 'word ' * 20 + '...')
+
+        # Words with hypens and apostrophes.
+        self.assertEqual(
+            utils.truncate_html_words("a-b " * 100, 20),
+            "a-b " * 20 + '...')
+        self.assertEqual(
+            utils.truncate_html_words("it's " * 100, 20),
+            "it's " * 20 + '...')
+
+        # Words with HTML entity references.
+        self.assertEqual(
+            utils.truncate_html_words("&eacute; " * 100, 20),
+            "&eacute; " * 20 + '...')
+        self.assertEqual(
+            utils.truncate_html_words("caf&eacute; " * 100, 20),
+            "caf&eacute; " * 20 + '...')
+        self.assertEqual(
+            utils.truncate_html_words("&egrave;lite " * 100, 20),
+            "&egrave;lite " * 20 + '...')
+        self.assertEqual(
+            utils.truncate_html_words("cafeti&eacute;re " * 100, 20),
+            "cafeti&eacute;re " * 20 + '...')
 
     def test_process_translations(self):
         # create a bunch of articles


### PR DESCRIPTION
Thanks for approving my last PR.

Here's a new one: this code avoids truncating words like "it's", "here's" or "caf&egrave;".

When this PR gets merged, I'll create a new one for improving the speed of `_HTMLWordTruncator`.