### PR TITLE
Check full paths when excluding files

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -114,6 +114,15 @@ Setting name (followed by default value, if any)                                
                                                                                  of these patterns will be ignored by the processor. For example,
                                                                                  the default ``['.#*']`` will ignore emacs lock files, and
                                                                                  ``['__pycache__']`` would ignore Python 3's bytecode caches.
+                                                                                 Longer patterns can be used to filter files and directories with
+                                                                                 more granularity. For example, if multiple files have the same
+                                                                                 name base name (eg. ``content/event1/event_details.rst`` and
+                                                                                 ``content/event2/event_details.rst``) each can be filtered
+                                                                                 without filtering all files with the same base name
+                                                                                 (``event_details.rst``) by passing a longer pattern. For example,
+                                                                                 ``['content/event2/event_details.rst']`` would filter the
+                                                                                 ``event_details.html`` file in the ``event2`` directory, and not
+                                                                                 the ``event_details.html`` file in the ``event1`` directory.
 ``MD_EXTENSIONS =`` ``{...}``                                                    A dict of the extensions that the Markdown processor
                                                                                  will use, with extensions' settings as the values.
                                                                                  Refer to the Python Markdown documentation's

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -116,11 +116,11 @@ Setting name (followed by default value, if any)                                
                                                                                  ``['__pycache__']`` would ignore Python 3's bytecode caches.
                                                                                  Longer patterns can be used to filter files and directories with
                                                                                  more granularity. For example, if multiple files have the same
-                                                                                 name base name (eg. ``content/event1/event_details.rst`` and
-                                                                                 ``content/event2/event_details.rst``) each can be filtered
+                                                                                 name base name (eg. ``event1/event_details.rst`` and
+                                                                                 ``event2/event_details.rst``) each can be filtered
                                                                                  without filtering all files with the same base name
                                                                                  (``event_details.rst``) by passing a longer pattern. For example,
-                                                                                 ``['content/event2/event_details.rst']`` would filter the
+                                                                                 ``['event2/event_details.rst']`` would filter the
                                                                                  ``event_details.html`` file in the ``event2`` directory, and not
                                                                                  the ``event_details.html`` file in the ``event1`` directory.
 ``MD_EXTENSIONS =`` ``{...}``                                                    A dict of the extensions that the Markdown processor

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -105,10 +105,13 @@ class Generator(object):
         """
         if extensions is None:
             extensions = tuple(self.readers.extensions)
-        basename = os.path.basename(path)
 
         # check IGNORE_FILES
         ignores = self.settings['IGNORE_FILES']
+        if any(fnmatch.fnmatch(path, ignore) for ignore in ignores):
+            return False
+
+        basename = os.path.basename(path)
         if any(fnmatch.fnmatch(basename, ignore) for ignore in ignores):
             return False
 


### PR DESCRIPTION
The `Generator._include_path` method needs to be updated because it
does not filter files with enough specificity. For example, let's say
our Pelican project is devoted to hosting article about talks a
different conferences. If we wanted to filter a talk
at `content/jacksconf-2016/videos/jacks-talk.json`, we could do so
(without using this patch) by including `jacks-talk.json` in the
list IGNORE_FILES. However, if there are multiple `jacks-talk.json`
files (maybe a bunch of different Jacks wanted to talk at a bunch of
different conferences), we would exclude all `jacks-talk.json` files
by including the single `jacks-talk.json` string in IGNORE_FILES. By
checking the full path passed to `_include_path`, we can filter on a
more granular level.
