### PR TITLE
Fix for the check: if the output directory is a part of the content path

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -163,7 +163,7 @@ class Pelican(object):
         # erase the directory if it is not the source and if that's
         # explicitly asked
         if (self.delete_outputdir and not
-                os.path.commonpath((self.path, 
+                os.path.commonpath((self.path,
                                     self.output_path)) != self.output_path):
             clean_output_dir(self.output_path, self.output_retention)
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -163,7 +163,7 @@ class Pelican(object):
         # erase the directory if it is not the source and if that's
         # explicitly asked
         if (self.delete_outputdir and not
-                os.path.realpath(self.path).startswith(self.output_path)):
+                os.path.commonpath((self.path, self.output_path)) != self.output_path):
             clean_output_dir(self.output_path, self.output_retention)
 
         for p in generators:

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -163,7 +163,8 @@ class Pelican(object):
         # erase the directory if it is not the source and if that's
         # explicitly asked
         if (self.delete_outputdir and not
-                os.path.commonpath((self.path, self.output_path)) != self.output_path):
+                os.path.commonpath((self.path, 
+                                    self.output_path)) != self.output_path):
             clean_output_dir(self.output_path, self.output_retention)
 
         for p in generators:


### PR DESCRIPTION
Hi,

Erasing of the output directory doesn't work in a case when it is a part of the content directory but it is not a subdirectory which is possible. 

For example,

DELETE_OUTPUT_DIRECTORY = True
PATH = '/path/to/repo/docs.src/content'
OUTPUT_PATH = '/path/to/repo/docs'

This happens because currently is being checked only if PATH `startswith` OUTPUT_PATH. Yes, it starts but it is not a subdirectory and they are absolutely different.

This pull-request proposes a proper check for this situation.

P.S.
 I removed os.path.realpath() from the check because all paths have already been saved as absolute at that moment  