### PR TITLE
Fix empty page listing for default/notmyidea theme (issue #2097)

### DIFF
--- a/pelican/themes/notmyidea/templates/index.html
+++ b/pelican/themes/notmyidea/templates/index.html
@@ -51,7 +51,7 @@
 {% else %}
 <section id="content" class="body">
 <h2>Pages</h2>
-    {% for page in PAGES %}
+    {% for page in pages %}
         <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
     {% endfor %}
 </section>


### PR DESCRIPTION
Issue #2097 still needs a fix, here's a patch. Would be cool to have this fixed. Thank you!