### PR TITLE
workaround for python issue28141; copystat fails on Android

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -728,7 +728,12 @@ class StaticGenerator(Generator):
             save_as = os.path.join(self.output_path, sc.save_as)
             mkdir_p(os.path.dirname(save_as))
             shutil.copy2(source_path, save_as)
-            logger.info('Copying %s to %s', sc.source_path, sc.save_as)
+            try:
+                # workaround for Android python copy2 bug ([issue28141])
+                shutil.copy2(source_path, save_as)
+            except Exception as e:
+                logger.error("A problem occurred copying file %s to %s; %s",
+                             source_path, save_as, e)
 
 
 class SourceFileGenerator(Generator):

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -337,7 +337,12 @@ def copy(source, destination, ignores=None):
             logger.info('Creating directory %s', dst_dir)
             os.makedirs(dst_dir)
         logger.info('Copying %s to %s', source_, destination_)
-        shutil.copy2(source_, destination_)
+        try:
+            # workaround for Android python copystat bug ([issue28141])
+            shutil.copy2(source_, destination_)
+        except Exception as e:
+            logger.error("A problem occurred copying file %s to %s; %s",
+                         source_, destination_, e)
 
     elif os.path.isdir(source_):
         if not os.path.exists(destination_):
@@ -367,7 +372,12 @@ def copy(source, destination, ignores=None):
                 dst_path = os.path.join(dst_dir, o)
                 if os.path.isfile(src_path):
                     logger.info('Copying %s to %s', src_path, dst_path)
-                    shutil.copy2(src_path, dst_path)
+                    try:
+                        # workaround for Android python copystat bug ([issue28141])
+                        shutil.copy2(src_path, dst_path)
+                    except Exception as e:
+                        logger.error("A problem occurred copying file %s to %s; %s",
+                                     src_path, dst_path, e)
                 else:
                     logger.warning('Skipped copy %s (not a file or '
                                    'directory) to %s',


### PR DESCRIPTION
I've been running pelican on Android in python 3.5 and under termux. It was failing whenever it called shutil.copy2 which called shutil.copystat which tries to change the last access and modification time of the destination files. 

You can see that bug documented here:
http://bugs.python.org/issue28141

The changes in this commit wrap the calls to copy2 in an exception handler.

I tested this against pelican  3.6.3 (and I do have pelican working on my Android tablet.)