### PR TITLE
Feed URL settings, making feeds aware of absolute URLs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -811,46 +811,95 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
 
 .. data:: FEED_ATOM = None, i.e. no Atom feed
 
-   Relative URL to output the Atom feed.
+   The location to save the Atom feed.
+
+.. data:: FEED_ATOM_URL = None
+
+   Relative URL of the Atom feed. If not set, ``FEED_ATOM`` is used both for
+   save location and URL.
 
 .. data:: FEED_RSS = None, i.e. no RSS
 
-   Relative URL to output the RSS feed.
+   The location to save the RSS feed.
+
+.. data:: FEED_RSS_URL = None
+
+   Relative URL of the RSS feed. If not set, ``FEED_RSS`` is used both for save
+   location and URL.
 
 .. data:: FEED_ALL_ATOM = 'feeds/all.atom.xml'
 
-   Relative URL to output the all-posts Atom feed: this feed will contain all
+   The location to save the all-posts Atom feed: this feed will contain all
    posts regardless of their language.
+
+.. data:: FEED_ALL_ATOM_URL = None
+
+   Relative URL of the all-posts Atom feed. If not set, ``FEED_ALL_ATOM`` is
+   used both for save location and URL.
 
 .. data:: FEED_ALL_RSS = None, i.e. no all-posts RSS
 
-   Relative URL to output the all-posts RSS feed: this feed will contain all
+   The location to save the the all-posts RSS feed: this feed will contain all
    posts regardless of their language.
+
+.. data:: FEED_ALL_RSS_URL = None
+
+   Relative URL of the all-posts RSS feed. If not set, ``FEED_ALL_RSS`` is used
+   both for save location and URL.
 
 .. data:: CATEGORY_FEED_ATOM = 'feeds/%s.atom.xml'
 
-   Where to put the category Atom feeds. [2]_
+   The location to save the category Atom feeds. [2]_
+
+.. data:: CATEGORY_FEED_ATOM_URL = None
+
+   Relative URL of the category Atom feeds, including the ``%s`` placeholder.
+   [2]_ If not set, ``CATEGORY_FEED_ATOM`` is used both for save location and
+   URL.
 
 .. data:: CATEGORY_FEED_RSS = None, i.e. no RSS
 
-   Where to put the category RSS feeds.
+   The location to save the category RSS feeds, including the ``%s``
+   placeholder. [2]_
+
+.. data:: CATEGORY_FEED_RSS_URL = None
+
+   Relative URL of the category RSS feeds, including the ``%s`` placeholder.
+   [2]_ If not set, ``CATEGORY_FEED_RSS`` is used both for save location and
+   URL.
 
 .. data:: AUTHOR_FEED_ATOM = 'feeds/%s.atom.xml'
 
-   Where to put the author Atom feeds. [2]_
+   The location to save the author Atom feeds. [2]_
+
+.. data:: AUTHOR_FEED_ATOM_URL = None
+
+   Relative URL of the author Atom feeds, including the ``%s`` placeholder.
+   [2]_ If not set, ``AUTHOR_FEED_ATOM`` is used both for save location and
+   URL.
 
 .. data:: AUTHOR_FEED_RSS = 'feeds/%s.rss.xml'
 
-   Where to put the author RSS feeds. [2]_
+   The location to save the author RSS feeds. [2]_
+
+.. data:: AUTHOR_FEED_RSS_URL = None
+
+   Relative URL of the author RSS feeds, including the ``%s`` placeholder. [2]_
+   If not set, ``AUTHOR_FEED_RSS`` is used both for save location and URL.
 
 .. data:: TAG_FEED_ATOM = None, i.e. no tag feed
 
-   Relative URL to output the tag Atom feed. It should be defined using a "%s"
-   match in the tag name.
+   The location to save the tag Atom feed, including the ``%s`` placeholder.
+   [2]_
+
+.. data:: TAG_FEED_ATOM_URL = None
+
+   Relative URL of the tag Atom feed, including the ``%s`` placeholder. [2]_
 
 .. data:: TAG_FEED_RSS = None, i.e. no RSS tag feed
 
-   Relative URL to output the tag RSS feed
+   Relative URL to output the tag RSS feed, including the ``%s`` placeholder.
+   If not set, ``TAG_FEED_RSS`` is used both for save location and URL.
 
 .. data:: FEED_MAX_ITEMS
 
@@ -865,7 +914,7 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
 
 If you don't want to generate some or any of these feeds, set the above variables to ``None``.
 
-.. [2] %s is the name of the category.
+.. [2] ``%s`` is replaced by name of the category / author / tag.
 
 
 FeedBurner
@@ -948,11 +997,23 @@ more information.
 
 .. data:: TRANSLATION_FEED_ATOM = 'feeds/all-%s.atom.xml'
 
-   Where to put the Atom feed for translations. [3]_
+   The location to save the Atom feed for translations. [3]_
+
+.. data:: TRANSLATION_FEED_ATOM_URL = None
+
+   Relative URL of the Atom feed for translations, including the ``%s``
+   placeholder. [3]_ If not set, ``TRANSLATION_FEED_ATOM`` is used both for
+   save location and URL.
 
 .. data:: TRANSLATION_FEED_RSS = None, i.e. no RSS
 
    Where to put the RSS feed for translations.
+
+.. data:: TRANSLATION_FEED_RSS_URL = None
+
+   Relative URL of the RSS feed for translations, including the ``%s``
+   placeholder. [3]_ If not set, ``TRANSLATION_FEED_RSS`` is used both for save
+   location and URL.
 
 .. [3] %s is the language
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -282,11 +282,16 @@ class ArticlesGenerator(CachingGenerator):
 
         if self.settings.get('FEED_ATOM'):
             writer.write_feed(self.articles, self.context,
-                              self.settings['FEED_ATOM'])
+                              self.settings['FEED_ATOM'],
+                              self.settings.get('FEED_ATOM_URL',
+                                                self.settings['FEED_ATOM']))
 
         if self.settings.get('FEED_RSS'):
             writer.write_feed(self.articles, self.context,
-                              self.settings['FEED_RSS'], feed_type='rss')
+                              self.settings['FEED_RSS'],
+                              self.settings.get('FEED_RSS_URL',
+                                                self.settings['FEED_RSS']),
+                              feed_type='rss')
 
         if (self.settings.get('FEED_ALL_ATOM') or
                 self.settings.get('FEED_ALL_RSS')):
@@ -297,11 +302,17 @@ class ArticlesGenerator(CachingGenerator):
 
             if self.settings.get('FEED_ALL_ATOM'):
                 writer.write_feed(all_articles, self.context,
-                                  self.settings['FEED_ALL_ATOM'])
+                                  self.settings['FEED_ALL_ATOM'],
+                                  self.settings.get(
+                                      'FEED_ALL_ATOM_URL',
+                                      self.settings['FEED_ALL_ATOM']))
 
             if self.settings.get('FEED_ALL_RSS'):
                 writer.write_feed(all_articles, self.context,
                                   self.settings['FEED_ALL_RSS'],
+                                  self.settings.get(
+                                      'FEED_ALL_RSS_URL',
+                                      self.settings['FEED_ALL_RSS']),
                                   feed_type='rss')
 
         for cat, arts in self.categories:
@@ -309,11 +320,19 @@ class ArticlesGenerator(CachingGenerator):
             if self.settings.get('CATEGORY_FEED_ATOM'):
                 writer.write_feed(arts, self.context,
                                   self.settings['CATEGORY_FEED_ATOM']
+                                  % cat.slug,
+                                  self.settings.get(
+                                      'CATEGORY_FEED_ATOM_URL',
+                                      self.settings['CATEGORY_FEED_ATOM'])
                                   % cat.slug, feed_title=cat.name)
 
             if self.settings.get('CATEGORY_FEED_RSS'):
                 writer.write_feed(arts, self.context,
                                   self.settings['CATEGORY_FEED_RSS']
+                                  % cat.slug,
+                                  self.settings.get(
+                                      'CATEGORY_FEED_RSS_URL',
+                                      self.settings['CATEGORY_FEED_RSS'])
                                   % cat.slug, feed_title=cat.name,
                                   feed_type='rss')
 
@@ -322,11 +341,19 @@ class ArticlesGenerator(CachingGenerator):
             if self.settings.get('AUTHOR_FEED_ATOM'):
                 writer.write_feed(arts, self.context,
                                   self.settings['AUTHOR_FEED_ATOM']
+                                  % auth.slug,
+                                  self.settings.get(
+                                      'AUTHOR_FEED_ATOM_URL',
+                                      self.settings['AUTHOR_FEED_ATOM'])
                                   % auth.slug, feed_title=auth.name)
 
             if self.settings.get('AUTHOR_FEED_RSS'):
                 writer.write_feed(arts, self.context,
                                   self.settings['AUTHOR_FEED_RSS']
+                                  % auth.slug,
+                                  self.settings.get(
+                                      'AUTHOR_FEED_RSS_URL',
+                                      self.settings['AUTHOR_FEED_RSS'])
                                   % auth.slug, feed_title=auth.name,
                                   feed_type='rss')
 
@@ -337,12 +364,20 @@ class ArticlesGenerator(CachingGenerator):
                 if self.settings.get('TAG_FEED_ATOM'):
                     writer.write_feed(arts, self.context,
                                       self.settings['TAG_FEED_ATOM']
+                                      % tag.slug,
+                                      self.settings.get(
+                                          'TAG_FEED_ATOM_URL',
+                                          self.settings['TAG_FEED_ATOM'])
                                       % tag.slug, feed_title=tag.name)
 
                 if self.settings.get('TAG_FEED_RSS'):
                     writer.write_feed(arts, self.context,
                                       self.settings['TAG_FEED_RSS'] % tag.slug,
-                                      feed_title=tag.name, feed_type='rss')
+                                      self.settings.get(
+                                          'TAG_FEED_RSS_URL',
+                                          self.settings['TAG_FEED_RSS'])
+                                      % tag.slug, feed_title=tag.name,
+                                      feed_type='rss')
 
         if (self.settings.get('TRANSLATION_FEED_ATOM') or
                 self.settings.get('TRANSLATION_FEED_RSS')):
@@ -355,11 +390,17 @@ class ArticlesGenerator(CachingGenerator):
                 if self.settings.get('TRANSLATION_FEED_ATOM'):
                     writer.write_feed(
                         items, self.context,
-                        self.settings['TRANSLATION_FEED_ATOM'] % lang)
+                        self.settings['TRANSLATION_FEED_ATOM'] % lang,
+                        self.settings.get(
+                            'TRANSLATION_FEED_ATOM_URL',
+                            self.settings['TRANSLATION_FEED_ATOM']) % lang)
                 if self.settings.get('TRANSLATION_FEED_RSS'):
                     writer.write_feed(
                         items, self.context,
                         self.settings['TRANSLATION_FEED_RSS'] % lang,
+                        self.settings.get(
+                            'TRANSLATION_FEED_RSS_URL',
+                            self.settings['TRANSLATION_FEED_RSS']) % lang,
                         feed_type='rss')
 
     def generate_articles(self, write):

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -155,6 +155,7 @@ class TestArticlesGenerator(unittest.TestCase):
         writer = MagicMock()
         generator.generate_feeds(writer)
         writer.write_feed.assert_called_with([], settings,
+                                             'feeds/all.atom.xml',
                                              'feeds/all.atom.xml')
 
         generator = ArticlesGenerator(
@@ -163,6 +164,20 @@ class TestArticlesGenerator(unittest.TestCase):
         writer = MagicMock()
         generator.generate_feeds(writer)
         self.assertFalse(writer.write_feed.called)
+
+    @unittest.skipUnless(MagicMock, 'Needs Mock module')
+    def test_generate_feeds_override_url(self):
+        settings = get_settings()
+        settings['CACHE_PATH'] = self.temp_cache
+        settings['FEED_ALL_ATOM_URL'] = 'feeds/atom/all/'
+        generator = ArticlesGenerator(
+            context=settings, settings=settings,
+            path=None, theme=settings['THEME'], output_path=None)
+        writer = MagicMock()
+        generator.generate_feeds(writer)
+        writer.write_feed.assert_called_with([], settings,
+                                             'feeds/all.atom.xml',
+                                             'feeds/atom/all/')
 
     def test_generate_context(self):
         articles_expected = [

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -5,10 +5,10 @@
         <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
         <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/{{ CSS_FILE }}" />
         {% if FEED_ALL_ATOM %}
-        <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
         {% endif %}
         {% if FEED_ALL_RSS %}
-        <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
         {% endif %}
 </head>
 
@@ -50,10 +50,10 @@
                         <h2>{{ SOCIAL_WIDGET_NAME | default('social') }}</h2>
                         <ul>
                             {% if FEED_ALL_ATOM %}
-                            <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate">atom feed</a></li>
+                            <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             {% endif %}
                             {% if FEED_ALL_RSS %}
-                            <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}" type="application/rss+xml" rel="alternate">rss feed</a></li>
+                            <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate">rss feed</a></li>
                             {% endif %}
 
                         {% for name, link in SOCIAL %}

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -5,28 +5,28 @@
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta charset="utf-8" />
         {% if FEED_ALL_ATOM %}
-        <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
         {% endif %}
         {% if FEED_ALL_RSS %}
-        <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Full RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Full RSS Feed" />
         {% endif %}
         {% if FEED_ATOM %}
-        <link href="{{ FEED_DOMAIN }}/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{%if FEED_ATOM_URL %}{{ FEED_ATOM_URL }}{% else %}{{ FEED_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
         {% endif %}
         {% if FEED_RSS %}
-        <link href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if FEED_RSS_URL %}{{ FEED_RSS_URL }}{% else %}{{ FEED_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
         {% endif %}
         {% if CATEGORY_FEED_ATOM and category %}
-        <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_ATOM|format(category.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_ATOM_URL %}{{ CATEGORY_FEED_ATOM_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_ATOM|format(category.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
         {% endif %}
         {% if CATEGORY_FEED_RSS and category %}
-        <link href="{{ FEED_DOMAIN }}/{{ CATEGORY_FEED_RSS|format(category.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_RSS_URL %}{{ CATEGORY_FEED_RSS_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_RSS|format(category.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
         {% endif %}
         {% if TAG_FEED_ATOM and tag %}
-        <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_ATOM|format(tag.slug) }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_ATOM_URL %}{{ TAG_FEED_ATOM_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_ATOM|format(tag.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
         {% endif %}
         {% if TAG_FEED_RSS and tag %}
-        <link href="{{ FEED_DOMAIN }}/{{ TAG_FEED_RSS|format(tag.slug) }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_RSS_URL %}{{ TAG_FEED_RSS_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_RSS|format(tag.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
         {% endif %}
         {% endblock head %}
 </head>

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -89,8 +89,8 @@ class Writer(object):
         self._written_files.add(filename)
         return open(filename, 'w', encoding=encoding)
 
-    def write_feed(self, elements, context, path=None, feed_type='atom',
-                   override_output=False, feed_title=None):
+    def write_feed(self, elements, context, path=None, url=None,
+                   feed_type='atom', override_output=False, feed_title=None):
         """Generate a feed with the list of articles provided
 
         Return the feed. If no path or output_path is specified, just
@@ -99,6 +99,8 @@ class Writer(object):
         :param elements: the articles to put on the feed.
         :param context: the context to get the feed metadata.
         :param path: the path to output.
+        :param url: the publicly visible feed URL; if None, path is used
+            instead
         :param feed_type: the feed type to use (atom or rss)
         :param override_output: boolean telling if we can override previous
             output with the same name (and if next files written with the same
@@ -112,7 +114,7 @@ class Writer(object):
             'SITEURL', path_to_url(get_relative_path(path)))
 
         self.feed_domain = context.get('FEED_DOMAIN')
-        self.feed_url = '{}/{}'.format(self.feed_domain, path)
+        self.feed_url = '{}/{}'.format(self.feed_domain, url if url else path)
 
         feed = self._create_new_feed(feed_type, feed_title, context)
 


### PR DESCRIPTION
With this PR, there are new `FEED_*_URL` configuration options that allow to specify custom URLs for feeds, which is helpful in case the feed filename and the actual URL differ a lot -- for example if a feed is saved to
    
    blog/feeds/all.atom.xml
    
but the actual URL from the user PoV is
    
    http://blog.your.site/feeds/all.atom.xml
    
This setting affects the generated feed XML (both RSS and Atom) and also the default `simple` and `notmyidea` themes were updated to be aware of the `*_URL` settings. This change is also fully backwards compatible, so if the `FEED_*_URL` setting is not present, the value of `FEED_*` is used for both file location and URL, as it was before.

Besides that, the feed generator is now aware of absolute URLs. So for example in case both `SITEURL` and `ARTICLE_URL` is absolute, the generated URLs are not improperly
    
    http://your.site/http://blog.your.site/the-article/
    
but rather
    
    http://blog.your.site/the-article/

This particular change is closely related to #2196, is referring to the same design decisions and should behave exactly the same (but it's not depending on it, so these PRs can be merged independently).

**Note:** Since feed generation and `RELATIVE_URL`s don't really make sense together, the URL joining code could be made a bit simpler, assuming the URLs in feeds should always be absolute. I just made it exactly the same way as in #2196 for consistency.

**Also:** I'm aware that the new feed URL settings are not very well tested, but I couldn't find a place where the feed generation could be tested separately without adding extensive amount of new sample data. Help in this direction very appreciated.

Thanks in advance!