### PR TITLE
fix split on NoneType bug

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -49,7 +49,7 @@ CONF = {
     'github_pages_branch': _GITHUB_PAGES_BRANCHES['project'],
     'default_pagination': 10,
     'siteurl': '',
-    'lang': locale.getlocale()[0].split('_')[0],
+    'lang': locale.getlocale()[0].split('_')[0] if locale.getlocale() is not None else None,
     'timezone': _DEFAULT_TIMEZONE
 }
 


### PR DESCRIPTION
AttributeError: 'NoneType' object has no attribute 'split'
locale -a, for the items that don't have a '_', show the error message abrove