### PR TITLE
Use 'ghp-import -p' to push instead of 'git push origin {branch}'

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -90,5 +90,4 @@ def publish():
 def gh_pages():
     """Publish to GitHub Pages"""
     rebuild()
-    local("ghp-import -b {github_pages_branch} {deploy_path}".format(**env))
-    local("git push origin {github_pages_branch}".format(**env))
+    local("ghp-import -b {github_pages_branch} {deploy_path} -p".format(**env))


### PR DESCRIPTION
`ghp-import` has the option `-p` to push the branch to origin/{branch} after committing. It doesn't need to call `git` separately. ( ref: https://pypi.python.org/pypi/ghp-import/0.4.2 )