### PR TITLE
Change periods (...) to ellipsis (…) in post summaries

### DIFF
--- a/pelican/tests/output/basic/category/misc.html
+++ b/pelican/tests/output/basic/category/misc.html
@@ -90,7 +90,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="/unbelievable.html">read more</a>
                 </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/basic/index.html
+++ b/pelican/tests/output/basic/index.html
@@ -227,7 +227,7 @@ YEAH !</p>
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="/unbelievable.html">read more</a>
                 </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="../unbelievable.html">read more</a>
 <p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -103,7 +103,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="../unbelievable.html">read more</a>
 <p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="./unbelievable.html">read more</a>
 <p>There are <a href="./unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
 <p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -103,7 +103,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
 <p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/output/custom_locale/index3.html
+++ b/pelican/tests/output/custom_locale/index3.html
@@ -59,7 +59,7 @@
 <div class="section" id="testing-another-case">
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
-pelican.conf, it will ...</p></div>
+pelican.conf, it will …</p></div>
                 <a class="readmore" href="./posts/2010/octobre/15/unbelievable/">read more</a>
 <p>There are <a href="./posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
             </article></li>

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -152,56 +152,56 @@ class TestUtils(LoggedTestCase):
             'short string')
         self.assertEqual(
             utils.truncate_html_words('word ' * 100, 20),
-            'word ' * 20 + '...')
+            'word ' * 20 + '…')
 
         # Words enclosed or intervaled by HTML tags.
         self.assertEqual(
             utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20),
-            '<p>' + 'word ' * 20 + '...</p>')
+            '<p>' + 'word ' * 20 + '…</p>')
         self.assertEqual(
             utils.truncate_html_words(
-                '<span\nstyle="\n...\n">' + 'word ' * 100 + '</span>', 20),
-            '<span\nstyle="\n...\n">' + 'word ' * 20 + '...</span>')
+                '<span\nstyle="\n…\n">' + 'word ' * 100 + '</span>', 20),
+            '<span\nstyle="\n…\n">' + 'word ' * 20 + '…</span>')
         self.assertEqual(
             utils.truncate_html_words('<br>' + 'word ' * 100, 20),
-            '<br>' + 'word ' * 20 + '...')
+            '<br>' + 'word ' * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words('<!-- comment -->' + 'word ' * 100, 20),
-            '<!-- comment -->' + 'word ' * 20 + '...')
+            '<!-- comment -->' + 'word ' * 20 + '…')
 
         # Words with hypens and apostrophes.
         self.assertEqual(
             utils.truncate_html_words("a-b " * 100, 20),
-            "a-b " * 20 + '...')
+            "a-b " * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words("it's " * 100, 20),
-            "it's " * 20 + '...')
+            "it's " * 20 + '…')
 
         # Words with HTML entity references.
         self.assertEqual(
             utils.truncate_html_words("&eacute; " * 100, 20),
-            "&eacute; " * 20 + '...')
+            "&eacute; " * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words("caf&eacute; " * 100, 20),
-            "caf&eacute; " * 20 + '...')
+            "caf&eacute; " * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words("&egrave;lite " * 100, 20),
-            "&egrave;lite " * 20 + '...')
+            "&egrave;lite " * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words("cafeti&eacute;re " * 100, 20),
-            "cafeti&eacute;re " * 20 + '...')
+            "cafeti&eacute;re " * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words("&int;dx " * 100, 20),
-            "&int;dx " * 20 + '...')
+            "&int;dx " * 20 + '…')
 
         # Words with HTML character references inside and outside
         # the ASCII range.
         self.assertEqual(
             utils.truncate_html_words("&#xe9; " * 100, 20),
-            "&#xe9; " * 20 + '...')
+            "&#xe9; " * 20 + '…')
         self.assertEqual(
             utils.truncate_html_words("&#x222b;dx " * 100, 20),
-            "&#x222b;dx " * 20 + '...')
+            "&#x222b;dx " * 20 + '…')
 
     def test_process_translations(self):
         # create a bunch of articles
@@ -378,7 +378,7 @@ class TestUtils(LoggedTestCase):
             utils.strftime(d, 'Yayınlanma tarihi: %A, %d %B %Y'),
             'Yayınlanma tarihi: Çarşamba, 29 Ağustos 2012')
 
-        # non-ascii format candidate (someone might pass it... for some reason)
+        # non-ascii format candidate (someone might pass it… for some reason)
         self.assertEqual(
             utils.strftime(d, '%Y yılında %üretim artışı'),
             '2012 yılında %üretim artışı')
@@ -413,7 +413,7 @@ class TestUtils(LoggedTestCase):
             utils.strftime(d, 'Écrit le %d %B %Y'),
             'Écrit le 29 août 2012')
 
-        # non-ascii format candidate (someone might pass it... for some reason)
+        # non-ascii format candidate (someone might pass it… for some reason)
         self.assertEqual(
             utils.strftime(d, '%écrits en %Y'),
             '%écrits en 2012')

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -531,12 +531,12 @@ class _HTMLWordTruncator(HTMLParser):
         self.handle_ref(six.unichr(codepoint))
 
 
-def truncate_html_words(s, num, end_text='...'):
+def truncate_html_words(s, num, end_text='…'):
     """Truncates HTML to a certain number of words.
 
     (not counting tags and comments). Closes opened tags if they were correctly
     closed in the given html. Takes an optional argument of what should be used
-    to notify that the string has been truncated, defaulting to ellipsis (...).
+    to notify that the string has been truncated, defaulting to ellipsis (…).
 
     Newlines in the HTML are preserved. (From the django framework).
     """


### PR DESCRIPTION
Use ellipsis when truncating, for example in `article.summary`. 