### PR TITLE
Test if summary is parsed by replacer

### DIFF
--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -316,6 +316,19 @@ class TestPage(LoggedTestCase):
             '?utm_whatever=234&highlight=word#section-2">link</a>'
         )
 
+        # also test for summary in metadata
+        args['metadata']['summary'] = (
+            'A simple summary test, with a '
+            '<a href="|filename|article.rst">link</a>'
+        )
+        args['context']['localsiteurl'] = 'http://notmyidea.org'
+        p = Page(**args)
+        self.assertEqual(
+            p.summary,
+            'A simple summary test, with a '
+            '<a href="http://notmyidea.org/article.html">link</a>'
+        )
+
     def test_intrasite_link_more(self):
         # type does not take unicode in PY2 and bytes in PY3, which in
         # combination with unicode literals leads to following insane line:


### PR DESCRIPTION
As mentioned in #1342 the issue is already resolved.

I took the liberty and reworded the commit issued by @smartass101 and only took the changes to the test.

Closes #1342 