### PR TITLE
Add HTML meta generator tag

### DIFF
--- a/pelican/tests/output/basic/a-markdown-powered-article.html
+++ b/pelican/tests/output/basic/a-markdown-powered-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A markdown powered article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/archives.html
+++ b/pelican/tests/output/basic/archives.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/article-1.html
+++ b/pelican/tests/output/basic/article-1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 1</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/article-2.html
+++ b/pelican/tests/output/basic/article-2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 2</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/article-3.html
+++ b/pelican/tests/output/basic/article-3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 3</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/author/alexis-metaireau.html
+++ b/pelican/tests/output/basic/author/alexis-metaireau.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - Alexis Métaireau</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/authors.html
+++ b/pelican/tests/output/basic/authors.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - Authors</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/categories.html
+++ b/pelican/tests/output/basic/categories.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/category/bar.html
+++ b/pelican/tests/output/basic/category/bar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - bar</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/category/cat1.html
+++ b/pelican/tests/output/basic/category/cat1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - cat1</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/category/misc.html
+++ b/pelican/tests/output/basic/category/misc.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - misc</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/category/yeah.html
+++ b/pelican/tests/output/basic/category/yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - yeah</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/filename_metadata-example.html
+++ b/pelican/tests/output/basic/filename_metadata-example.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>FILENAME_METADATA example</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/index.html
+++ b/pelican/tests/output/basic/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/oh-yeah.html
+++ b/pelican/tests/output/basic/oh-yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Oh yeah !</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/override/index.html
+++ b/pelican/tests/output/basic/override/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Override url/save_as</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/basic/pages/this-is-a-test-hidden-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a test hidden page</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/basic/pages/this-is-a-test-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a test page</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/second-article-fr.html
+++ b/pelican/tests/output/basic/second-article-fr.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Deuxième article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/second-article.html
+++ b/pelican/tests/output/basic/second-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Second article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tag/bar.html
+++ b/pelican/tests/output/basic/tag/bar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - bar</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tag/baz.html
+++ b/pelican/tests/output/basic/tag/baz.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>The baz tag</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tag/foo.html
+++ b/pelican/tests/output/basic/tag/foo.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - foo</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tag/foobar.html
+++ b/pelican/tests/output/basic/tag/foobar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - foobar</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tag/oh.html
+++ b/pelican/tests/output/basic/tag/oh.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Oh Oh Oh</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tag/yeah.html
+++ b/pelican/tests/output/basic/tag/yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - yeah</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/tags.html
+++ b/pelican/tests/output/basic/tags.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A Pelican Blog - Tags</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/this-is-a-super-article.html
+++ b/pelican/tests/output/basic/this-is-a-super-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a super article !</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/basic/unbelievable.html
+++ b/pelican/tests/output/basic/unbelievable.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Unbelievable !</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />

--- a/pelican/tests/output/custom/a-markdown-powered-article.html
+++ b/pelican/tests/output/custom/a-markdown-powered-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A markdown powered article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/archives.html
+++ b/pelican/tests/output/custom/archives.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/article-1.html
+++ b/pelican/tests/output/custom/article-1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 1</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/article-2.html
+++ b/pelican/tests/output/custom/article-2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 2</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/article-3.html
+++ b/pelican/tests/output/custom/article-3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 3</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/authors.html
+++ b/pelican/tests/output/custom/authors.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Authors</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/categories.html
+++ b/pelican/tests/output/custom/categories.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/category/bar.html
+++ b/pelican/tests/output/custom/category/bar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/category/cat1.html
+++ b/pelican/tests/output/custom/category/cat1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - cat1</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - misc</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/category/yeah.html
+++ b/pelican/tests/output/custom/category/yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom/drafts/a-draft-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A draft article</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/filename_metadata-example.html
+++ b/pelican/tests/output/custom/filename_metadata-example.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>FILENAME_METADATA example</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/index.html
+++ b/pelican/tests/output/custom/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/index2.html
+++ b/pelican/tests/output/custom/index2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/jinja2_template.html
+++ b/pelican/tests/output/custom/jinja2_template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/oh-yeah-fr.html
+++ b/pelican/tests/output/custom/oh-yeah-fr.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Trop bien !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/oh-yeah.html
+++ b/pelican/tests/output/custom/oh-yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Oh yeah !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/override/index.html
+++ b/pelican/tests/output/custom/override/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Override url/save_as</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a test hidden page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a test page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/second-article-fr.html
+++ b/pelican/tests/output/custom/second-article-fr.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Deuxième article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/second-article.html
+++ b/pelican/tests/output/custom/second-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Second article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tag/baz.html
+++ b/pelican/tests/output/custom/tag/baz.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>The baz tag</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - foo</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tag/foobar.html
+++ b/pelican/tests/output/custom/tag/foobar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - foobar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tag/oh.html
+++ b/pelican/tests/output/custom/tag/oh.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Oh Oh Oh</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tag/yeah.html
+++ b/pelican/tests/output/custom/tag/yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/tags.html
+++ b/pelican/tests/output/custom/tags.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Tags</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/this-is-a-super-article.html
+++ b/pelican/tests/output/custom/this-is-a-super-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a super article !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom/unbelievable.html
+++ b/pelican/tests/output/custom/unbelievable.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Unbelievable !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/archives.html
+++ b/pelican/tests/output/custom_locale/archives.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/authors.html
+++ b/pelican/tests/output/custom_locale/authors.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Authors</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/categories.html
+++ b/pelican/tests/output/custom_locale/categories.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/category/bar.html
+++ b/pelican/tests/output/custom_locale/category/bar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/category/cat1.html
+++ b/pelican/tests/output/custom_locale/category/cat1.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - cat1</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - misc</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/category/yeah.html
+++ b/pelican/tests/output/custom_locale/category/yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom_locale/drafts/a-draft-article.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A draft article</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/index.html
+++ b/pelican/tests/output/custom_locale/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/index2.html
+++ b/pelican/tests/output/custom_locale/index2.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/index3.html
+++ b/pelican/tests/output/custom_locale/index3.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/jinja2_template.html
+++ b/pelican/tests/output/custom_locale/jinja2_template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/oh-yeah-fr.html
+++ b/pelican/tests/output/custom_locale/oh-yeah-fr.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Trop bien !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/override/index.html
+++ b/pelican/tests/output/custom_locale/override/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Override url/save_as</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a test hidden page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a test page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>This is a super article !</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Unbelievable !</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Oh yeah !</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>A markdown powered article</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 1</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 2</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Article 3</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Second article</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>FILENAME_METADATA example</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/second-article-fr.html
+++ b/pelican/tests/output/custom_locale/second-article-fr.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Deuxième article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tag/bar.html
+++ b/pelican/tests/output/custom_locale/tag/bar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tag/baz.html
+++ b/pelican/tests/output/custom_locale/tag/baz.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>The baz tag</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tag/foo.html
+++ b/pelican/tests/output/custom_locale/tag/foo.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - foo</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tag/foobar.html
+++ b/pelican/tests/output/custom_locale/tag/foobar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - foobar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tag/oh.html
+++ b/pelican/tests/output/custom_locale/tag/oh.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Oh Oh Oh</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tag/yeah.html
+++ b/pelican/tests/output/custom_locale/tag/yeah.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/tests/output/custom_locale/tags.html
+++ b/pelican/tests/output/custom_locale/tags.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>Alexis' log - Tags</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="{{ DEFAULT_LANG }}">
 <head>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
         <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/{{ CSS_FILE }}" />
         {% if FEED_ALL_ATOM %}

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -4,6 +4,7 @@
         {% block head %}
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
         {% if FEED_ALL_ATOM %}
         <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
         {% endif %}


### PR DESCRIPTION
Added meta generator HTML tag to default themes.
Good for Pelican since numerous sites measure the popularity of web technologies searching for meta generator tag. Such as [BuilWith](https://builtwith.com/) etc.