### PR TITLE
Correct import of socketserver on Python 3

### DIFF
--- a/pelican/tools/templates/fabfile.py.in
+++ b/pelican/tools/templates/fabfile.py.in
@@ -3,7 +3,10 @@ import fabric.contrib.project as project
 import os
 import shutil
 import sys
-import SocketServer
+try:
+    import socketserver
+except ImportError:
+    import SocketServer as socketserver
 
 from pelican.server import ComplexHTTPRequestHandler
 
@@ -48,7 +51,7 @@ def serve():
     """Serve site at http://localhost:8000/"""
     os.chdir(env.deploy_path)
 
-    class AddressReuseTCPServer(SocketServer.TCPServer):
+    class AddressReuseTCPServer(socketserver.TCPServer):
         allow_reuse_address = True
 
     server = AddressReuseTCPServer(('', PORT), ComplexHTTPRequestHandler)


### PR DESCRIPTION
This change fixes #2154 

