### PR TITLE
Fix typo from documentation

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -93,9 +93,9 @@ interprets the HTML in a very straightforward manner, reading metadata from
         </body>
     </html>
 
-With HTML, there is one simple exception to the standard metadata: ``tags`` can
-be specified either via the ``tags`` metadata, as is standard in Pelican, or
-via the ``keywords`` metadata, as is standard in HTML. The two can be used
+With HTML, there is one simple exception to the standard metadata: tags can be
+specified either via the ``tags`` metadata, as is standard in Pelican, or via
+the ``keywords`` metadata, as is standard in HTML. The two can be used
 interchangeably.
 
 Note that, aside from the title, none of this article metadata is mandatory:


### PR DESCRIPTION
I think that the documentation should say simply tags (no code formatting). @justinmayer can you confirm it, as you were the one who wrote it four years ago? I may be missing something.