### PR TITLE
Add static file options: hard/symlink & only-when-modified

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -230,6 +230,20 @@ Basic settings
    ``PAGE_PATHS``. If you are trying to publish your site's source files,
    consider using the ``OUTPUT_SOURCES`` setting instead.
 
+.. data:: STATIC_CREATE_LINKS = False
+
+   Create links instead of copying files. If the content and output
+   directories are on the same device, then create hard links.  Falls
+   back to symbolic links if the output directory is on a different
+   filesystem. If symlinks are created, don't forget to add the ``-L``
+   or ``--copy-links`` option to rsync when uploading your site.
+
+.. data:: STATIC_CHECK_IF_MODIFIED = False
+
+   If set to ``True``, and ``STATIC_CREATE_LINKS`` is ``False``, compare
+   mtimes of content and output files, and only copy content files that
+   are newer than existing output files.
+
 .. data:: TYPOGRIFY = False
 
    If set to True, several typographical improvements will be incorporated into

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -82,6 +82,8 @@ DEFAULT_CONFIG = {
     'PAGE_LANG_SAVE_AS': posix_join('pages', '{slug}-{lang}.html'),
     'STATIC_URL': '{path}',
     'STATIC_SAVE_AS': '{path}',
+    'STATIC_CREATE_LINKS': False,
+    'STATIC_CHECK_IF_MODIFIED': False,
     'CATEGORY_URL': 'category/{slug}.html',
     'CATEGORY_SAVE_AS': posix_join('category', '{slug}.html'),
     'TAG_URL': 'tag/{slug}.html',


### PR DESCRIPTION
Hello,

I am interested in improving `StaticGenerator`. Please let me know if a similar effort is already under way, and also bring your recommendations and ideas. I don't have a timeline but I'd really like to have at least a basic working feature in about 2 weeks given the free time that I have.

The problem is when the site content has several large static files, like videos. When generating the site, all the static files are copied, regardless of modification time. Even `WRITE_SELECTED` doesn't prevent that. For example, the pages and article take 4 seconds to process, but the static files add another almost 30 seconds to it.

I'm thinking of adding a setting `STATIC_CHECK_MODIFIED`, false by default (the current behaviour). I'm currently working on inserting the logic in the `StaticGenerator.generate_context()` method.

Once it works well with mtimes, then maybe I can add a `STATIC_CHECK_MODIFIED_METHOD` settings which would be "mtime" by default, or the name of a hashlib function. But I doubt that computing hashes on two video files (source_path and save_as) would be faster than just copying one over the other.

Then I also want to try symlinks or hardlinks from save_as to source_path. I imagine that would be fast and even space efficient. Do you think of any problems that could arise if the output files are links and not copies?

I also think #1980 is a great idea which could also solve the problem and I might look into it.

Sincerely,
Alexandre de Verteuil
