### PR TITLE
Typo on extension files in the example

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -187,8 +187,8 @@ In this example, ``article1.rst`` could look like this::
 
     See below intra-site link examples in reStructuredText format.
 
-    `a link relative to the current file <{filename}../article2.md>`_
-    `a link relative to the content root <{filename}/article2.md>`_
+    `a link relative to the current file <{filename}../article2.rstd>`_
+    `a link relative to the content root <{filename}/article2.rst>`_
 
 and ``article2.md``::
 
@@ -197,8 +197,8 @@ and ``article2.md``::
 
     See below intra-site link examples in Markdown format.
 
-    [a link relative to the current file]({filename}category/article1.rst)
-    [a link relative to the content root]({filename}/category/article1.rst)
+    [a link relative to the current file]({filename}category/article1.md)
+    [a link relative to the content root]({filename}/category/article1.md)
 
 Linking to static files
 -----------------------


### PR DESCRIPTION
rst example shows md file in the link and md example shows rst file in the links

For example, category/article1.rst should be category/article1.md