### PR TITLE
Add period in line 136 in content.rst

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -133,7 +133,7 @@ expression to be set in the ``FILENAME_METADATA`` setting. All named groups
 that are matched will be set in the metadata object. The default value for the
 ``FILENAME_METADATA`` setting will only extract the date from the filename. For
 example, if you would like to extract both the date and the slug, you could set
-something like: ``'(?P<date>\d{4}-\d{2}-\d{2})_(?P<slug>.*)'``
+something like: ``'(?P<date>\d{4}-\d{2}-\d{2})_(?P<slug>.*)'``.
 
 Please note that the metadata available inside your files takes precedence over
 the metadata extracted from the filename.


### PR DESCRIPTION
I added a missing period in documentation, section "File metadata", line 136 in file "content.rst". 