### PR TITLE
do not fail tox if coveralls push fails

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
 commands =
     {envpython} --version
     nosetests -sv --with-coverage --cover-package=pelican pelican
-    coveralls
+    - coveralls
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
When tox environments are run locally, coveralls exits with an error
code as it is not authenticated to push to coveralls. Adding the - in
front allows tox to ignore a fail on this command and not mark the test
case as failed.