### PR TITLE
Fix quote escaping in HTML attributes. Fixes issue #1260.

### DIFF
--- a/pelican/tests/content/article_with_attributes_containing_double_quotes.html
+++ b/pelican/tests/content/article_with_attributes_containing_double_quotes.html
@@ -1,0 +1,11 @@
+<html>
+    <head>
+    </head>
+    <body>
+        Ensure that if an attribute value contains a double quote, it is
+        surrounded with single quotes, otherwise with double quotes.
+        <span data-test="'single quoted string'">Span content</span>
+        <span data-test='"double quoted string"'>Span content</span>
+        <span data-test="string without quotes">Span content</span>
+    </body>
+</html>

--- a/pelican/tests/test_cache.py
+++ b/pelican/tests/test_cache.py
@@ -61,7 +61,7 @@ class TestCache(unittest.TestCase):
         - article_with_null_attributes.html
         - 2012-11-30_md_w_filename_meta#foo-bar.md
         """
-        self.assertEqual(generator.readers.read_file.call_count, 3)
+        self.assertEqual(generator.readers.read_file.call_count, 4)
 
     @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_article_reader_content_caching(self):

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -587,6 +587,17 @@ class HTMLReaderTest(ReaderTest):
         <input name="test" disabled style="" />
     ''', page.content)
 
+    def test_article_with_attributes_containing_double_quotes(self):
+        page = self.read_file(path='article_with_attributes_containing_' +
+                                   'double_quotes.html')
+        self.assertEqual('''
+        Ensure that if an attribute value contains a double quote, it is
+        surrounded with single quotes, otherwise with double quotes.
+        <span data-test="'single quoted string'">Span content</span>
+        <span data-test='"double quoted string"'>Span content</span>
+        <span data-test="string without quotes">Span content</span>
+    ''', page.content)
+
     def test_article_metadata_key_lowercase(self):
         # Keys of metadata should be lowercase.
         page = self.read_file(path='article_with_uppercase_metadata.html')

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -28,6 +28,11 @@ import six
 from six.moves import html_entities
 from six.moves.html_parser import HTMLParser
 
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
+
 logger = logging.getLogger(__name__)
 
 
@@ -546,6 +551,14 @@ def truncate_html_words(s, num, end_text='...'):
         out += '</%s>' % tag
     # Return string
     return out
+
+
+def escape_html(text, quote=True):
+    """Escape '&', '<' and '>' to HTML-safe sequences.
+
+    In Python 2 this uses cgi.escape and in Python 3 this uses html.escape. We
+    wrap here to ensure the quote argument has an identical default."""
+    return escape(text, quote=quote)
 
 
 def process_translations(content_list, order_by=None):


### PR DESCRIPTION
Hello, I think this fixes #1260.  runarberg seemed to have already done most of the work in 2014, so I won't claim originality. But anyway, I hope it's useful to you :)

If an the value of an HTML attribute contains a double quote, we now escape with single quotes, otherwise we escape with double quotes.