### PR TITLE
Set setup.py open file encoding to UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from os import walk
 from os.path import join, relpath
+from io import open
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ entry_points = {
     ]
 }
 
-README = open('README.rst').read()
-CHANGELOG = open('docs/changelog.rst').read()
+README = open('README.rst', 'r', encoding='utf-8').read()
+CHANGELOG = open('docs/changelog.rst', 'r', encoding='utf-8').read()
 
 setup(
     name='pelican',


### PR DESCRIPTION
Package building environments usually differ with a working environment
where locale settings are tricky. This change enforce using UTF-8 to
open files in setup.py in order to avoid possible encoding errors when
reading README and changelog files when they contain non-ASCII chars.