### PR TITLE
LOG_FILTER cannot be used with '%s'ed messages

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -777,6 +777,16 @@ be filtered out.
 
 For example: ``[(logging.WARN, 'TAG_SAVE_AS is set to False')]``
 
+It is possible to filter out messages by a template. Check out source code to
+obtain a template.
+
+For example: ``[(logging.WARN, 'Empty alt attribute for image %s in %s')]``
+
+**Warning:** Silencing messages by templates is a dangerous feature. It is
+possible to unintentionally filter out multiple message types with the same
+template (including messages from future Pelican versions). Proceed with
+caution.
+
 .. _reading_only_modified_content:
 
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -787,6 +787,8 @@ possible to unintentionally filter out multiple message types with the same
 template (including messages from future Pelican versions). Proceed with
 caution.
 
+Note: This option does nothing ``--debug`` is passed.
+
 .. _reading_only_modified_content:
 
 

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -112,12 +112,12 @@ class LimitFilter(logging.Filter):
         else:
             self._raised_messages.add(message_key)
 
-        # ignore LOG_FILTER records
-        # use .msg and not .getMessage() for string formatting to allow
-        # filtering by templates
-        ignore_key = (record.levelno, record.msg)
-        if ignore_key in self._ignore:
-            return False
+        # ignore LOG_FILTER records by templates when "debug" isn't enabled
+        logger_level = logging.getLogger().getEffectiveLevel()
+        if logger_level > logging.DEBUG:
+            ignore_key = (record.levelno, record.msg)
+            if ignore_key in self._ignore:
+                return False
 
         # check if we went over threshold
         if group:

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -92,6 +92,7 @@ class LimitFilter(logging.Filter):
     """
 
     _ignore = set()
+    _raised_messages = set()
     _threshold = 5
     _group_count = defaultdict(int)
 
@@ -105,12 +106,18 @@ class LimitFilter(logging.Filter):
         group_args = record.__dict__.get('limit_args', ())
 
         # ignore record if it was already raised
-        # use .getMessage() and not .msg for string formatting
-        ignore_key = (record.levelno, record.getMessage())
-        if ignore_key in self._ignore:
+        message_key = (record.levelno, record.getMessage())
+        if message_key in self._raised_messages:
             return False
         else:
-            self._ignore.add(ignore_key)
+            self._raised_messages.add(message_key)
+
+        # ignore LOG_FILTER records
+        # use .msg and not .getMessage() for string formatting to allow
+        # filtering by templates
+        ignore_key = (record.levelno, record.msg)
+        if ignore_key in self._ignore:
+            return False
 
         # check if we went over threshold
         if group:


### PR DESCRIPTION
Currently LOG_FILTER doesn’t allow ignoring messages with '%s' placeholders, because `ignore_key` variable in `filter` method of `log` module use 'getMessage()' method of `LogRecord` class, but not `msg` field.

Example which isn’t work:

```
LOG_FILTER = [
    (logging.WARN, 'Empty alt attribute for image %s in %s')
]
```

The problem is that now no way to suppress such warnings. I guess, filtering by `msg` field doesn’t break anything, but allow to more complex filtering.

Or maybe better intruduce another varible, say LOG_FILTER_GROUP, with such functionality.