### PR TITLE
Fixes Exception name related bugs

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -473,5 +473,6 @@ def is_valid_content(content, f):
         return True
     except NameError as e:
         logger.error(
-            "Skipping %s: could not find information about '%s'", f, e)
+            "Skipping %s: could not find information about '%s'",
+            f, six.text_type(e))
         return False

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -157,7 +157,7 @@ class SafeLogger(logging.Logger):
         so convert the message to unicode with the correct encoding
         '''
         if isinstance(arg, Exception):
-            text = '%s: %s' % (arg.__class__.__name__, arg)
+            text = str('%s: %s') % (arg.__class__.__name__, arg)
             if six.PY2:
                 text = text.decode(self._exc_encoding)
             return text


### PR DESCRIPTION
Fixes two bugs that was introduced by #1743:

 - First was the unnecessary exception name output when skipping
content files if a required metadata wasn't available.
It was
`ERROR: Skipping ./demo.rst: could not find information about 'NameError: date'`
and now should be
`ERROR: Skipping ./demo.rst: could not find information about 'date'`

 - Second was a more serious issue. Improper string formatting in the logger
resulted in implicit decoding and would break for non-ascii error messages.