### PR TITLE
Allow for atom and rss feeds to use :summary: attributes.

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -49,6 +49,7 @@ DEFAULT_CONFIG = {
     'AUTHOR_FEED_RSS': posix_join('feeds', '%s.rss.xml'),
     'TRANSLATION_FEED_ATOM': posix_join('feeds', 'all-%s.atom.xml'),
     'FEED_MAX_ITEMS': '',
+    'FEED_USE_SUMMARY': False,
     'SITEURL': '',
     'SITENAME': 'A Pelican Blog',
     'DISPLAY_PAGES_ON_MENU': True,
@@ -304,6 +305,7 @@ def configure_settings(settings):
         'AUTHOR_FEED_ATOM', 'AUTHOR_FEED_RSS',
         'TAG_FEED_ATOM', 'TAG_FEED_RSS',
         'TRANSLATION_FEED_ATOM', 'TRANSLATION_FEED_RSS',
+        'FEED_USE_SUMMARY',
     ]
 
     if any(settings.get(k) for k in feed_keys):

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -48,13 +48,20 @@ class Writer(object):
 
         title = Markup(item.title).striptags()
         link = '%s/%s' % (self.site_url, item.url)
+        description = item.get_content(self.site_url)
+        try:
+            if self.settings['FEED_USE_SUMMARY']:
+                description = item.summary
+        except:
+            pass
+
         feed.add_item(
             title=title,
             link=link,
             unique_id='tag:%s,%s:%s' % (urlparse(link).netloc,
                                         item.date.date(),
                                         urlparse(link).path.lstrip('/')),
-            description=item.get_content(self.site_url),
+            description=description,
             categories=item.tags if hasattr(item, 'tags') else None,
             author_name=getattr(item, 'author', ''),
             pubdate=set_date_tzinfo(


### PR DESCRIPTION
Cancelled my previous pull request and have followed https://github.com/getpelican/pelican/wiki/Git-Tips.

I have tested the functionality and it is working correctly.

I ran unittests but the output generated was unreadable and unrelated to my changes.
