### PR TITLE
Add index and author replacement indicators

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -329,11 +329,11 @@ of ``{attach}``, and letting the file's location be determined by the project's
 ``STATIC_SAVE_AS`` and ``STATIC_URL`` settings. (Per-file ``save_as`` and
 ``url`` overrides can still be set in ``EXTRA_PATH_METADATA``.)
 
-Linking to tags and categories
-------------------------------
+Linking to authors, categories, index and tags
+----------------------------------------------
 
-You can link to tags and categories using the ``{tag}tagname`` and
-``{category}foobar`` syntax.
+You can link to authors, categories, index and tags using the ``{author}name``,
+``{category}foobar``, ``{index}`` and ``{tag}tagname`` syntax.
 
 Deprecated internal link syntax
 -------------------------------

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -21,7 +21,7 @@ from pelican.utils import (SafeDatetime, deprecated_attribute, memoized,
                            slugify, strftime, truncate_html_words)
 
 # Import these so that they're avalaible when you import from pelican.contents.
-from pelican.urlwrappers import (URLWrapper, Author, Category, Tag)  # NOQA
+from pelican.urlwrappers import (Author, Category, Tag, URLWrapper)  # NOQA
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +253,10 @@ class Content(object):
                 origin = '/'.join((siteurl, Category(path, self.settings).url))
             elif what == 'tag':
                 origin = '/'.join((siteurl, Tag(path, self.settings).url))
+            elif what == 'index':
+                origin = '/'.join((siteurl, self.settings['INDEX_SAVE_AS']))
+            elif what == 'author':
+                origin = '/'.join((siteurl, Author(path, self.settings).url))
             else:
                 logger.warning(
                     "Replacement Indicator '%s' not recognized, "

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -64,6 +64,7 @@ DEFAULT_CONFIG = {
     'REVERSE_CATEGORY_ORDER': False,
     'DELETE_OUTPUT_DIRECTORY': False,
     'OUTPUT_RETENTION': [],
+    'INDEX_SAVE_AS': 'index.html',
     'ARTICLE_URL': '{slug}.html',
     'ARTICLE_SAVE_AS': '{slug}.html',
     'ARTICLE_ORDER_BY': 'reversed-date',

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -606,6 +606,40 @@ class TestStatic(LoggedTestCase):
 
         self.assertNotEqual(content, html)
 
+    def test_author_link_syntax(self):
+        "{author} link syntax triggers url replacement."
+
+        html = '<a href="{author}foo">link</a>'
+        page = Page(
+            content=html,
+            metadata={'title': 'fakepage'},
+            settings=self.settings,
+            source_path=os.path.join('dir', 'otherdir', 'fakepage.md'),
+            context=self.context)
+        content = page.get_content('')
+
+        self.assertNotEqual(content, html)
+
+    def test_index_link_syntax(self):
+        "{index} link syntax triggers url replacement."
+
+        html = '<a href="{index}">link</a>'
+        page = Page(
+            content=html,
+            metadata={'title': 'fakepage'},
+            settings=self.settings,
+            source_path=os.path.join('dir', 'otherdir', 'fakepage.md'),
+            context=self.context)
+        content = page.get_content('')
+
+        self.assertNotEqual(content, html)
+
+        expected_html = ('<a href="' +
+                         '/'.join((self.settings['SITEURL'],
+                                   self.settings['INDEX_SAVE_AS'])) +
+                         '">link</a>')
+        self.assertEqual(content, expected_html)
+
     def test_unknown_link_syntax(self):
         "{unknown} link syntax should trigger warning."
 

--- a/pelican/tests/test_urlwrappers.py
+++ b/pelican/tests/test_urlwrappers.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from pelican.tests.support import unittest
-from pelican.urlwrappers import Category, Tag, URLWrapper
+from pelican.urlwrappers import Author, Category, Tag, URLWrapper
 
 
 class TestURLWrapper(unittest.TestCase):
@@ -34,9 +34,11 @@ class TestURLWrapper(unittest.TestCase):
     def test_equality(self):
         tag = Tag('test', settings={})
         cat = Category('test', settings={})
+        author = Author('test', settings={})
 
         # same name, but different class
         self.assertNotEqual(tag, cat)
+        self.assertNotEqual(tag, author)
 
         # should be equal vs text representing the same name
         self.assertEqual(tag, u'test')
@@ -47,6 +49,10 @@ class TestURLWrapper(unittest.TestCase):
         # Tags describing the same should be equal
         tag_equal = Tag('Test', settings={})
         self.assertEqual(tag, tag_equal)
+
+        # Author describing the same should be equal
+        author_equal = Author('Test', settings={})
+        self.assertEqual(author, author_equal)
 
         cat_ascii = Category('指導書', settings={})
         self.assertEqual(cat_ascii, u'zhi-dao-shu')


### PR DESCRIPTION
There is no easy way to make a link to index of website created with pelican. This patch is aiming to fix this issue. With this patch we can create links to our index with `[Link]({index})`.

Patch also adds author replacement indicator. We can create links to author pages with: `[Link]({author}Someone)`.