### PR TITLE
Add a per post max-summary-length metadata (#2209)

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -340,11 +340,24 @@ class Content(object):
         if hasattr(self, '_summary'):
             return self._update_content(self._summary, siteurl)
 
-        if self.settings['SUMMARY_MAX_LENGTH'] is None:
+        # a page specific max summary length was found
+        if hasattr(self, 'summary_max_length'):
+            summary_max_length = getattr(self, 'summary_max_length')
+            if summary_max_length.upper() == 'NONE':
+                return self.content
+            else:
+                summary_max_length = int(summary_max_length)
+                return truncate_html_words(self.content, summary_max_length)
+
+        if 'SUMMARY_MAX_LENGTH' in self.settings:
+            summary_max_length = self.settings['SUMMARY_MAX_LENGTH']
+        else:
+            summary_max_length = None
+
+        if summary_max_length is None:
             return self.content
 
-        return truncate_html_words(self.content,
-                                   self.settings['SUMMARY_MAX_LENGTH'])
+        return truncate_html_words(self.content, summary_max_length)
 
     @property
     def summary(self):


### PR DESCRIPTION
This is a proposed PR to help pelican better support the use case of issue #2209.

In #2209 I wanted to create a post with embedded html and Javascript, but the per site `SUMMARY_MAX_LENGTH` default of 50 was resulting in the script being truncated on the site index page, ... and thus broken when the post is displayed on the index page.

There appear to be two workarounds for users who want to do as I did.

1. Add in the metadata a `summary: ` header and create a different summary
2. Change the  site setting of `SUMMARY_MAX_LENGTH` to something huge.

Neither workaround is great, the former means even short and simple embedded html and javascript might not work on the index page, and the latter means the index page takes on a dramatically different form from then on.

This PR enables contents.py's `get_summary()` to recognize a metadata header for the post of `SUMMARY_MAX_LENGTH` and if it is present, to use that to override any site setting or default for `SUMMARY_MAX_LENGTH`.

Now a user can add to a post a metadata header like

    SUMMARY_MAX_LENGTH: None
    summary_max_length: None
    SUMMARY_MAX_LENGTH: 2000

To change the summary max length for the specific post. A value of `None` means there is no summary max length for that post.

Please note: I have tested it on my own very small static site, but I was not able to run the pelican unittests on Windows 7 with Python 2.7. I tried running it on a freshly cloned `master` and it failed, my log file of doing such is at https://gist.github.com/jerryasher/0e954abb32b30f5d56c074a8f8a5036c