### PR TITLE
Add a temporary_locale context manager. Addresses #1347.

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -414,7 +414,7 @@ class TestUtils(LoggedTestCase):
             self.assertEqual(utils.strftime(d, '%d %B %Y'), '29 août 2012')
 
             # depending on OS, the first letter is m or M
-            self.assertTrue(utils.strftime(d, '%A') in ('mercredi', 'Mercredi'))
+            self.assertIn(utils.strftime(d, '%A'), ('mercredi', 'Mercredi'))
 
             # with text
             self.assertEqual(


### PR DESCRIPTION
Code is taken directly from the original description of the issue, plus a few places in the tests where I spotted it could be used immediately.

Tests passing locally, plus a test for the new code.
