### PR TITLE
Replaces MD_EXTENSIONS with MARKDOWN; Fixes #1024 

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -26,6 +26,7 @@ asselinpaul
 Axel Haustant
 Ben Rosser (TC01)
 Benoît HERVIER
+Bernhard Scheirle
 Borgar
 Brandon W Maister
 Brendan Wholihan

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Next release
 * Author slugs can be controlled with greater precision using the
   ``AUTHOR_SUBSTITUTIONS`` setting. Keeping non-alphanum characters is supported
   as well but discouraged.
+* Replaced ``MD_EXTENSIONS`` with ``MARKDOWN``
 
 3.6.3 (2015-08-14)
 ==================

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -55,7 +55,7 @@ install Markdown``.
 
 Pelican also supports `Markdown Extensions`_, which might have to be installed
 separately if they are not included in the default ``Markdown`` package and can
-be configured and loaded via the ``MD_EXTENSIONS`` setting.
+be configured and loaded via the ``MARKDOWN`` setting.
 
 Metadata syntax for Markdown posts should follow this pattern::
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -121,9 +121,9 @@ Setting name (followed by default value, if any)                                
                                                                                  for a complete list of supported options.
                                                                                  The ``extensions`` option will be automatically computed from the 
                                                                                  ``extension_configs`` option.
-                                                                                 Default is ``'extension_configs': {'markdown.extensions.codehilite':
+                                                                                 Default is ``{'extension_configs': {'markdown.extensions.codehilite':
                                                                                  {'css_class': 'highlight'},'markdown.extensions.extra': {},
-                                                                                 'markdown.extensions.meta': {},},``.
+                                                                                 'markdown.extensions.meta': {},}, 'output_format': 'html5',}``.
 ``OUTPUT_PATH = 'output/'``                                                      Where to output the generated files.
 ``PATH``                                                                         Path to content directory to be processed by Pelican. If undefined,
                                                                                  and content path is not specified via an argument to the ``pelican``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -114,15 +114,16 @@ Setting name (followed by default value, if any)                                
                                                                                  of these patterns will be ignored by the processor. For example,
                                                                                  the default ``['.#*']`` will ignore emacs lock files, and
                                                                                  ``['__pycache__']`` would ignore Python 3's bytecode caches.
-``MD_EXTENSIONS =`` ``{...}``                                                    A dict of the extensions that the Markdown processor
-                                                                                 will use, with extensions' settings as the values.
+``MARKDOWN =`` ``{...}``                                                         Extra configuration settings for the Markdown processor.
                                                                                  Refer to the Python Markdown documentation's
-                                                                                 `Extensions section <http://pythonhosted.org/Markdown/extensions/>`_
-                                                                                 for a complete list of supported extensions and their options.
-                                                                                 Default is ``{'markdown.extensions.codehilite' : {'css_class': 'highlight'},
-                                                                                 'markdown.extensions.extra': {}, 'markdown.extensions.meta': {}}``.
-                                                                                 (Note that the dictionary defined in your settings file will
-                                                                                 update this default one.)
+                                                                                 `Options section 
+                                                                                 <http://pythonhosted.org/Markdown/reference.html#markdown>`_
+                                                                                 for a complete list of supported options.
+                                                                                 The ``extensions`` option will be automatically computed from the 
+                                                                                 ``extension_configs`` option.
+                                                                                 Default is ``'extension_configs': {'markdown.extensions.codehilite':
+                                                                                 {'css_class': 'highlight'},'markdown.extensions.extra': {},
+                                                                                 'markdown.extensions.meta': {},},``.
 ``OUTPUT_PATH = 'output/'``                                                      Where to output the generated files.
 ``PATH``                                                                         Path to content directory to be processed by Pelican. If undefined,
                                                                                  and content path is not specified via an argument to the ``pelican``

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -246,8 +246,16 @@ class MarkdownReader(BaseReader):
 
     def __init__(self, *args, **kwargs):
         super(MarkdownReader, self).__init__(*args, **kwargs)
-        self.extensions = self.settings['MD_EXTENSIONS']
-        self.extensions.setdefault('markdown.extensions.meta', {})
+        # make sure 'extension_configs' exists and
+        # and either way 'markdown.extensions.meta' must be in there
+        settings = self.settings['MARKDOWN']
+        settings.setdefault('extension_configs', {})
+        settings['extension_configs'].setdefault(
+            'markdown.extensions.meta', {})
+        settings.setdefault('extensions', [])
+        settings['extensions'].extend(
+            list(settings['extension_configs'].keys()))
+        settings['extensions'] = list(set(settings['extensions']))
         self._source_path = None
 
     def _parse_metadata(self, meta):
@@ -283,8 +291,7 @@ class MarkdownReader(BaseReader):
         """Parse content and metadata of markdown files"""
 
         self._source_path = source_path
-        self._md = Markdown(extensions=self.extensions.keys(),
-                            extension_configs=self.extensions)
+        self._md = Markdown(**self.settings['MARKDOWN'])
         with pelican_open(source_path) as text:
             content = self._md.convert(text)
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -107,6 +107,7 @@ DEFAULT_CONFIG = {
             'markdown.extensions.extra': {},
             'markdown.extensions.meta': {},
         },
+        'output_format': 'html5',
     },
     'JINJA_EXTENSIONS': [],
     'JINJA_FILTERS': {},

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -101,10 +101,12 @@ DEFAULT_CONFIG = {
     'PELICAN_CLASS': 'pelican.Pelican',
     'DEFAULT_DATE_FORMAT': '%a %d %B %Y',
     'DATE_FORMATS': {},
-    'MD_EXTENSIONS': {
-        'markdown.extensions.codehilite': {'css_class': 'highlight'},
-        'markdown.extensions.extra': {},
-        'markdown.extensions.meta': {},
+    'MARKDOWN': {
+        'extension_configs': {
+            'markdown.extensions.codehilite': {'css_class': 'highlight'},
+            'markdown.extensions.extra': {},
+            'markdown.extensions.meta': {},
+        },
     },
     'JINJA_EXTENSIONS': [],
     'JINJA_FILTERS': {},
@@ -368,13 +370,11 @@ def configure_settings(settings):
                            PATH_KEY)
             settings[PATH_KEY] = DEFAULT_CONFIG[PATH_KEY]
 
-    # Save people from declaring MD_EXTENSIONS as a list rather than a dict
-    if not isinstance(settings.get('MD_EXTENSIONS', {}), dict):
-        logger.warning('The format of the MD_EXTENSIONS setting has '
-                       'changed. It should now be a dict mapping '
-                       'fully-qualified extension names to their '
-                       'configurations. Falling back to the default.')
-        settings['MD_EXTENSIONS'] = DEFAULT_CONFIG['MD_EXTENSIONS']
+    # Deprecated warning of MD_EXTENSIONS
+    if 'MD_EXTENSIONS' in settings:
+        logger.warning('MD_EXTENSIONS is deprecated use MARKDOWN '
+                       'instead. Falling back to the default.')
+        settings['MARKDOWN'] = DEFAULT_CONFIG['MARKDOWN']
 
     # Add {PAGE,ARTICLE}_PATHS to {ARTICLE,PAGE}_EXCLUDES
     mutually_exclusive = ('ARTICLE', 'PAGE')

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -208,18 +208,17 @@ class TestPelican(LoggedTestCase):
             msg="Writing .*",
             level=logging.INFO)
 
-    def test_md_extensions_list_deprecation(self):
-        """Test that a warning is issued if MD_EXTENSIONS is a list"""
+    def test_md_extensions_deprecation(self):
+        """Test that a warning is issued if MD_EXTENSIONS is used"""
         settings = read_settings(path=None, override={
             'PATH': INPUT_PATH,
             'OUTPUT_PATH': self.temp_path,
             'CACHE_PATH': self.temp_cache,
-            'MD_EXTENSIONS': ['meta'],
+            'MD_EXTENSIONS': {},
         })
         pelican = Pelican(settings=settings)
         mute(True)(pelican.run)()
-        self.assertIsInstance(pelican.settings['MD_EXTENSIONS'], dict)
         self.assertLogCountEqual(
             count=1,
-            msg="The format of the MD_EXTENSIONS setting has changed",
+            msg="MD_EXTENSIONS is deprecated use MARKDOWN instead.",
             level=logging.WARNING)

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -482,10 +482,12 @@ class MdReaderTest(ReaderTest):
         # expected
         page = self.read_file(
             path='article_with_markdown_markup_extensions.md',
-            MD_EXTENSIONS={
-                'markdown.extensions.toc': {},
-                'markdown.extensions.codehilite': {},
-                'markdown.extensions.extra': {}
+            MARKDOWN={
+                'extension_configs': {
+                    'markdown.extensions.toc': {},
+                    'markdown.extensions.codehilite': {},
+                    'markdown.extensions.extra': {}
+                }
             }
         )
         expected = ('<div class="toc">\n'

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -405,20 +405,20 @@ class MdReaderTest(ReaderTest):
             _path('article_with_markdown_and_footnote.md'))
         expected_content = (
             '<p>This is some content'
-            '<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" '
-            'rel="footnote">1</a></sup>'
+            '<sup id="fnref-1"><a class="footnote-ref" href="#fn-1"'
+            '>1</a></sup>'
             ' with some footnotes'
-            '<sup id="fnref:footnote"><a class="footnote-ref" '
-            'href="#fn:footnote" rel="footnote">2</a></sup></p>\n'
+            '<sup id="fnref-footnote"><a class="footnote-ref" '
+            'href="#fn-footnote">2</a></sup></p>\n'
 
             '<div class="footnote">\n'
-            '<hr />\n<ol>\n<li id="fn:1">\n'
+            '<hr>\n<ol>\n<li id="fn-1">\n'
             '<p>Numbered footnote&#160;'
-            '<a class="footnote-backref" href="#fnref:1" rev="footnote" '
+            '<a class="footnote-backref" href="#fnref-1" '
             'title="Jump back to footnote 1 in the text">&#8617;</a></p>\n'
-            '</li>\n<li id="fn:footnote">\n'
+            '</li>\n<li id="fn-footnote">\n'
             '<p>Named footnote&#160;'
-            '<a class="footnote-backref" href="#fnref:footnote" rev="footnote"'
+            '<a class="footnote-backref" href="#fnref-footnote"'
             ' title="Jump back to footnote 2 in the text">&#8617;</a></p>\n'
             '</li>\n</ol>\n</div>')
         expected_metadata = {


### PR DESCRIPTION
MARKDOWN_SETTINGS will be directly passed to the Markdown constructor, which is more flexible.

**TODO:**
- [x] Update Documentation
- [x] Fix tests
- [x] Make flake8 happy 

**Refs:**
Fixes #1024 
Replaces #1423
http://pythonhosted.org/Markdown/reference.html#using-markdown-as-a-python-library
