### PR TITLE
Use awscli instead of s3cmd for S3 in Makefile

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -111,7 +111,7 @@ ftp_upload: publish
 	lftp ftp://$$(FTP_USER)@$$(FTP_HOST) -e "mirror -R $$(OUTPUTDIR) $$(FTP_TARGET_DIR) ; quit"
 
 s3_upload: publish
-	s3cmd sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl-public --delete-removed --guess-mime-type --no-mime-magic --no-preserve
+	aws s3 sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl public-read --delete
 
 cf_upload: publish
 	cd $(OUTPUTDIR) && swift -v -A https://auth.api.rackspacecloud.com/v1.0 -U $(CLOUDFILES_USERNAME) -K $(CLOUDFILES_API_KEY) upload -c $(CLOUDFILES_CONTAINER) .


### PR DESCRIPTION
Today I ran into an issue where MIME types weren't being set correctly when using `make s3_upload`, causing my website not to render because the stylesheets were being sent as html/plain.

After some research, it looks like this was already covered in #1626.

This implements the solution as described in #1626, switching over to use awscli. 

I've been using it now with no problems (everything uploads as expected, MIME types are set correctly), and can agree with the comments in #1626 stating that awscli is the recommended way of moving forward.

Fixes #1626 