### PR TITLE
Make name of blogroll/social widgets configurable

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -24,6 +24,7 @@ Andrew Spiers
 Arnaud BOS
 asselinpaul
 Axel Haustant
+Ben Rosser (TC01)
 Benoît HERVIER
 Borgar
 Brandon W Maister

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -724,6 +724,10 @@ Setting name              What does it do?
 ``TWITTER_USERNAME``      Allows for adding a button to articles to encourage
                           others to tweet about them. Add your Twitter username
                           if you want this button to appear.
+``LINKS_WIDGET_NAME``     Allows override of the name of the links widget.
+                          If not specified, defaults to "links".
+``SOCIAL_WIDGET_NAME``    Allows override of the name of the "social" widget.
+                          If not specified, defaults to "social".
 =======================   =======================================================
 
 In addition, you can use the "wide" version of the ``notmyidea`` theme by

--- a/pelican/tests/output/custom/a-markdown-powered-article.html
+++ b/pelican/tests/output/custom/a-markdown-powered-article.html
@@ -71,7 +71,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/archives.html
+++ b/pelican/tests/output/custom/archives.html
@@ -56,7 +56,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/article-1.html
+++ b/pelican/tests/output/custom/article-1.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/article-2.html
+++ b/pelican/tests/output/custom/article-2.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/article-3.html
+++ b/pelican/tests/output/custom/article-3.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau.html
@@ -129,7 +129,7 @@
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau2.html
@@ -143,7 +143,7 @@ YEAH !</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -94,7 +94,7 @@ pelican.conf, it will ...</p></div>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/authors.html
+++ b/pelican/tests/output/custom/authors.html
@@ -38,7 +38,7 @@
 
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/categories.html
+++ b/pelican/tests/output/custom/categories.html
@@ -36,7 +36,7 @@
 </ul>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/category/bar.html
+++ b/pelican/tests/output/custom/category/bar.html
@@ -54,7 +54,7 @@ YEAH !</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/category/cat1.html
+++ b/pelican/tests/output/custom/category/cat1.html
@@ -123,7 +123,7 @@
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -134,7 +134,7 @@ pelican.conf, it will ...</p></div>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/category/yeah.html
+++ b/pelican/tests/output/custom/category/yeah.html
@@ -62,7 +62,7 @@
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom/drafts/a-draft-article.html
@@ -56,7 +56,7 @@ listed anywhere else.</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/filename_metadata-example.html
+++ b/pelican/tests/output/custom/filename_metadata-example.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/index.html
+++ b/pelican/tests/output/custom/index.html
@@ -129,7 +129,7 @@
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/index2.html
+++ b/pelican/tests/output/custom/index2.html
@@ -143,7 +143,7 @@ YEAH !</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -94,7 +94,7 @@ pelican.conf, it will ...</p></div>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/jinja2_template.html
+++ b/pelican/tests/output/custom/jinja2_template.html
@@ -33,7 +33,7 @@ Some text
 
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/oh-yeah-fr.html
+++ b/pelican/tests/output/custom/oh-yeah-fr.html
@@ -72,7 +72,7 @@ Translations:
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/oh-yeah.html
+++ b/pelican/tests/output/custom/oh-yeah.html
@@ -77,7 +77,7 @@ YEAH !</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/override/index.html
+++ b/pelican/tests/output/custom/override/index.html
@@ -37,7 +37,7 @@ at a custom location.</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
@@ -37,7 +37,7 @@ Anyone can see this page but it's not linked to anywhere!</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-page.html
@@ -37,7 +37,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/second-article-fr.html
+++ b/pelican/tests/output/custom/second-article-fr.html
@@ -72,7 +72,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/second-article.html
+++ b/pelican/tests/output/custom/second-article.html
@@ -72,7 +72,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -113,7 +113,7 @@ YEAH !</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tag/baz.html
+++ b/pelican/tests/output/custom/tag/baz.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -83,7 +83,7 @@ as well as <strong>inline markup</strong>.</p>
             </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tag/foobar.html
+++ b/pelican/tests/output/custom/tag/foobar.html
@@ -62,7 +62,7 @@
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tag/oh.html
+++ b/pelican/tests/output/custom/tag/oh.html
@@ -36,7 +36,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tag/yeah.html
+++ b/pelican/tests/output/custom/tag/yeah.html
@@ -54,7 +54,7 @@ YEAH !</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/tags.html
+++ b/pelican/tests/output/custom/tags.html
@@ -43,7 +43,7 @@
 
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/this-is-a-super-article.html
+++ b/pelican/tests/output/custom/this-is-a-super-article.html
@@ -85,7 +85,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom/unbelievable.html
+++ b/pelican/tests/output/custom/unbelievable.html
@@ -102,7 +102,7 @@ pelican.conf, it will have nothing in default.</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/archives.html
+++ b/pelican/tests/output/custom_locale/archives.html
@@ -56,7 +56,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau.html
@@ -129,7 +129,7 @@
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
@@ -143,7 +143,7 @@ YEAH !</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
@@ -94,7 +94,7 @@ pelican.conf, it will ...</p></div>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/authors.html
+++ b/pelican/tests/output/custom_locale/authors.html
@@ -38,7 +38,7 @@
 
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/categories.html
+++ b/pelican/tests/output/custom_locale/categories.html
@@ -36,7 +36,7 @@
 </ul>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/category/bar.html
+++ b/pelican/tests/output/custom_locale/category/bar.html
@@ -54,7 +54,7 @@ YEAH !</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/category/cat1.html
+++ b/pelican/tests/output/custom_locale/category/cat1.html
@@ -123,7 +123,7 @@
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -134,7 +134,7 @@ pelican.conf, it will ...</p></div>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/category/yeah.html
+++ b/pelican/tests/output/custom_locale/category/yeah.html
@@ -62,7 +62,7 @@
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom_locale/drafts/a-draft-article.html
@@ -56,7 +56,7 @@ listed anywhere else.</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/index.html
+++ b/pelican/tests/output/custom_locale/index.html
@@ -129,7 +129,7 @@
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/index2.html
+++ b/pelican/tests/output/custom_locale/index2.html
@@ -143,7 +143,7 @@ YEAH !</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/index3.html
+++ b/pelican/tests/output/custom_locale/index3.html
@@ -94,7 +94,7 @@ pelican.conf, it will ...</p></div>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/jinja2_template.html
+++ b/pelican/tests/output/custom_locale/jinja2_template.html
@@ -33,7 +33,7 @@ Some text
 
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/oh-yeah-fr.html
+++ b/pelican/tests/output/custom_locale/oh-yeah-fr.html
@@ -72,7 +72,7 @@ Translations:
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/override/index.html
+++ b/pelican/tests/output/custom_locale/override/index.html
@@ -37,7 +37,7 @@ at a custom location.</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
@@ -37,7 +37,7 @@ Anyone can see this page but it's not linked to anywhere!</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
@@ -37,7 +37,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
@@ -85,7 +85,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
@@ -102,7 +102,7 @@ pelican.conf, it will have nothing in default.</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
@@ -77,7 +77,7 @@ YEAH !</p>
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
@@ -71,7 +71,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
@@ -72,7 +72,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/second-article-fr.html
+++ b/pelican/tests/output/custom_locale/second-article-fr.html
@@ -72,7 +72,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tag/bar.html
+++ b/pelican/tests/output/custom_locale/tag/bar.html
@@ -113,7 +113,7 @@ YEAH !</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tag/baz.html
+++ b/pelican/tests/output/custom_locale/tag/baz.html
@@ -70,7 +70,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tag/foo.html
+++ b/pelican/tests/output/custom_locale/tag/foo.html
@@ -83,7 +83,7 @@ as well as <strong>inline markup</strong>.</p>
                 </section><!-- /#content -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tag/foobar.html
+++ b/pelican/tests/output/custom_locale/tag/foobar.html
@@ -62,7 +62,7 @@
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tag/oh.html
+++ b/pelican/tests/output/custom_locale/tag/oh.html
@@ -36,7 +36,7 @@
 </section>
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tag/yeah.html
+++ b/pelican/tests/output/custom_locale/tag/yeah.html
@@ -54,7 +54,7 @@ YEAH !</p>
             </aside><!-- /#featured -->
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/tests/output/custom_locale/tags.html
+++ b/pelican/tests/output/custom_locale/tags.html
@@ -43,7 +43,7 @@
 
         <section id="extras" class="body">
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>links</h2>
                         <ul>
                             <li><a href="http://biologeek.org">Biologeek</a></li>
                             <li><a href="http://filyb.info/">Filyb</a></li>

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -41,7 +41,7 @@
         <section id="extras" class="body">
         {% if LINKS %}
                 <div class="blogroll">
-                        <h2>blogroll</h2>
+                        <h2>{{ LINKS_WIDGET_NAME | default('links') }}</h2>
                         <ul>
                         {% for name, link in LINKS %}
                             <li><a href="{{ link }}">{{ name }}</a></li>
@@ -51,7 +51,7 @@
         {% endif %}
         {% if SOCIAL or FEED_ALL_ATOM or FEED_ALL_RSS %}
                 <div class="social">
-                        <h2>social</h2>
+                        <h2>{{ SOCIAL_WIDGET_NAME | default('social') }}</h2>
                         <ul>
                             {% if FEED_ALL_ATOM %}
                             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate">atom feed</a></li>


### PR DESCRIPTION
The ```BLOGROLL_WIDGET_NAME``` and ```SOCIAL_WIDGET_NAME``` settings are now respected by notmyidea if they are specified in your config file. They override the default names of "blogroll" and "links" in the notmyidea theme.

I'm sure I'm not the only one who would prefer to call the "Blogroll" widget "Links"; I know that some themes (at the very least pelican-bootstrap3) do this by default, and obviously it's easy enough to change on any theme, but I think it would make more sense if it was a configurable option that themes would respect...

So I figured I would implement this and send a pull request at the main pelican repository for the notmyidea theme, and if it's agreed that this is a useful feature, perhaps we can update some of the themes in pelican-themes too?

If ```BLOGROLL_WIDGET_NAME``` and ```SOCIAL_WIDGET_NAME``` aren't defined, the theme uses the default option-- in this case, "blogroll" and "social".

The change is documented in settings.rst. 