### PR TITLE
Optional items in FILENAME_METADATA expression.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -672,7 +672,7 @@ def parse_path_metadata(source_path, settings=None, process=None):
                     # .items() for py3k compat.
                     for k, v in match.groupdict().items():
                         k = k.lower()  # metadata must be lowercase
-                        if k not in metadata:
+                        if v is not None and k not in metadata:
                             if process:
                                 v = process(k, v)
                             metadata[k] = v

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -166,6 +166,25 @@ class RstReaderTest(ReaderTest):
         }
         self.assertDictHasSubset(page.metadata, expected)
 
+    def test_article_with_optional_filename_metadata(self):
+        page = self.read_file(
+            path='2012-11-29_rst_w_filename_meta#foo-bar.rst',
+            FILENAME_METADATA='(?P<date>\d{4}-\d{2}-\d{2})?')
+        expected = {
+            'date': SafeDatetime(2012, 11, 29),
+            'reader': 'rst',
+        }
+        self.assertDictHasSubset(page.metadata, expected)
+
+        page = self.read_file(
+            path='article.rst',
+            FILENAME_METADATA='(?P<date>\d{4}-\d{2}-\d{2})?')
+        expected = {
+            'reader': 'rst',
+        }
+        self.assertDictHasSubset(page.metadata, expected)
+        self.assertNotIn('date', page.metadata, 'Date should not be set.')
+
     def test_article_metadata_key_lowercase(self):
         # Keys of metadata should be lowercase.
         reader = readers.RstReader(settings=get_settings())
@@ -560,6 +579,25 @@ class MdReaderTest(ReaderTest):
             'mymeta': 'foo',
         }
         self.assertDictHasSubset(page.metadata, expected)
+
+    def test_article_with_optional_filename_metadata(self):
+        page = self.read_file(
+            path='2012-11-30_md_w_filename_meta#foo-bar.md',
+            FILENAME_METADATA='(?P<date>\d{4}-\d{2}-\d{2})?')
+        expected = {
+            'date': SafeDatetime(2012, 11, 30),
+            'reader': 'markdown',
+        }
+        self.assertDictHasSubset(page.metadata, expected)
+
+        page = self.read_file(
+            path='empty.md',
+            FILENAME_METADATA='(?P<date>\d{4}-\d{2}-\d{2})?')
+        expected = {
+            'reader': 'markdown',
+        }
+        self.assertDictHasSubset(page.metadata, expected)
+        self.assertNotIn('date', page.metadata, 'Date should not be set.')
 
     def test_duplicate_tags_or_authors_are_removed(self):
         reader = readers.MarkdownReader(settings=get_settings())


### PR DESCRIPTION
To keep my articles somewhat organised, I like to add the date to the filename of the article and extract it using `FILENAME_METADATA`. However, for pages I don't quite want to do that. I used to use a simple plugin to set the date based on mtime, but since `DEFAULT_DATE = 'fs'` uses mtime now (since December 2016) instead of ctime, this option is great for this.

However, things go wrong when making the date capture group optional in the `FILENAME_METADATA` expression. Previously I monkey patched the `pelican.readers.parse_path_metadata` function, but since the `DEFAULT_DATE = 'fs'` option changed, I figured it's a good idea to try and get this part of the date configuration sorted within Pelican itself as well.


## Case:

files:
- `content/index.md`
- `content/articles/2017-03-11.interesting-article.md`

pelicanconf.py:
```python
FILENAME_METADATA = '(?:(?P<date>\d{4}-\d{2}-\d{2})\.)?(?P<slug>.*)\.md'
```


## Error:

The regex match result for the "date" group is `None` for `content/index.md`. When Pelican attempts to process the date, `None.replace()` throws an `AttributeError: 'NoneType' object has no attribute 'replace'`.


## Solution:

In addition to checking `if k not in metadata` when applying the matched filename metadata, also check `if v is not None`.

Please see the commit in the pull request for the actual change + added tests.