### PR TITLE
Fixes #1868: Add warning when markdown is not installed but user has markdown files

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -69,10 +69,12 @@ I want to use Markdown, but I got an error.
 
 If you try to generate Markdown content without first installing the Markdown
 library, may see a message that says ``No valid files found in content``.
-Markdown is not a hard dependency for Pelican, so if you have content in
+Markdown is not a required dependency for Pelican, so if you have content in
 Markdown format, you will need to explicitly install the Markdown library.
-You can do so by typing the following command, prepending ``sudo`` if
-permissions require it::
+Pelican will attempt to check this for you, so you should also see an error
+message that says ``It appears you do not have the "markdown" package
+installed``.  You can do so by typing the following command, prepending
+``sudo`` if permissions require it::
 
     pip install markdown
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -19,7 +19,7 @@ from pelican import signals
 from pelican.generators import (ArticlesGenerator, PagesGenerator,
                                 SourceFileGenerator, StaticGenerator,
                                 TemplatePagesGenerator)
-from pelican.readers import Readers
+from pelican.readers import Markdown, MarkdownReader, Readers
 from pelican.settings import read_settings
 from pelican.utils import (clean_output_dir, file_watcher,
                            folder_watcher, maybe_pluralize)
@@ -400,6 +400,21 @@ def main():
                                             [''],
                                             pelican.ignore_files),
                     'settings': file_watcher(args.settings)}
+
+        # check to see if user is attempting to process markdown without the
+        # dependency installed
+        markdown_files = folder_watcher(
+            pelican.path,
+            MarkdownReader.file_extensions,
+            pelican.ignore_files
+        )
+
+        if Markdown is False and next(markdown_files) is not None:
+            logger.warning(
+                'It appears you have Markdown content but do not have the '
+                '"markdown" package installed, which is required for '
+                'processing Markdown-based content.'
+            )
 
         old_static = settings.get("STATIC_PATHS", [])
         for static_path in old_static:


### PR DESCRIPTION
I am going a little bit further than the suggested fix in the issue discussion, because I think the suggested hint is misleading in certain contexts: for instance, when the user _does_ have the markdown package installed, but put their content in a place Pelican can't find. IMHO, misleading hints are worse than no hints at all.

This fix has the additional benefit of warning the user about files that are silently not getting processed. For instance, if a user currently has one HTML file in their content and the rest are Markdown, they do not receive a "No valid files found in content" warning, and only a single file gets processed. I personally find this confusing.
