### PR TITLE
Add --fatal=errors|warnings program option

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -322,6 +322,11 @@ def parse_arguments():
                         dest='selected_paths', default=None,
                         help='Comma separated list of selected paths to write')
 
+    parser.add_argument('--fatal', metavar='errors|warnings',
+                        choices=('errors', 'warnings'),
+                        help=('Exit the program with non-zero status if any '
+                              'errors/warnings encountered.'))
+
     return parser.parse_args()
 
 
@@ -378,7 +383,7 @@ def get_instance(args):
 
 def main():
     args = parse_arguments()
-    init(args.verbosity)
+    init(args.verbosity, args.fatal)
 
     logger.debug('Pelican version: %s', __version__)
     logger.debug('Python version: %s', sys.version.split()[0])

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -388,26 +388,27 @@ def main():
     logger.debug('Pelican version: %s', __version__)
     logger.debug('Python version: %s', sys.version.split()[0])
 
-    pelican, settings = get_instance(args)
-    readers = Readers(settings)
-
-    watchers = {'content': folder_watcher(pelican.path,
-                                          readers.extensions,
-                                          pelican.ignore_files),
-                'theme': folder_watcher(pelican.theme,
-                                        [''],
-                                        pelican.ignore_files),
-                'settings': file_watcher(args.settings)}
-
-    old_static = settings.get("STATIC_PATHS", [])
-    for static_path in old_static:
-        # use a prefix to avoid possible overriding of standard watchers above
-        watchers['[static]%s' % static_path] = folder_watcher(
-            os.path.join(pelican.path, static_path),
-            [''],
-            pelican.ignore_files)
-
     try:
+        pelican, settings = get_instance(args)
+        readers = Readers(settings)
+
+        watchers = {'content': folder_watcher(pelican.path,
+                                              readers.extensions,
+                                              pelican.ignore_files),
+                    'theme': folder_watcher(pelican.theme,
+                                            [''],
+                                            pelican.ignore_files),
+                    'settings': file_watcher(args.settings)}
+
+        old_static = settings.get("STATIC_PATHS", [])
+        for static_path in old_static:
+            # use a prefix to avoid possible overriding of standard watchers
+            # above
+            watchers['[static]%s' % static_path] = folder_watcher(
+                os.path.join(pelican.path, static_path),
+                [''],
+                pelican.ignore_files)
+
         if args.autoreload:
             print('  --- AutoReload Mode: Monitoring `content`, `theme` and'
                   ' `settings` for changes. ---')

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -175,7 +175,22 @@ class LimitLogger(SafeLogger):
     def enable_filter(self):
         self.addFilter(LimitLogger.limit_filter)
 
-logging.setLoggerClass(LimitLogger)
+
+class FatalLogger(LimitLogger):
+    warnings_fatal = False
+    errors_fatal = False
+
+    def warning(self, *args, **kwargs):
+        super(FatalLogger, self).warning(*args, **kwargs)
+        if FatalLogger.warnings_fatal:
+            raise RuntimeError('Warning encountered')
+
+    def error(self, *args, **kwargs):
+        super(FatalLogger, self).error(*args, **kwargs)
+        if FatalLogger.errors_fatal:
+            raise RuntimeError('Error encountered')
+
+logging.setLoggerClass(FatalLogger)
 
 
 def supports_color():
@@ -203,7 +218,9 @@ def get_formatter():
         return TextFormatter()
 
 
-def init(level=None, handler=logging.StreamHandler(), name=None):
+def init(level=None, fatal='', handler=logging.StreamHandler(), name=None):
+    FatalLogger.warnings_fatal = fatal.startswith('warning')
+    FatalLogger.errors_fatal = bool(fatal)
 
     logger = logging.getLogger(name)
 


### PR DESCRIPTION
Or is there an alternative when one is using continuous integration to build and relies on program exiting cleanly (or not) as an indicator of success?