### PR TITLE
Initialize locale for Python 2+ in quickstart script. Fixes #2043

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -21,6 +21,8 @@ import six
 
 from pelican import __version__
 
+if (sys.version_info.major == 2):
+    locale.setlocale(locale.LC_ALL, '')
 
 _TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                               "templates")


### PR DESCRIPTION
Previously #2054 . I apologise for recreating the pull request, but I messed up the commits' author metadata.
Includes a check for python 2 only, as requested.