### PR TITLE
Changed rebuild to preview in publish to GitHub pages command in fabfile.py

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -89,6 +89,6 @@ def publish():
 
 def gh_pages():
     """Publish to GitHub Pages"""
-    rebuild()
+    preview()
     local("ghp-import -b {github_pages_branch} {deploy_path}".format(**env))
     local("git push origin {github_pages_branch}".format(**env))


### PR DESCRIPTION
I think it wrong to build not-publish version before publishing site.
