### PR TITLE
Update content'rst with ARTICLE_EXCLUDES information

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -315,6 +315,14 @@ If a static file is linked multiple times, the relocating feature of
 After the first link, Pelican will treat ``{attach}`` like ``{filename}``.
 This avoids breaking the already-processed links.
 
+Bare in mind that if you'd like to put Markdown, HTML or reStructuredText files
+into directories configured in ``STATIC_PATHS`` you should also add those
+directories to ``ARTICLE_EXCLUDES`` list. Otherwise Pelican's article
+generator will try to parse those files and return error::
+
+    STATIC_PATHS = ['images', 'presentations']
+    ARTICLE_EXCLUDES = ['presentations']
+
 **Be careful when linking to a file from multiple documents:**
 Since the first link to a file finalizes its location and Pelican does
 not define the order in which documents are processed, using ``{attach}`` on a


### PR DESCRIPTION
There's lack in documentation for situations when user puts rst/md/html files inside directory defined in STATIC_PATHS. Normally those files will be parsed by ArticlesGenerator and return error since those files are not meant to be parsed. Thus we should expose information about ARTICLE_EXCLUDES in the documentation for those situations.

See [stackoverflow](http://stackoverflow.com/questions/37104625/how-can-i-copy-html-files-without-pelican-parsing-it/40889552#40889552) for reference.