### PR TITLE
Fix typogrifying objects without title

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -545,6 +545,8 @@ class Readers(FileStampDataCacher):
 
             if content:
                 content = typogrify_wrapper(content)
+
+            if 'title' in metadata:
                 metadata['title'] = typogrify_wrapper(metadata['title'])
 
             if 'summary' in metadata:


### PR DESCRIPTION
This fixes my use case where I use `readers.read_file` from within a plugin to load something that is neither a page nor an article and it makes little sense for it to have a title, but it has metadata and content that should be parsed like the rest of the objects.