### PR TITLE
Add --log-dedup-min-level CLI option

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -14,7 +14,7 @@ import six
 
 # pelican.log has to be the first pelican module to be loaded
 # because logging.setLoggerClass has to be called before logging.getLogger
-from pelican.log import init
+from pelican.log import init as init_logging
 from pelican import signals  # noqa
 from pelican.generators import (ArticlesGenerator, PagesGenerator,
                                 SourceFileGenerator, StaticGenerator,
@@ -327,6 +327,11 @@ def parse_arguments():
                         help=('Exit the program with non-zero status if any '
                               'errors/warnings encountered.'))
 
+    parser.add_argument('--logs-dedup-min-level', default='WARNING',
+                        choices=('DEBUG', 'INFO', 'WARNING', 'ERROR'),
+                        help=('Only enable log de-duplication for levels equal'
+                              ' to or above the specified value'))
+
     return parser.parse_args()
 
 
@@ -384,7 +389,9 @@ def get_instance(args):
 
 def main():
     args = parse_arguments()
-    init(args.verbosity, args.fatal)
+    logs_dedup_min_level = getattr(logging, args.logs_dedup_min_level)
+    init_logging(args.verbosity, args.fatal,
+                 logs_dedup_min_level=logs_dedup_min_level)
 
     logger.debug('Pelican version: %s', __version__)
     logger.debug('Python version: %s', sys.version.split()[0])

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -91,6 +91,8 @@ class LimitFilter(logging.Filter):
     E.g.: log.warning(('43 is not the answer', 'More erroneous answers'))
     """
 
+    LOGS_DEDUP_MIN_LEVEL = logging.WARNING
+
     _ignore = set()
     _raised_messages = set()
     _threshold = 5
@@ -98,7 +100,7 @@ class LimitFilter(logging.Filter):
 
     def filter(self, record):
         # don't limit log messages for anything above "warning"
-        if record.levelno > logging.WARN:
+        if record.levelno > self.LOGS_DEDUP_MIN_LEVEL:
             return True
 
         # extract group
@@ -226,7 +228,8 @@ def get_formatter():
         return TextFormatter()
 
 
-def init(level=None, fatal='', handler=logging.StreamHandler(), name=None):
+def init(level=None, fatal='', handler=logging.StreamHandler(), name=None,
+         logs_dedup_min_level=None):
     FatalLogger.warnings_fatal = fatal.startswith('warning')
     FatalLogger.errors_fatal = bool(fatal)
 
@@ -237,6 +240,8 @@ def init(level=None, fatal='', handler=logging.StreamHandler(), name=None):
 
     if level:
         logger.setLevel(level)
+    if logs_dedup_min_level:
+        LimitFilter.LOGS_DEDUP_MIN_LEVEL = logs_dedup_min_level
 
 
 def log_warnings():


### PR DESCRIPTION
Currently this value is hardcoded in `LimitFilter.filter`.
However when running the devserver, it is handy to print what is performed during each `pelican.run`.

Thanks to this change I was able to understand what was going on and to tweak my `pelicanconf.py` in order to speed up things.