### PR TITLE
Tell Travis to use Python 3.5 image when running Tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.5"
 env:
   - TOX_ENV=docs
   - TOX_ENV=flake8


### PR DESCRIPTION
To hopefully fix this, as mentioned in https://github.com/getpelican/pelican/issues/2139#issuecomment-331139908:
```
$ tox -e $TOX_ENV
py35 create: /home/travis/build/getpelican/pelican/.tox/py35
ERROR: InvocationError: Failed to get version_info for python3.5: pyenv: python3.5: command not found
The `python3.5' command exists in these Python versions:
  3.5
  3.5.3
___________________________________ summary ____________________________________
ERROR:   py35: InvocationError: Failed to get version_info for python3.5: pyenv: python3.5: command not found
The `python3.5' command exists in these Python versions:
  3.5
  3.5.3
The command "tox -e $TOX_ENV" exited with 1.
```
https://travis-ci.org/getpelican/pelican/jobs/278160355

(The 3.3 error will be fixed by dropping 3.3 it in #2216.)