### PR TITLE
Docker nginx deploy

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -44,7 +44,7 @@ CONF = {
     'siteurl': '',
     'lang': 'en',
     'timezone': 'Europe/Paris',
-    'docker_base_image': 'nginx',
+    'docker_base_image': 'nginx:alpine',
     'docker_target_dir': '/usr/share/nginx/html',
     'docker_container_name': 'pelican_site_container'
 }

--- a/pelican/tools/templates/Dockerfile.in
+++ b/pelican/tools/templates/Dockerfile.in
@@ -1,2 +1,2 @@
-FROM nginx
+FROM nginx:alpine
 COPY output /usr/share/nginx/html

--- a/pelican/tools/templates/Dockerfile.in
+++ b/pelican/tools/templates/Dockerfile.in
@@ -1,0 +1,2 @@
+FROM nginx
+COPY output /usr/share/nginx/html

--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -23,6 +23,11 @@ env.cloudfiles_container = '$cloudfiles_container'
 # Github Pages configuration
 env.github_pages_branch = "$github_pages_branch"
 
+# Docker configuration
+env.docker_blog_image = '$docker_base_image-blog'
+env.docker_target_dir = '$docker_target_dir'
+env.docker_container_name = '$docker_container_name'
+
 # Port for `serve`
 PORT = 8000
 
@@ -91,3 +96,29 @@ def gh_pages():
     """Publish to GitHub Pages"""
     rebuild()
     local("ghp-import -b {github_pages_branch} {deploy_path} -p".format(**env))
+
+def docker_rebuild():
+    """Rebuild the pelican site for production and install in a docker image :
+       - Kill and remove any existing pelican_site container.
+       - Copy the site into the webserver base image, build a new pelican_site
+         container.
+       - Run our new container.
+    """
+    clean()
+    preview()  # Builds the production version of the site
+
+    if local("docker ps -a | grep %s; exit 0" %
+             env.docker_container_name, capture=True) != "":
+        local("docker rm -f  {docker_container_name}".format(**env))
+
+
+# Remove the existing blog docker image
+    if local("docker images | grep %s; exit 0" %
+            env.docker_blog_image, capture=True) != "" :
+        local("docker rmi  {docker_blog_image}".format(**env))
+        
+# Now build and run the new image
+    local("docker build -t {docker_blog_image} .".format(**env))
+
+    local("docker run -d -p 80:80 --name {docker_container_name} \
+            {docker_blog_image} ".format(**env))


### PR DESCRIPTION
# A feature to allow a pelican site to be deployed inside of a container.

I've run the python -m unittest discover set of tests 
    Ran 187 tests in 3.868s
    OK (skipped=21)

This was tested against python 2.7.6 ( happy to test on other versions of course if this feature looks acceptable).
I've run the flake8 command on the two modified files

```
- A new fabric target is introduced 'docker-rebuild'. This will rebuild a
  production version of the users site and deploy this by bind-mounting the
  pelican output directory to the web content  directory within the container.

- The fabric target takes care of container management, cleaning up previous containers
  and instantiating new ones whenever the ' fab docker rebuild' command is issued.

- Unlike other solutions where pelican runs inside the container, this solution
  decouples pelican from the deployment of the blog, it's more in keeping with
  the existing fabric build targets e.g. cf_upload

- The default container based web server is nginx, this can be changed when
  running the pelican_quickstart

- The docker-rebuild target works transparently with docker-machine if
  desired, to allow for very fast rebuild and update of pelican sites running
  within remote containers.

- Docker must be preinstalled on the host machine for this to work
```

Happy to squash the commit too.

Comments welcome.

Rob Rennison
