### PR TITLE
Improve path metadata processing

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -659,7 +659,7 @@ def parse_path_metadata(source_path, settings=None, process=None):
                           ('PATH_METADATA', source_path)]:
             checks.append((settings.get(key, None), data))
         if settings.get('USE_FOLDER_AS_CATEGORY', None):
-            checks.insert(0, ('(?P<category>.*)', subdir))
+            checks.append(('(?P<category>.*)', subdir))
         for regexp, data in checks:
             if regexp and data:
                 match = re.match(regexp, data)

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -666,8 +666,8 @@ def parse_path_metadata(source_path, settings=None, process=None):
                 if match:
                     # .items() for py3k compat.
                     for k, v in match.groupdict().items():
+                        k = k.lower()  # metadata must be lowercase
                         if k not in metadata:
-                            k = k.lower()  # metadata must be lowercase
                             if process:
                                 v = process(k, v)
                             metadata[k] = v


### PR DESCRIPTION
Small improvements to `parse_path_metadata` in readers.py, trying to fix:

* The last problem of issue #1128 (category clashes with USE_FOLDER_AS_CATEGORY), see also #2012
* #2011, camel-case metadata name in `PATH_METADATA` produces strange results