### PR TITLE
Introduce Jinja2 filters for converting links in additional fields

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Next release
 ============
 
 * New signal: ``feed_generated``
+* Introduced ``expand_link`` and ``expand_links`` Jinja2 filters to allow URL
+  replacement in user-defined metadata fields.
 
 3.7.1 (2017-01-10)
 ==================

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -202,6 +202,29 @@ and ``article2.md``::
     [a link relative to the current file]({filename}category/article1.rst)
     [a link relative to the content root]({filename}/category/article1.rst)
 
+The link replacing works by default on article and page contents as well as
+summaries. If you need to replace links in custom formatted fields that are
+referenced in the ``FORMATTED_FIELDS`` setting, use the ``expand_links``
+Jinja2 filter in your template, passing the field name as a parameter::
+
+    {{ article|expand_links('legal') }}
+
+If your custom field consists of just one link (for example a link to article
+cover image for a social meta tag), use the ``expand_link`` Jinja2 filter::
+
+    {{ article|expand_link('cover') }}
+
+With the above being in a template and ``FORMATTED_FIELDS`` setting containing
+the ``'legal'`` field, a RST article making use of both fields could look like
+this::
+
+    An article
+    ##########
+
+    :date: 2017-06-22
+    :legal: This article is released under `CC0 {filename}/license.rst`.
+    :cover: {filename}/img/article-cover.jpg
+
 Linking to static files
 -----------------------
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -21,8 +21,9 @@ from pelican import signals
 from pelican.cache import FileStampDataCacher
 from pelican.contents import Article, Draft, Page, Static, is_valid_content
 from pelican.readers import Readers
-from pelican.utils import (DateFormatter, copy, mkdir_p, posixize_path,
-                           process_translations, python_2_unicode_compatible)
+from pelican.utils import (DateFormatter, HtmlLinkExpander, LinkExpander, copy,
+                           mkdir_p, posixize_path, process_translations,
+                           python_2_unicode_compatible)
 
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,10 @@ class Generator(object):
 
         # provide utils.strftime as a jinja filter
         self.env.filters.update({'strftime': DateFormatter()})
+
+        # provide link expansion as a jinja filter
+        self.env.filters.update({'expand_link': LinkExpander(settings)})
+        self.env.filters.update({'expand_links': HtmlLinkExpander()})
 
         # get custom Jinja filters from user settings
         custom_filters = self.settings['JINJA_FILTERS']

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -147,6 +147,40 @@ class DateFormatter(object):
         return formatted
 
 
+class LinkExpander(object):
+    """Link expander object used as a jinja filter
+
+    Expands a custom field that contains just a link to internal content. The
+    same rules as when links are expanded in article/page contents and
+    summaries apply.
+    """
+
+    def __init__(self, settings):
+        self.intrasite_link_regex = settings['INTRASITE_LINK_REGEX']
+
+    def __call__(self, content, attr):
+        link_regex = r"""^
+            (?P<markup>)(?P<quote>)
+            (?P<path>{0}(?P<value>.*))
+            $""".format(self.intrasite_link_regex)
+        links = re.compile(link_regex, re.X)
+        return links.sub(
+            lambda m: content._link_replacer(content.get_siteurl(), m),
+            getattr(content, attr))
+
+
+class HtmlLinkExpander(object):
+    """HTML link expander object used as a jinja filter
+
+    Expands links to internal contents in a custom HTML field. The same rules
+    as when links are expanded in article/page contents and summaries apply.
+    """
+
+    def __call__(self, content, attr):
+        return content._update_content(getattr(content, attr),
+                                       content.get_siteurl())
+
+
 def python_2_unicode_compatible(klass):
     """
     A decorator that defines __unicode__ and __str__ methods under Python 2.


### PR DESCRIPTION
*Reworked to reflect the review comment, see below for the original proposal.*

Until now, the link replacing worked only on article and page contents or summaries. With this patch, if one needes to replace links in custom fields, there are two new Jinja2 filters that can do that. For fields that are referenced in the `FORMATTED_FIELDS` setting, one can use the `expand_links` Jinja2 filter in the template, passing the field name as a parameter:

    {{ article|expand_links('legal') }}

If the custom field consists of just one link (for example a link to article cover image for a social meta tag), one can use the `expand_link` Jinja2 filter:

    {{ article|expand_link('cover') }}

With the above being in a template and `FORMATTED_FIELDS` setting containing the `'legal'` field, a RST article making use of both fields could look like this:

```rst
An article
##########

:date: 2017-06-22
:legal: This article is released under `CC0 {filename}/license.rst`.
:cover: {filename}/img/article-cover.jpg
```

**Disclaimer:** I'm a Python noob and pretty new to Pelican as well, so it's possible I did something terribly wrong here. I am happy to incorporate changes based on your reviews. Things I'm not sure about:

- I added an entry to the changelog and to the contents docs as well. Hope I did that correctly :)
- I was not able to create any tests for this, because in order to test this there needs to be a template that makes use of the additional metadata. This is probably the case for `FORMATTED_FIELDS` as well -- however I was not able to find any test covering this setting.

Fixes #1169 (which is closed now).

- - -

## Introduce INTERNAL_LINK_FIELDS setting (obsoleted by the above)

Metadata fields with links to internal content listed in this array will be properly converted to absolute URLs the same way as they do in page/article content and summary. This allows themes to specify custom metadata fields to be used for linking to internal content such as social media tags, page background etc. For example, a theme can define this for an article page:

```html
<meta property="og:title" content="{{ article.title }}" />
<meta property="og:image" content="{{ article.cover }}" />
```

And then a reST article can include an image as an additional metadata field:

```reST
A cool article
##############

:date: 2017-06-06
:cover: {filename}/img/cool-photo.jpg
```

With the following in the settings:

```py
SITEURL = "http://cool.site/"
INTERNAL_LINK_FIELDS = ['cover']
```

The generated article page will have this:

```html
<meta property="og:title" content="A cool article" />
<meta property="og:image" content="http://cool.site/img/cool-photo.jpg" />
```