### PR TITLE
Use <time> instead of <abbr>

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -21,13 +21,13 @@
  {{ translations.translations_for(article) }}
   </header>
   <footer class="post-info">
-    <abbr class="published" title="{{ article.date.isoformat() }}">
+    <time class="published" datetime="{{ article.date.isoformat() }}">
       {{ article.locale_date }}
-    </abbr>
+    </time>
 	{% if article.modified %}
-    <abbr class="modified" title="{{ article.modified.isoformat() }}">
+    <time class="modified" datetime="{{ article.modified.isoformat() }}">
       {{ article.locale_modified }}
-    </abbr>
+    </time>
 	{% endif %}
     {% if article.authors %}
     <address class="vcard author">

--- a/pelican/themes/simple/templates/index.html
+++ b/pelican/themes/simple/templates/index.html
@@ -10,7 +10,7 @@
         <li><article class="hentry">
                 <header> <h2 class="entry-title"><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2> </header>
                 <footer class="post-info">
-                    <abbr class="published" title="{{ article.date.isoformat() }}"> {{ article.locale_date }} </abbr>
+                    <time class="published" datetime="{{ article.date.isoformat() }}"> {{ article.locale_date }} </time>
                     <address class="vcard author">By
                     {% for author in article.authors %}
                         <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>


### PR DESCRIPTION
The pubdate given is in no way an abbreviation. Hence the semantics of
<abbr> do not justify its usage in this context.

<time> was introduced in HTML5. It's datetime attribute can override the
textContent. Anyway it specifies a date+time of a given event.

http://www.w3.org/TR/html5/text-level-semantics.html#the-time-element

Originally the pubdate attribute was meant to annotate that the
publication date of the closest section unit is specified, but this was
dropped and is not part of the official specification.

https://www.w3.org/wiki/HTML/Elements/time

This is a followup for issue #1832