### PR TITLE
Use unichr() instead of chr() with Python 2.

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -190,6 +190,18 @@ class TestUtils(LoggedTestCase):
         self.assertEqual(
             utils.truncate_html_words("cafeti&eacute;re " * 100, 20),
             "cafeti&eacute;re " * 20 + '...')
+        self.assertEqual(
+            utils.truncate_html_words("&int;dx " * 100, 20),
+            "&int;dx " * 20 + '...')
+
+        # Words with HTML character references inside and outside
+        # the ASCII range.
+        self.assertEqual(
+            utils.truncate_html_words("&#xe9; " * 100, 20),
+            "&#xe9; " * 20 + '...')
+        self.assertEqual(
+            utils.truncate_html_words("&#x222b;dx " * 100, 20),
+            "&#x222b;dx " * 20 + '...')
 
     def test_process_translations(self):
         # create a bunch of articles

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -499,14 +499,14 @@ class _HTMLWordTruncator(HTMLParser):
         except KeyError:
             self.handle_ref('')
         else:
-            self.handle_ref(chr(codepoint))
+            self.handle_ref(six.unichr(codepoint))
 
     def handle_charref(self, name):
         if name.startswith('x'):
             codepoint = int(name[1:], 16)
         else:
             codepoint = int(name)
-        self.handle_ref(chr(codepoint))
+        self.handle_ref(six.unichr(codepoint))
 
 
 def truncate_html_words(s, num, end_text='...'):


### PR DESCRIPTION
This fixes the problem noticed by @justinmayer on https://github.com/getpelican/pelican/pull/1802#issuecomment-142351070