### PR TITLE
Fix rsync_upload in Makefile template

### DIFF
--- a/pelican/tools/templates/Makefile.in
+++ b/pelican/tools/templates/Makefile.in
@@ -102,7 +102,7 @@ ssh_upload: publish
 	scp -P $$(SSH_PORT) -r $$(OUTPUTDIR)/* $$(SSH_USER)@$$(SSH_HOST):$$(SSH_TARGET_DIR)
 
 rsync_upload: publish
-	rsync -e "ssh -p $(SSH_PORT)" -P -rvzc --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR) --cvs-exclude
+	rsync -e "ssh -p $(SSH_PORT)" -P -rvzc --cvs-exclude --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 
 dropbox_upload: publish
 	cp -r $$(OUTPUTDIR)/* $$(DROPBOX_DIR)


### PR DESCRIPTION

In Makefile template `--cvs-exclude` option for `rsync_upload` is in bad
place - it should be placed before destination.

PoC:

```
/bin/sh: --cvs-exclude: command not found
make: *** [rsync_upload] Error 127
```