### PR TITLE
Import readline in pelican_quickstart.py if available

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -12,7 +12,7 @@ import sys
 import pytz
 
 try:
-    import readline
+    import readline  #NOQA
 except ImportError:
     pass
 

--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -12,7 +12,7 @@ import sys
 import pytz
 
 try:
-    import readline  #NOQA
+    import readline  # NOQA
 except ImportError:
     pass
 

--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -12,6 +12,11 @@ import sys
 import pytz
 
 try:
+    import readline
+except ImportError:
+    pass
+
+try:
     import tzlocal
     _DEFAULT_TIMEZONE = tzlocal.get_localzone().zone
 except:


### PR DESCRIPTION
I was confused when I tried to paste using <kbd>Control</kbd>+<kbd>Y</kbd> in my Bash shell because it printed C^Y instead of pasting the text I deleted previously with <kbd>Control</kbd>+<kbd>W</kbd>. With readline, users won't have this weird experience.