### PR TITLE
import wordpress using real name from urlencoded file name

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import time
+import urllib
 
 from codecs import open
 
@@ -134,7 +135,7 @@ def get_items(xml):
 
 def get_filename(filename, post_id):
     if filename is not None:
-        return filename
+        return urllib.unquote(unicode(filename).encode("utf-8")).decode("utf-8")
     else:
         return post_id
 


### PR DESCRIPTION
When I try to import my wordpress site, the file name encoded by urlencode became useless, so I change the file name to decoded string. I think this patch is useful for user who use language other than English.
