### PR TITLE
Fix tag count calculation in Dotclear import

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -259,7 +259,7 @@ def dc2fields(file):
         # Get tags related to a post
         tag = post_meta.replace('{', '').replace('}', '').replace('a:1:s:3:\\"tag\\";a:', '').replace('a:0:', '')
         if len(tag) > 1:
-            if int(tag[:1]) == 1:
+            if int(len(tag[:1])) == 1:
                 newtag = tag.split('"')[1]
                 tags.append(
                     BeautifulSoup(


### PR DESCRIPTION
Upon import of a dotclear backup, `pelican-import` returned this stacktrace:

```
  File "/usr/bin/pelican-import", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python3.4/site-packages/pelican/tools/pelican_import.py", line 809, in main
    attachments = attachments or None)
  File "/usr/lib/python3.4/site-packages/pelican/tools/pelican_import.py", line 621, in fields2pelican
    kind, in_markup) in fields:
  File "/usr/lib/python3.4/site-packages/pelican/tools/pelican_import.py", line 262, in dc2fields
    if int(tag[:1]) == 1:
ValueError: invalid literal for int() with base 10: 'a'
```