### PR TITLE
Prevent server from dying when query strings present

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -18,6 +18,10 @@ class ComplexHTTPRequestHandler(srvmod.SimpleHTTPRequestHandler):
     SUFFIXES = ['', '.html', '/index.html']
 
     def do_GET(self):
+        # cut off a query string
+        if '?' in self.path:
+            self.path, _ = self.path.split('?', 1)
+
         # Try to detect file by applying various suffixes
         for suffix in self.SUFFIXES:
             if not hasattr(self, 'original_path'):


### PR DESCRIPTION
When calling a url that contains a query string, `ComplexHTTPRequestHandler.do_GET` can't find the file since it doesn't exist.

```WARNING:root:Unable to find`/pages/track-my-progress`or variations.```

Removing the query string if present.
