### PR TITLE
Allow setting Jinja environment arguments from settings

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -81,9 +81,11 @@ Basic settings
 
       OUTPUT_RETENTION = [".hg", ".git", ".bzr"]
 
-.. data:: JINJA_EXTENSIONS = []
+.. data:: JINJA_ENVIRONMENT = {'trim_blocks': True, 'lstrip_blocks': True}
 
-   A list of any Jinja2 extensions you want to use.
+   A dictionary of custom Jinja2 environment variables you want to use. This
+   also includes a list of extensions you may want to include.
+   See `Jinja Environment documentation`_.
 
 .. data:: JINJA_FILTERS = {}
 
@@ -1215,4 +1217,5 @@ Example settings
 
 
 .. _Jinja custom filters documentation: http://jinja.pocoo.org/docs/api/#custom-filters
+.. _Jinja Environment documentation: http://jinja.pocoo.org/docs/dev/api/#jinja2.Environment
 .. _Docutils Configuration: http://docutils.sourceforge.net/docs/user/config.html

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -61,14 +61,12 @@ class Generator(object):
         simple_loader = FileSystemLoader(os.path.join(theme_path,
                                          "themes", "simple", "templates"))
         self.env = Environment(
-            trim_blocks=True,
-            lstrip_blocks=True,
             loader=ChoiceLoader([
                 FileSystemLoader(self._templates_path),
                 simple_loader,  # implicit inheritance
                 PrefixLoader({'!simple': simple_loader})  # explicit one
             ]),
-            extensions=self.settings['JINJA_EXTENSIONS'],
+            **self.settings['JINJA_ENVIRONMENT']
         )
 
         logger.debug('Template list: %s', self.env.list_templates())

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -98,6 +98,25 @@ class TestGenerator(unittest.TestCase):
             'subdir.md', found_files,
             "get_files() excluded a subdirectory by name, ignoring its path")
 
+    def test_custom_jinja_environment(self):
+        """
+            Test that setting the JINJA_ENVIRONMENT
+            properly gets set from the settings config
+        """
+        settings = get_settings()
+        comment_start_string = 'abc'
+        comment_end_string = '/abc'
+        settings['JINJA_ENVIRONMENT'] = {
+            'comment_start_string': comment_start_string,
+            'comment_end_string': comment_end_string
+        }
+        generator = Generator(settings.copy(), settings,
+                              CUR_DIR, settings['THEME'], None)
+        self.assertEqual(comment_start_string,
+                         generator.env.comment_start_string)
+        self.assertEqual(comment_end_string,
+                         generator.env.comment_end_string)
+
 
 class TestArticlesGenerator(unittest.TestCase):
 


### PR DESCRIPTION
Allow the ability to set custom Jinja environment arguments from within the settings. One consideration is that this setting could also be used in favor of `"JINJA_EXTENSIONS"` by just setting the key in the dictionary.

One potential downside is that someone could override the arguments already being set [here](https://github.com/getpelican/pelican/blob/master/pelican/generators.py#L64). We could whitelist/blacklist arguments that need to stay as the defaults.
