### PR TITLE
In --autoreload mode, only reprocess modified files

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -488,8 +488,6 @@ def main():
             if next(watchers['theme']) is None:
                 logger.warning('Empty theme folder. Using `basic` theme.')
 
-            modified_files = [val for vals in list(modified.values())
-                              for val in vals]
             pelican.run()
 
     except Exception as e:

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -141,7 +141,7 @@ class Pelican(object):
                 )
                 self.settings[old] = self.settings[new]
 
-    def run(self):
+    def run(self, modified=None):
         """Run the generators and return"""
         start_time = time.time()
 
@@ -164,11 +164,13 @@ class Pelican(object):
         # explicitly asked
         if (self.delete_outputdir and not
                 os.path.realpath(self.path).startswith(self.output_path)):
-            clean_output_dir(self.output_path, self.output_retention)
+            clean_output_dir(self.output_path,
+                             self.output_retention,
+                             files_to_clean=modified)
 
         for p in generators:
             if hasattr(p, 'generate_context'):
-                p.generate_context()
+                p.generate_context(modified=modified)
 
         signals.all_generators_finalized.send(generators)
 
@@ -462,7 +464,9 @@ def main():
                             logger.warning('Empty theme folder. Using `basic` '
                                            'theme.')
 
-                        pelican.run()
+                        modified_files = [v for vals in list(modified.values())
+                                          for v in vals]
+                        pelican.run(modified=modified_files)
 
                 except KeyboardInterrupt:
                     logger.warning("Keyboard interrupt, quitting.")
@@ -484,6 +488,8 @@ def main():
             if next(watchers['theme']) is None:
                 logger.warning('Empty theme folder. Using `basic` theme.')
 
+            modified_files = [val for vals in list(modified.values())
+                              for val in vals]
             pelican.run()
 
     except Exception as e:

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -286,22 +286,22 @@ class TestUtils(LoggedTestCase):
         file_watcher = utils.file_watcher(path)
 
         # first check returns True
-        self.assertEqual(next(folder_watcher), True)
-        self.assertEqual(next(file_watcher), True)
+        self.assertTrue(next(folder_watcher))
+        self.assertTrue(next(file_watcher))
 
         # next check without modification returns False
-        self.assertEqual(next(folder_watcher), False)
-        self.assertEqual(next(file_watcher), False)
+        self.assertFalse(next(folder_watcher))
+        self.assertFalse(next(file_watcher))
 
         # after modification, returns True
         t = time.time()
         os.utime(path, (t, t))
-        self.assertEqual(next(folder_watcher), True)
-        self.assertEqual(next(file_watcher), True)
+        self.assertTrue(next(folder_watcher))
+        self.assertTrue(next(file_watcher))
 
         # file watcher with None or empty path should return None
-        self.assertEqual(next(utils.file_watcher('')), None)
-        self.assertEqual(next(utils.file_watcher(None)), None)
+        self.assertIsNone(next(utils.file_watcher('')))
+        self.assertIsNone(next(utils.file_watcher(None)))
 
         empty_path = os.path.join(os.path.dirname(__file__), 'empty')
         try:
@@ -309,9 +309,9 @@ class TestUtils(LoggedTestCase):
             os.mkdir(os.path.join(empty_path, "empty_folder"))
             shutil.copy(__file__, empty_path)
 
-            # if no files of interest, returns None
+            # if no files of interest, returns empty list
             watcher = utils.folder_watcher(empty_path, ['rst'])
-            self.assertEqual(next(watcher), None)
+            self.assertEqual(next(watcher), [])
         except OSError:
             self.fail("OSError Exception in test_files_changed test")
         finally:


### PR DESCRIPTION
This PR makes Pelican's `--autoreload` mode more efficient by only reprocessing modified files when the watched content changes.