### PR TITLE
Allow for atom and rss feeds to use :summary: attributes from article…

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -45,13 +45,20 @@ class Writer(object):
 
         title = Markup(item.title).striptags()
         link = '%s/%s' % (self.site_url, item.url)
+        description = item.get_content(self.site_url)
+        try:
+            if self.settings['FEED_USE_SUMMARY']:
+                description = item.summary
+        except:
+            pass
+
         feed.add_item(
             title=title,
             link=link,
             unique_id='tag:%s,%s:%s' % (urlparse(link).netloc,
                                         item.date.date(),
                                         urlparse(link).path.lstrip('/')),
-            description=item.get_content(self.site_url),
+            description=description,
             categories=item.tags if hasattr(item, 'tags') else None,
             author_name=getattr(item, 'author', ''),
             pubdate=set_date_tzinfo(


### PR DESCRIPTION
…/pages, requires FEED_USE_SUMMARY bool in settings file.

This has no effect except when FEED_USE_SUMMARY = True in the pelicanconf.py

The change here alters the atom and rss feeds that are generated. The feeds will only contain :summary: attribute contents instead of the entire content of the articles/pages.  I have not tested the case where FEED_USE_SUMMARY = True and there are no :summary: atrributes in any articles/pages but that seems like a corner case that is unlikely.