### PR TITLE
Remove article.keywords from simple theme

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 {% block head %}
   {{ super() }}
-  {% for keyword in article.keywords %}
-    <meta name="keywords" content="{{keyword}}" />
-  {% endfor %}
-
   {% if article.description %}
     <meta name="description" content="{{article.description}}" />
   {% endif %}


### PR DESCRIPTION
We don't process 'keywords' metadata specially, so it never gets
processed into a list.

This prevents issues like #1733.