### PR TITLE
Add new signal: feed_generated

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Release history
 Next release
 ============
 
-- Nothing yet
+* New signal: ``feed_generated``
 
 3.7.1 (2017-01-10)
 ==================

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -118,6 +118,8 @@ static_generator_init               static_generator               invoked in th
 static_generator_finalized          static_generator               invoked at the end of StaticGenerator.generate_context
 content_object_init                 content_object                 invoked at the end of Content.__init__
 content_written                     path, context                  invoked each time a content file is written.
+feed_generated                      context, feed                  invoked each time a feed gets generated. Can be used to modify a feed
+                                                                   object before it gets written.
 feed_written                        path, context, feed            invoked each time a feed file is written.
 =================================   ============================   ===========================================================================
 

--- a/pelican/signals.py
+++ b/pelican/signals.py
@@ -47,4 +47,5 @@ content_object_init = signal('content_object_init')
 
 # Writers signals
 content_written = signal('content_written')
+feed_generated = signal('feed_generated')
 feed_written = signal('feed_written')

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -122,6 +122,7 @@ class Writer(object):
         for i in range(max_items):
             self._add_item_to_the_feed(feed, elements[i])
 
+        signals.feed_generated.send(context, feed=feed)
         if path:
             complete_path = os.path.join(self.output_path, path)
             try:


### PR DESCRIPTION
This signal gets emitted before a feed gets written to disk.
Therefore it allows plugins to do arbitrary changes to the feed.

Use case:
The pelican_comment_system could use this signal to force empty feeds to not update^1 on every site rebuild. Would fix: https://github.com/getpelican/pelican-plugins/issues/780

^1:  The feed update element get set to the current date/time for empty feeds and therefore changes on every rebuild.