### PR TITLE
Import env.github_pages_branch in fabfile from quickstart question

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -21,7 +21,7 @@ env.cloudfiles_api_key = '$cloudfiles_api_key'
 env.cloudfiles_container = '$cloudfiles_container'
 
 # Github Pages configuration
-env.github_pages_branch = "gh-pages"
+env.github_pages_branch = "$github_pages_branch"
 
 # Port for `serve`
 PORT = 8000


### PR DESCRIPTION
`env.github_pages_branch` of `fabfile.py.in` is hard-coded by "gh-pages". This makes the quickstart question, 'Is this your personal page (username.github.io)?' meaningless. Even though the github page is not a Project Pages, `$ fab gh_pages` makes wrong branch 'gh-pages' and push it to the same branch of github. 