### PR TITLE
Check for 0 dates in pelican-import

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -160,8 +160,11 @@ def wp2fields(xml, wp_custpost=False):
 
             content = item.find('encoded').string
             raw_date = item.find('post_date').string
-            date_object = time.strptime(raw_date, '%Y-%m-%d %H:%M:%S')
-            date = time.strftime('%Y-%m-%d %H:%M', date_object)
+            if raw_date == u'0000-00-00 00:00:00':
+                date = None
+            else:
+                date_object = time.strptime(raw_date, '%Y-%m-%d %H:%M:%S')
+                date = time.strftime('%Y-%m-%d %H:%M', date_object)
             author = item.find('creator').string
 
             categories = [cat.string for cat


### PR DESCRIPTION
Check for 0 dates.

Haven' checked why these dates occur, but fixes the import of my own blog.

Error that I was getting before applying this fix -
```
Traceback (most recent call last):
  File "/mnt/data/home/stu/.virtualenvs/blog/bin/pelican-import", line 11, in <module>
    sys.exit(main())
  File "/mnt/data/home/stu/.virtualenvs/blog/local/lib/python2.7/site-packages/pelican/tools/pelican_import.py", line 896, in main
    attachments=attachments or None)
  File "/mnt/data/home/stu/.virtualenvs/blog/local/lib/python2.7/site-packages/pelican/tools/pelican_import.py", line 684, in fields2pelican
    kind, in_markup) in fields:
  File "/mnt/data/home/stu/.virtualenvs/blog/local/lib/python2.7/site-packages/pelican/tools/pelican_import.py", line 163, in wp2fields
    date_object = time.strptime(raw_date, '%Y-%m-%d %H:%M:%S')
  File "/usr/lib/python2.7/_strptime.py", line 478, in _strptime_time
    return _strptime(data_string, format)[0]
  File "/usr/lib/python2.7/_strptime.py", line 332, in _strptime
    (data_string, format))
ValueError: time data u'0000-00-00 00:00:00' does not match format u'%Y-%m-%d %H:%M:%S'

```