### PR TITLE
Override theme templates. Refs #1092

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -52,9 +52,9 @@ class Generator(object):
         # templates cache
         self._templates = {}
         self._templates_path = []
+        self._templates_path += self.settings['EXTRA_TEMPLATES_PATHS']
         self._templates_path.append(os.path.expanduser(
             os.path.join(self.theme, 'templates')))
-        self._templates_path += self.settings['EXTRA_TEMPLATES_PATHS']
 
         theme_path = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
Updated Jinga2 loader so that paths specified in `EXTRA_TEMPLATES_PATHS`
are checked for a template before checking in the theme's `template/`
directory.  This allows a user to override any theme template file.