### PR TITLE
Correct typos from documentation

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -11,7 +11,7 @@ The idea behind "pages" is that they are usually not temporal in nature and are
 used for content that does not change very often (e.g., "About" or "Contact"
 pages).
 
-You can find sample content in the repository at ``pelican/samples/content/``.
+You can find sample content in the repository at ``samples/content/``.
 
 .. _internal_metadata:
 

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -11,7 +11,7 @@ The idea behind "pages" is that they are usually not temporal in nature and are
 used for content that does not change very often (e.g., "About" or "Contact"
 pages).
 
-You can find sample content in the repository at: ``pelican/samples/content/``
+You can find sample content in the repository at ``pelican/samples/content/``.
 
 .. _internal_metadata:
 


### PR DESCRIPTION
- paragraph missing stop
- Remove unnecessary colon