### PR TITLE
Try to prevent writing outside of the output directory

### DIFF
--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -497,6 +497,30 @@ class TestArticle(TestPage):
         article = Article(**article_kwargs)
         self.assertEqual(article.url, 'fedora.qa/this-week-in-fedora-qa/')
 
+    def test_valid_save_as_detects_breakout(self):
+        settings = get_settings()
+        article_kwargs = self._copy_page_kwargs()
+        article_kwargs['metadata']['slug'] = '../foo'
+        article_kwargs['settings'] = settings
+        article = Article(**article_kwargs)
+        self.assertFalse(article.valid_save_as())
+
+    def test_valid_save_as_detects_breakout_to_root(self):
+        settings = get_settings()
+        article_kwargs = self._copy_page_kwargs()
+        article_kwargs['metadata']['slug'] = '/foo'
+        article_kwargs['settings'] = settings
+        article = Article(**article_kwargs)
+        self.assertFalse(article.valid_save_as())
+
+    def test_valid_save_as_passes_valid(self):
+        settings = get_settings()
+        article_kwargs = self._copy_page_kwargs()
+        article_kwargs['metadata']['slug'] = 'foo'
+        article_kwargs['settings'] = settings
+        article = Article(**article_kwargs)
+        self.assertTrue(article.valid_save_as())
+
 
 class TestStatic(LoggedTestCase):
 

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -11,6 +11,8 @@ from tempfile import mkdtemp
 
 import pytz
 
+import six
+
 from pelican import utils
 from pelican.generators import TemplatePagesGenerator
 from pelican.settings import read_settings
@@ -666,3 +668,34 @@ class TestDateFormatter(unittest.TestCase):
         with utils.pelican_open(output_path) as output_file:
             self.assertEqual(output_file,
                              utils.strftime(self.date, 'date = %A, %d %B %Y'))
+
+
+class TestSanitisedJoin(unittest.TestCase):
+    def test_detect_parent_breakout(self):
+        with six.assertRaisesRegex(
+                self,
+                RuntimeError,
+                "Attempted to break out of output directory to /foo/test"):
+            utils.sanitised_join(
+                "/foo/bar",
+                "../test"
+            )
+
+    def test_detect_root_breakout(self):
+        with six.assertRaisesRegex(
+                self,
+                RuntimeError,
+                "Attempted to break out of output directory to /test"):
+            utils.sanitised_join(
+                "/foo/bar",
+                "/test"
+            )
+
+    def test_pass_deep_subpaths(self):
+        self.assertEqual(
+            utils.sanitised_join(
+                "/foo/bar",
+                "test"
+            ),
+            os.path.join("/foo/bar", "test")
+        )

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -36,6 +36,18 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def sanitised_join(base_directory, *parts):
+    joined = os.path.abspath(os.path.join(base_directory, *parts))
+    if not joined.startswith(os.path.abspath(base_directory)):
+        raise RuntimeError(
+            "Attempted to break out of output directory to {}".format(
+                joined
+            )
+        )
+
+    return joined
+
+
 def strftime(date, date_format):
     '''
     Replacement for built-in strftime

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -21,6 +21,18 @@ if not six.PY3:
 logger = logging.getLogger(__name__)
 
 
+def _sanitised_join(base_directory, *parts):
+    joined = os.path.abspath(os.path.join(base_directory, *parts))
+    if not joined.startswith(base_directory):
+        raise RuntimeError(
+            "attempt to break out of output directory to {}".format(
+                joined
+            )
+        )
+
+    return joined
+
+
 class Writer(object):
 
     def __init__(self, output_path, settings=None):
@@ -123,7 +135,8 @@ class Writer(object):
             self._add_item_to_the_feed(feed, elements[i])
 
         if path:
-            complete_path = os.path.join(self.output_path, path)
+            complete_path = _sanitised_join(self.output_path, path)
+
             try:
                 os.makedirs(os.path.dirname(complete_path))
             except Exception:
@@ -169,7 +182,8 @@ class Writer(object):
             if localcontext['localsiteurl']:
                 context['localsiteurl'] = localcontext['localsiteurl']
             output = template.render(localcontext)
-            path = os.path.join(output_path, name)
+            path = _sanitised_join(output_path, name)
+
             try:
                 os.makedirs(os.path.dirname(path))
             except Exception:

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -13,24 +13,12 @@ import six
 from pelican import signals
 from pelican.paginator import Paginator
 from pelican.utils import (get_relative_path, is_selected_for_writing,
-                           path_to_url, set_date_tzinfo)
+                           path_to_url, sanitised_join, set_date_tzinfo)
 
 if not six.PY3:
     from codecs import open
 
 logger = logging.getLogger(__name__)
-
-
-def _sanitised_join(base_directory, *parts):
-    joined = os.path.abspath(os.path.join(base_directory, *parts))
-    if not joined.startswith(base_directory):
-        raise RuntimeError(
-            "attempt to break out of output directory to {}".format(
-                joined
-            )
-        )
-
-    return joined
 
 
 class Writer(object):
@@ -135,7 +123,7 @@ class Writer(object):
             self._add_item_to_the_feed(feed, elements[i])
 
         if path:
-            complete_path = _sanitised_join(self.output_path, path)
+            complete_path = sanitised_join(self.output_path, path)
 
             try:
                 os.makedirs(os.path.dirname(complete_path))
@@ -182,7 +170,7 @@ class Writer(object):
             if localcontext['localsiteurl']:
                 context['localsiteurl'] = localcontext['localsiteurl']
             output = template.render(localcontext)
-            path = _sanitised_join(output_path, name)
+            path = sanitised_join(output_path, name)
 
             try:
                 os.makedirs(os.path.dirname(path))


### PR DESCRIPTION
This implements two layers to prevent files from being written outside the output directory:

* Firstly, a new method on ``Content`` is added which checks, called from is_valid_content, that the ``save_as`` path stays within the output directory. If this is not the case, an error is logged and the content is not generated.

* Secondly, the writer checks before writing to the file that it is within the OUTPUT_PATH and raises a RuntimeError when that is not the case.