### PR TITLE
Do not quit autoreload with debug on if exception

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -469,7 +469,8 @@ def main():
 
                 except Exception as e:
                     if (args.verbosity == logging.DEBUG):
-                        raise
+                        logger.error(
+                            'Exception occurred: %s', e, exc_info=True)
                     logger.warning(
                         'Caught exception "%s". Reloading.', e)
 


### PR DESCRIPTION
Also print out traceback to help debugging.

----

I was designing my own theme and I found `--autoreload` with `--debug` will raise exception and quit Pelican when an error occursm such as a syntax error in template like `{{ foobar }`. You will have to manually restart Pelican, and it's very often I had a typo causing syntax error.

This behavior seems to contradict the purpose of using `--autoreload`. From the current code, 945b8384edd9dff922bfd34aa3a74c909cb4a41a, if you don't use with `--debug`, it will reload. However, the warning message most of time isn't helpful to pinpoint where the error occurs, for example:

```py
WARNING: Caught exception "TemplateSyntaxError: unexpected '}'". Reloading
```

It doesn't say the file and which line. The information is only provided with `--debug`.

So, I made autoreload not to raise the caught exception and also to print out traceback, which was actually from [documentation][log], basically I coded virtually nearly nothing. Here is how it looks:

[log]: http://docs.getpelican.com/en/3.6.3/contribute.html#outputting-traceback-in-the-logs

```py
-> Modified: theme. re-generating...
ERROR: Exception occurred: TemplateSyntaxError: unexpected '}'
  |___
  | Traceback (most recent call last):
[snip] 
  |   File "/tmp/tpy/test/s2/templates/base.html", line 2, in template
  |     <html lang="{{ DEFAULT_LANG }">
  | TemplateSyntaxError: unexpected '}'
WARNING: Caught exception "TemplateSyntaxError: unexpected '}'". Reloading.
```