### PR TITLE
import: multiple wordpress attachments may point to the same URL, download it only once

### DIFF
--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -377,9 +377,13 @@ class TestWordpressXMLAttachements(unittest.TestCase):
         good_url = path_to_file_url(real_file)
         bad_url = 'http://localhost:1/not_a_file.txt'
         silent_da = mute()(download_attachments)
+        url_cache = set()
         with temporary_folder() as temp:
-            locations = list(silent_da(temp, [good_url, bad_url]))
+            locations = list(silent_da(temp, [good_url, bad_url], url_cache))
             self.assertEqual(1, len(locations))
+            # only cache successful retrivals
+            self.assertTrue(good_url in url_cache)
+            self.assertFalse(bad_url in url_cache)
             directory = locations[0]
             self.assertTrue(
                 directory.endswith(os.path.join('content', 'article.rst')),

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -13,7 +13,7 @@ import time
 from codecs import open
 
 from six.moves.urllib.error import URLError
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import quote, urlparse
 from six.moves.urllib.request import urlretrieve
 
 # because logging.setLoggerClass has to be called before logging.getLogger
@@ -667,7 +667,8 @@ def download_attachments(output_path, urls):
             os.makedirs(full_path)
         print('downloading {}'.format(filename))
         try:
-            urlretrieve(url, os.path.join(full_path, filename))
+            quote_url = quote(url, safe="%/:=&?~#+!$,;'@()*[]")
+            urlretrieve(quote_url, os.path.join(full_path, filename))
             locations.append(os.path.join(localpath, filename))
         except (URLError, IOError) as e:
             # Python 2.7 throws an IOError rather Than URLError


### PR DESCRIPTION
This PR also includes a very small fix to support URLs with non-ascii characters which is unrelated but touches the same lines. 
