### PR TITLE
Add FAQ about static files parsed as content

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -253,6 +253,7 @@ Pelican plugin system.
 
 Since I upgraded Pelican my pages are no longer rendered
 ========================================================
+
 Pages were available to themes as lowercase ``pages`` and uppercase
 ``PAGES``. To bring this inline with the :ref:`templates-variables` section,
 ``PAGES`` has been removed. This is quickly resolved by updating your theme

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -264,3 +264,15 @@ to iterate over ``pages`` instead of ``PAGES``. Just replace::
 with something like::
 
     {% for pg in pages %}
+
+How can I stop Pelican from trying to parse my static files as content?
+=======================================================================
+
+Pelican's article and page generators run before it's static generator. That
+means if you use a setup similar to the default configuration, where a static
+source directory is defined inside a ``*_PATHS`` setting, all files that have a
+valid content file ending (``.html``, ``.rst``, ``.md``, ...) will be treated as
+articles or pages before they get treated as static files.
+
+To circumvent this issue either use the appropriate ``*_EXCLUDES`` setting or
+disable the offending reader via ``READERS`` if you don't need it.


### PR DESCRIPTION
Since #1509 got merged this pops up again and again (latest #1845). This
PR addresses the issue by adding a FAQ about it that explains why it is
necessary to add `*_EXCLUDES`.