### PR TITLE
Fix warnings originating from bad regexes

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -712,7 +712,7 @@ Metadata
 
    The default metadata you want to use for all articles and pages.
 
-.. data:: FILENAME_METADATA = '(?P<date>\d{4}-\d{2}-\d{2}).*'
+.. data:: FILENAME_METADATA = r'(?P<date>\d{4}-\d{2}-\d{2}).*'
 
    The regexp that will be used to extract any metadata from the filename. All
    named groups that are matched will be set in the metadata object.  The
@@ -720,7 +720,7 @@ Metadata
 
    For example, to extract both the date and the slug::
 
-      FILENAME_METADATA = '(?P<date>\d{4}-\d{2}-\d{2})_(?P<slug>.*)'
+      FILENAME_METADATA = r'(?P<date>\d{4}-\d{2}-\d{2})_(?P<slug>.*)'
 
    See also ``SLUGIFY_SOURCE``.
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -111,10 +111,10 @@ class Pelican(object):
             structure = self.settings['ARTICLE_PERMALINK_STRUCTURE']
 
             # Convert %(variable) into {variable}.
-            structure = re.sub('%\((\w+)\)s', '{\g<1>}', structure)
+            structure = re.sub(r'%\((\w+)\)s', '{\g<1>}', structure)
 
             # Convert %x into {date:%x} for strftime
-            structure = re.sub('(%[A-z])', '{date:\g<1>}', structure)
+            structure = re.sub(r'(%[A-z])', '{date:\g<1>}', structure)
 
             # Strip a / prefix
             structure = re.sub('^/', '', structure)

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -650,9 +650,9 @@ def parse_path_metadata(source_path, settings=None, process=None):
     ...     settings=settings,
     ...     process=reader.process_metadata)
     >>> pprint.pprint(metadata)  # doctest: +ELLIPSIS
-    {'category': <pelican.urlwrappers.Category object at ...>,
-     'date': SafeDatetime(2013, 1, 1, 0, 0),
-     'slug': 'my-slug'}
+    ... {'category': <pelican.urlwrappers.Category object at ...>,
+    ...  'date': SafeDatetime(2013, 1, 1, 0, 0),
+    ...  'slug': 'my-slug'}
     """
     metadata = {}
     dirname, basename = os.path.split(source_path)

--- a/pelican/rstdirectives.py
+++ b/pelican/rstdirectives.py
@@ -75,7 +75,7 @@ directives.register_directive('code-block', Pygments)
 directives.register_directive('sourcecode', Pygments)
 
 
-_abbr_re = re.compile('\((.*)\)$', re.DOTALL)
+_abbr_re = re.compile(r'\((.*)\)$', re.DOTALL)
 
 
 class abbreviation(nodes.Inline, nodes.TextElement):

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -121,7 +121,7 @@ DEFAULT_CONFIG = {
     'DEFAULT_PAGINATION': False,
     'DEFAULT_ORPHANS': 0,
     'DEFAULT_METADATA': {},
-    'FILENAME_METADATA': '(?P<date>\d{4}-\d{2}-\d{2}).*',
+    'FILENAME_METADATA': r'(?P<date>\d{4}-\d{2}-\d{2}).*',
     'PATH_METADATA': '',
     'EXTRA_PATH_METADATA': {},
     'DEFAULT_STATUS': 'published',

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -305,8 +305,8 @@ def slugify(value, substitutions=()):
             replace = replace and not skip
 
     if replace:
-        value = re.sub('[^\w\s-]', '', value).strip()
-        value = re.sub('[-\s]+', '-', value)
+        value = re.sub(r'[^\w\s-]', '', value).strip()
+        value = re.sub(r'[-\s]+', '-', value)
     else:
         value = value.strip()
 


### PR DESCRIPTION
Starting with python 3.6 warnings are issued for invalid escape
sequences in regular expressions. This commit corrects all
DeprecationWarning's via properly declaring the offending
regular expressions as raw strings.

Resolves #2095.