### PR TITLE
Ignore output for development server

### DIFF
--- a/pelican/tools/templates/develop_server.sh.in
+++ b/pelican/tools/templates/develop_server.sh.in
@@ -62,11 +62,11 @@ function start_up(){
   local port=$$1
   echo "Starting up Pelican and HTTP server"
   shift
-  $$PELICAN --debug --autoreload -r $$INPUTDIR -o $$OUTPUTDIR -s $$CONFFILE $$PELICANOPTS &
+  $$PELICAN --quiet --autoreload -r $$INPUTDIR -o $$OUTPUTDIR -s $$CONFFILE $$PELICANOPTS &> /dev/null &
   pelican_pid=$$!
   echo $$pelican_pid > $$PELICAN_PID
   mkdir -p $$OUTPUTDIR && cd $$OUTPUTDIR
-  $PY -m pelican.server $$port &
+  $PY -m pelican.server $$port &> /dev/null &
   srv_pid=$$!
   echo $$srv_pid > $$SRV_PID
   cd $$BASEDIR


### PR DESCRIPTION
The Makefile starts pelican to continuously generate the website and a
development web server both in the background, but the commands do still
output text to the shell. This behaviour is annoying when the same shell
is used further, therefore the output of both commands get redirected to
/dev/null.
Note: Even the -q, --quiet flag of pelican does not suppress
all output.

This fixes #1888
