### PR TITLE
Add option to include full content into RSS feeds

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -839,6 +839,12 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    Maximum number of items allowed in a feed. Feed item quantity is
    unrestricted by default.
 
+.. data:: RSS_FEED_SUMMARY_ONLY = True
+
+   Only include item summaries in the ``description`` tag of RSS feeds. If set
+   to ``False``, the full content will be included instead. This setting
+   doesn't affect Atom feeds, only RSS ones.
+
 If you don't want to generate some or any of these feeds, set the above variables to ``None``.
 
 .. [2] %s is the name of the category.

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -49,6 +49,7 @@ DEFAULT_CONFIG = {
     'AUTHOR_FEED_RSS': posix_join('feeds', '%s.rss.xml'),
     'TRANSLATION_FEED_ATOM': posix_join('feeds', 'all-%s.atom.xml'),
     'FEED_MAX_ITEMS': '',
+    'RSS_FEED_SUMMARY_ONLY': True,
     'SITEURL': '',
     'SITENAME': 'A Pelican Blog',
     'DISPLAY_PAGES_ON_MENU': True,

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -47,11 +47,16 @@ class Writer(object):
 
         title = Markup(item.title).striptags()
         link = '%s/%s' % (self.site_url, item.url)
+        is_rss = isinstance(feed, Rss201rev2Feed)
+        if not is_rss or self.settings.get('RSS_FEED_SUMMARY_ONLY'):
+            description = item.summary
+        else:
+            description = item.get_content(self.site_url)
         feed.add_item(
             title=title,
             link=link,
             unique_id=get_tag_uri(link, item.date),
-            description=item.summary,
+            description=description,
             content=item.get_content(self.site_url),
             categories=item.tags if hasattr(item, 'tags') else None,
             author_name=getattr(item, 'author', ''),


### PR DESCRIPTION
Include only summary by default.

This follow ups pull #1989, where Atom feeds start to include full
content, but RSS feeds become summary-only.