### PR TITLE
Fixes unit test test_period_in_timeperiod_archive (TestArticlesGenerator)

### DIFF
--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -297,6 +297,8 @@ class TestArticlesGenerator(unittest.TestCase):
         Test that the context of a generated period_archive is passed
         'period' : a tuple of year, month, day according to the time period
         """
+        old_locale = locale.setlocale(locale.LC_ALL)
+        locale.setlocale(locale.LC_ALL, str('C'))
         settings = get_settings(filenames={})
 
         settings['YEAR_ARCHIVE_SAVE_AS'] = 'posts/{date:%Y}/index.html'
@@ -357,6 +359,7 @@ class TestArticlesGenerator(unittest.TestCase):
                                  generator.get_template("period_archives"),
                                  settings,
                                  blog=True, dates=dates)
+        locale.setlocale(locale.LC_ALL, old_locale)
 
     def test_nonexistent_template(self):
         """Attempt to load a non-existent template"""


### PR DESCRIPTION
Python 2.7:
On systems with a none english default locale (e.g. de_DE.utf8) this test failed because the
period is a tuple of year and month name and the month name depends on the
locale.

Python 3:
The test passed. (Without this patch)
Shouldn't it fail with python 3 too?


Refs:
https://github.com/getpelican/pelican/blob/09fb6a1393fc26f22fea21f8e96da058675a2cdb/pelican/tests/test_generators.py#L331

---


On python 3.5.2 test_error_on_warning (pelican.tests.test_testsuite.TestSuiteTest) fails here, but on travis it passes. Do you know what could be the cause for this?
