### PR TITLE
Add current date when publishing to GitHub Pages

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -90,7 +90,7 @@ def publish():
 
 def gh_pages():
     """Publish to GitHub Pages"""
-    rebuild()
+    preview()
     local('ghp-import -b {github_pages_branch} '
           '-m {commit_message} '
           '{deploy_path} -p'.format(**env))

--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -1,4 +1,5 @@
 from fabric.api import *
+import datetime
 import fabric.contrib.project as project
 import os
 import shutil
@@ -22,6 +23,7 @@ env.cloudfiles_container = '$cloudfiles_container'
 
 # Github Pages configuration
 env.github_pages_branch = "$github_pages_branch"
+env.commit_message = "'Publish site on {}'".format(datetime.date.today().isoformat())
 
 # Port for `serve`
 PORT = 8000
@@ -89,4 +91,6 @@ def publish():
 def gh_pages():
     """Publish to GitHub Pages"""
     rebuild()
-    local("ghp-import -b {github_pages_branch} {deploy_path} -p".format(**env))
+    local('ghp-import -b {github_pages_branch} '
+          '-m {commit_message} '
+          '{deploy_path} -p'.format(**env))


### PR DESCRIPTION
The current gh_pages Fabric task publishes the build website with the default "Update documentation" commit message. That is not very informative. This change adds the current date upon publishing so we can better track the build history.