### PR TITLE
Fix "Kickstart your site" heading level in docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -87,7 +87,7 @@ If you installed Pelican via distutils or the bleeding-edge method, simply
 perform the same step to install the most recent version.
 
 Kickstart your site
-===================
+-------------------
 
 Once Pelican has been installed, you can create a skeleton project via the
 ``pelican-quickstart`` command, which begins by asking some questions about


### PR DESCRIPTION
"Kickstart your site" should not be a sub-heading of "Upgrading"

current state:
![screen shot 2016-02-19 at 18 26 47](https://cloud.githubusercontent.com/assets/649835/13192123/ccfd32ae-d736-11e5-904b-bfb98d98c19b.png)
