### PR TITLE
Generate output directory before 'CD'ing into it

### DIFF
--- a/pelican/tools/templates/develop_server.sh.in
+++ b/pelican/tools/templates/develop_server.sh.in
@@ -65,7 +65,7 @@ function start_up(){
   $$PELICAN --debug --autoreload -r $$INPUTDIR -o $$OUTPUTDIR -s $$CONFFILE $$PELICANOPTS &
   pelican_pid=$$!
   echo $$pelican_pid > $$PELICAN_PID
-  cd $$OUTPUTDIR
+  mkdir -p $$OUTPUTDIR && cd $$OUTPUTDIR
   $PY -m pelican.server $$port &
   srv_pid=$$!
   echo $$srv_pid > $$SRV_PID


### PR DESCRIPTION
If the output directory does not exist the 'cd' will fail, but the
script will resume, starting the server in the base directory. Therefore
we first make sure the output directory actually exists.