### PR TITLE
Allow directory entries in EXTRA_PATH_METADATA

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -783,7 +783,8 @@ Metadata
 
    Extra metadata dictionaries keyed by relative path. Relative paths require
    correct OS-specific directory separators (i.e. / in UNIX and \\ in Windows)
-   unlike some other Pelican file settings.
+   unlike some other Pelican file settings. Paths to a directory apply to all
+   files under it. The most-specific path wins conflicts.
 
 Not all metadata needs to be :ref:`embedded in source file itself
 <internal_metadata>`. For example, blog posts are often named following a

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -273,6 +273,38 @@ class RstReaderTest(ReaderTest):
         }
         self.assertDictHasSubset(page.metadata, expected)
 
+    def test_article_extra_path_metadata_recurse(self):
+        parent = "TestCategory"
+        notparent = "TestCategory/article"
+        path = "TestCategory/article_without_category.rst"
+
+        epm = {
+            parent: {'epmr_inherit': parent,
+                     'epmr_override': parent, },
+            notparent: {'epmr_bogus': notparent},
+            path:   {'epmr_override': path, },
+            }
+        expected_metadata = {
+            'epmr_inherit': parent,
+            'epmr_override': path,
+            }
+
+        page = self.read_file(path=path, EXTRA_PATH_METADATA=epm)
+        self.assertDictHasSubset(page.metadata, expected_metadata)
+
+        # Make sure vars aren't getting "inherited" by mistake...
+        path = "article.rst"
+        page = self.read_file(path=path, EXTRA_PATH_METADATA=epm)
+        for k in expected_metadata.keys():
+            self.assertNotIn(k, page.metadata)
+
+        # Same, but for edge cases where one file's name is a prefix of
+        # another.
+        path = "TestCategory/article_without_category.rst"
+        page = self.read_file(path=path, EXTRA_PATH_METADATA=epm)
+        for k in epm[notparent].keys():
+            self.assertNotIn(k, page.metadata)
+
     def test_typogrify(self):
         # if nothing is specified in the settings, the content should be
         # unmodified


### PR DESCRIPTION
This lets the user apply arbitrary metadata to everything in a directory. My specific use case is changing the stylesheet and template, but it also provides workarounds for cases when DEFAULT_METADATA isn't enough; e.g. applying the [default draft recipe](http://docs.getpelican.com/en/3.6.3/content.html#publishing-drafts) from the docs may not work as expected because [pages and articles accept different status types](https://github.com/getpelican/pelican/issues/1620#issuecomment-73736406).