### PR TITLE
Fix PEP8 violations. Fixes #2032

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import sys, os
+import os
+import sys
+
+from pelican import __version__
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 sys.path.append(os.path.abspath(os.pardir))
 
-from pelican import __version__
-
-# -- General configuration -----------------------------------------------------
+# -- General configuration ----------------------------------------------------
 templates_path = ['_templates']
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.ifconfig', 'sphinx.ext.extlinks']
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.ifconfig',
+              'sphinx.ext.extlinks']
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'Pelican'
@@ -30,7 +33,7 @@ extlinks = {
     'pelican-doc':  ('http://docs.getpelican.com/%s/', '')
 }
 
-# -- Options for HTML output ---------------------------------------------------
+# -- Options for HTML output --------------------------------------------------
 
 html_theme = 'default'
 if not on_rtd:
@@ -63,13 +66,13 @@ def setup(app):
     app.add_stylesheet('theme_overrides.css')   # path relative to _static
 
 
-# -- Options for LaTeX output --------------------------------------------------
+# -- Options for LaTeX output -------------------------------------------------
 latex_documents = [
-    ('index', 'Pelican.tex', 'Pelican Documentation',
-   'Alexis Métaireau', 'manual'),
+    ('index', 'Pelican.tex', 'Pelican Documentation', 'Alexis Métaireau',
+     'manual'),
 ]
 
-# -- Options for manual page output --------------------------------------------
+# -- Options for manual page output -------------------------------------------
 man_pages = [
     ('index', 'pelican', 'pelican documentation',
      ['Alexis Métaireau'], 1),

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from os import walk
-from os.path import join, relpath, dirname
+from os.path import join, relpath
 
 from setuptools import setup
 
@@ -31,22 +31,22 @@ setup(
     long_description=README + '\n' + CHANGELOG,
     packages=['pelican', 'pelican.tools'],
     package_data={
-        # we manually collect the package data, as opposed to using include_package_data=True
-        # because we don't want the tests to be included automatically as package data
-        # (MANIFEST.in is too greedy)
-        'pelican': [
-            relpath(join(root, name), 'pelican')
-            for root, _, names in walk(join('pelican', 'themes')) for name in names
-        ],
-        'pelican.tools': [
-            relpath(join(root, name), join('pelican', 'tools'))
-            for root, _, names in walk(join('pelican', 'tools', 'templates')) for name in names
-        ],
+        # we manually collect the package data, as opposed to using,
+        # include_package_data=True because we don't want the tests to be
+        # included automatically as package data (MANIFEST.in is too greedy)
+        'pelican': [relpath(join(root, name), 'pelican')
+                    for root, _, names in walk(join('pelican', 'themes'))
+                    for name in names],
+        'pelican.tools': [relpath(join(root, name), join('pelican', 'tools'))
+                          for root, _, names in walk(join('pelican',
+                                                          'tools',
+                                                          'templates'))
+                          for name in names],
     },
     install_requires=requires,
     entry_points=entry_points,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+         'Development Status :: 5 - Production/Stable',
          'Environment :: Console',
          'License :: OSI Approved :: GNU Affero General Public License v3',
          'Operating System :: OS Independent',


### PR DESCRIPTION
Mostly straightforward changes. For the setup.py 'package_data' I opted
for  explicit by converting the long list comprehensions to 'for' loops.
Less efficient but more readable.
