### PR TITLE
Fixes an issue in test_testsuite.py that causes errors in python 3.5.

### DIFF
--- a/pelican/tests/test_testsuite.py
+++ b/pelican/tests/test_testsuite.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 
-import sys
 import warnings
+
+import six
 
 from pelican.tests.support import unittest
 
 
 class TestSuiteTest(unittest.TestCase):
-
-    @unittest.skipIf(sys.version_info[:2] == (3, 3),
-                     "does not throw an exception on python 3.3")
     def test_error_on_warning(self):
-        with self.assertRaises(UserWarning):
+        if six.PY2:
+            asserter = self.assertRaises
+        else:
+            asserter = self.assertWarns
+
+        with asserter(UserWarning):
             warnings.warn('test warning')


### PR DESCRIPTION
Also removes the condition in python 3.3, since it's no longer an issue.