### PR TITLE
Fabric file not compatible with python 3

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -3,7 +3,11 @@ import fabric.contrib.project as project
 import os
 import shutil
 import sys
-import SocketServer
+
+if sys.version_info.major == 2:
+    import SocketServer
+elif sys.version_info.major == 3:
+    import socketserver as SocketServer
 
 from pelican.server import ComplexHTTPRequestHandler
 


### PR DESCRIPTION
Python 3 changes the name of SocketServer to socketserver. This fixes the naming error.
