### PR TITLE
Fix metadata intrasite links

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -151,8 +151,8 @@ class Content(object):
 
 
         # store the summary metadata if it is set
-        if 'summary' in metadata:
-            self._summary = metadata['summary']
+        if 'summary' in self.metadata:
+            self._summary = self.metadata['summary']
 
         signals.content_object_init.send(self)
 
@@ -348,7 +348,7 @@ class Content(object):
         content.
         """
         if hasattr(self, '_summary'):
-            return self._update_content(self._summary, siteurl)
+            return self._summary
 
         if self.settings['SUMMARY_MAX_LENGTH'] is None:
             return self.content

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -140,6 +140,16 @@ class Content(object):
         if not hasattr(self, 'status'):
             self.status = getattr(self, 'default_status', None)
 
+        for key in self.settings['FORMATTED_FIELDS']:
+            if key in self.metadata:
+                value = self._update_content(
+                    self.metadata[key],
+                    self.get_siteurl()
+                )
+                self.metadata[key] = value
+                setattr(self, key.lower(), value)
+
+
         # store the summary metadata if it is set
         if 'summary' in metadata:
             self._summary = metadata['summary']

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -319,17 +319,21 @@ class TestPage(LoggedTestCase):
         )
 
         # also test for summary in metadata
-        args['metadata']['summary'] = (
+        parsed = (
             'A simple summary test, with a '
             '<a href="|filename|article.rst">link</a>'
         )
-        args['context']['localsiteurl'] = 'http://notmyidea.org'
-        p = Page(**args)
-        self.assertEqual(
-            p.summary,
+        linked = (
             'A simple summary test, with a '
             '<a href="http://notmyidea.org/article.html">link</a>'
         )
+        args['settings']['FORMATTED_FIELDS'] = ['summary', 'custom']
+        args['metadata']['summary'] = parsed
+        args['metadata']['custom'] = parsed
+        args['context']['localsiteurl'] = 'http://notmyidea.org'
+        p = Page(**args)
+        self.assertEqual(p.summary, linked)
+        self.assertEqual(p.custom, linked)
 
     def test_intrasite_link_more(self):
         # type does not take unicode in PY2 and bytes in PY3, which in


### PR DESCRIPTION
Fix intrasite links for non-'summary' metadata

Metadata like `MyArticleBanner: ![alt text]({attach}banner.jpg)` would be property parsed (as defined in `FORMATTED_FIELDS`), but the intrasite links would not be processed.

Only the summary gets its intrasite links processed, has its value is either generated from the content (calling self._update_content at some point) or self._update_content is explicitly called if summary is passed as metadata.

This PR expands the paths as soon as possible in (`Content.__init__`) for metadata defined in `FORMATTED_FIELDS`.
