### PR TITLE
Fixes #1759 -- gracefully handle RST parse errors.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -210,7 +210,6 @@ class RstReader(BaseReader):
         extra_params = {'initial_header_level': '2',
                         'syntax_highlight': 'short',
                         'input_encoding': 'utf-8',
-                        'exit_status_level': 2,
                         'embed_stylesheet': False}
         user_params = self.settings.get('DOCUTILS_SETTINGS')
         if user_params:
@@ -223,7 +222,25 @@ class RstReader(BaseReader):
         pub.writer.translator_class = PelicanHTMLTranslator
         pub.process_programmatic_settings(None, extra_params, None)
         pub.set_source(source_path=source_path)
-        pub.publish(enable_exit_status=True)
+        status = user_params.get('enable_exit_status', False)
+        try:
+            pub.publish(enable_exit_status=status)
+        except SystemExit:
+            logger.error(
+                '%s "%s" %s',
+                'Error processing',
+                source_path,
+                '\nChanges have been ignored!',
+                exc_info=self.settings.get('DEBUG', False))
+            raise
+        except:
+            logger.error(
+                '%s "%s" %s',
+                'Exception while processing',
+                source_path,
+                '\nUse "--debug" to display a stack trace.',
+                exc_info=self.settings.get('DEBUG', False))
+            raise
         return pub
 
     def read(self, source_path):


### PR DESCRIPTION
- Revert the change in #1224 where 'exit_status_level' is hard coded inside 
  RstReader  "extra_params" attribute in order to trigger an "exit 1": Docutils 
  *will* issue a SystemExit when this and 'enable_status_exit' are set which 
  has the unwanted effect of breaking user experience by forcing a quit when 
  Pelican is in regenerate mode.
- Do not set 'enable_status_exit' to True by default in 'publish' which is 
  another revert of #1224: Docutils code does check whether the parameter is 
  set in order to decide whether SystemExit should be called or not. We give 
  users more flexibility by allowing the parameter to be set in Pelican config.  
  Also, we are defaulting to False to avoid SystemExit for the reasons 
  explained above.
- When SystemExit is disabled raise an exception that takes advantage of 
  Pelican's "--debug" command line argument to display the traceback.
- For integration with CI tools (as referenced in #1224) users can pass the 
  "--fatal" command line argument that -- when SystemExit is enabled by 
  configuring the 2 parameters discussed above -- will cause an "exit 1".