### PR TITLE
Pin Sphinx version to 1.4.9 for docs tests. Fixes #2059

### DIFF
--- a/requirements/developer.pip
+++ b/requirements/developer.pip
@@ -3,4 +3,4 @@
 # Development
 flake8
 flake8-import-order
-sphinx
+sphinx==1.4.9

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 [testenv:docs]
 basepython = python2.7
 deps =
-    sphinx
+    sphinx==1.4.9
     sphinx_rtd_theme
 changedir = docs
 commands =


### PR DESCRIPTION
Sphinx 1.5 seems to have some issues including the one in #2059. This fixes it to 1.4.9 until a more stable sphinx version is released.