### PR TITLE
Add '--no-mime-magic --no-preserve' to s3_upload

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -111,7 +111,7 @@ ftp_upload: publish
 	lftp ftp://$$(FTP_USER)@$$(FTP_HOST) -e "mirror -R $$(OUTPUTDIR) $$(FTP_TARGET_DIR) ; quit"
 
 s3_upload: publish
-	s3cmd sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl-public --delete-removed --guess-mime-type
+	s3cmd sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl-public --delete-removed --guess-mime-type --no-mime-magic --no-preserve
 
 cf_upload: publish
 	cd $(OUTPUTDIR) && swift -v -A https://auth.api.rackspacecloud.com/v1.0 -U $(CLOUDFILES_USERNAME) -K $(CLOUDFILES_API_KEY) upload -c $(CLOUDFILES_CONTAINER) .


### PR DESCRIPTION
`--no-mime-magic` is absolutely critical on POSIX generators with broken libmagic - css files for example will otherwise be uploaded with the incorrect header and be completely broken for the user without knowing why right away.

`--no-preserve` prevents leaking username and permissions, otherwise a header is passed and set on S3 that is the received by the client:

```
x-amz-meta-s3cmd-attrs: uid:1000/gname:xenith/uname:xenith/gid:1000/mode:33188/mtime:1446050473/atime:1446050473/md5:7a747784b1f67ae304c09eacc7210c2c/ctime:1446050585
```