### PR TITLE
Default --output to "content" instead of "output"

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -786,9 +786,9 @@ def main():
     parser.add_argument(
         '--feed', action='store_true', dest='feed',
         help='Feed to parse')
-    parser.add_argument(
-        '-o', '--output', dest='output', default='output',
-        help='Output path')
+    parser.add_argument('-o', '--output', dest='output', default='content',
+        help=('Where to output the generated markup files. If not specified, a '
+            'directory will be created, named "content" in the current path.'))
     parser.add_argument(
         '-m', '--markup', dest='markup', default='rst',
         help='Output markup format (supports rst & markdown)')


### PR DESCRIPTION
The default workflow of the rest of the tools expect the .rst|.md files to be in the content folder, but the pelican-import command was defaulting to placing those files in the output folder which is where pelican puts the generated html. This change creates a workflow which is more obvious for new users.