### PR TITLE
Make THEME_STATIC_PATHS work for files as well

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -696,14 +696,21 @@ class StaticGenerator(Generator):
                     final_path=None):
         """Copy all the paths from source to destination"""
         for path in paths:
+            source_path = os.path.join(source, path)
+
             if final_path:
-                copy(os.path.join(source, path),
-                     os.path.join(output_path, destination, final_path),
-                     self.settings['IGNORE_FILES'])
+                if os.path.isfile(source_path):
+                    destination_path = os.path.join(output_path, destination,
+                                                    final_path,
+                                                    os.path.basename(path))
+                else:
+                    destination_path = os.path.join(output_path, destination,
+                                                    final_path)
             else:
-                copy(os.path.join(source, path),
-                     os.path.join(output_path, destination, path),
-                     self.settings['IGNORE_FILES'])
+                destination_path = os.path.join(output_path, destination, path)
+
+            copy(source_path, destination_path,
+                 self.settings['IGNORE_FILES'])
 
     def _file_update_required(self, staticfile):
         source_path = os.path.join(self.path, staticfile.source_path)

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -699,6 +699,53 @@ class TestStaticGenerator(unittest.TestCase):
     def set_ancient_mtime(self, path, timestamp=1):
         os.utime(path, (timestamp, timestamp))
 
+    def test_theme_static_paths_dirs(self):
+        """Test that StaticGenerator properly copies also files mentioned in
+           TEMPLATE_STATIC_PATHS, not just directories."""
+        settings = get_settings(
+            PATH=self.content_path,
+            filenames={})
+        context = settings.copy()
+        context['staticfiles'] = []
+
+        StaticGenerator(
+            context=context, settings=settings,
+            path=settings['PATH'], output_path=self.temp_output,
+            theme=settings['THEME']).generate_output(None)
+
+        # The content of dirs listed in THEME_STATIC_PATHS (defaulting to
+        # "static") is put into the output
+        self.assertTrue(os.path.isdir(os.path.join(self.temp_output,
+                                                   "theme/css/")))
+        self.assertTrue(os.path.isdir(os.path.join(self.temp_output,
+                                                   "theme/fonts/")))
+
+    def test_theme_static_paths_files(self):
+        """Test that StaticGenerator properly copies also files mentioned in
+           TEMPLATE_STATIC_PATHS, not just directories."""
+        settings = get_settings(
+            PATH=self.content_path,
+            THEME_STATIC_PATHS=['static/css/fonts.css', 'static/fonts/'],
+            filenames={})
+        context = settings.copy()
+        context['staticfiles'] = []
+
+        StaticGenerator(
+            context=context, settings=settings,
+            path=settings['PATH'], output_path=self.temp_output,
+            theme=settings['THEME']).generate_output(None)
+
+        # Only the content of dirs and files listed in THEME_STATIC_PATHS are
+        # put into the output, not everything from static/
+        self.assertFalse(os.path.isdir(os.path.join(self.temp_output,
+                                                    "theme/css/")))
+        self.assertFalse(os.path.isdir(os.path.join(self.temp_output,
+                                                    "theme/fonts/")))
+        self.assertTrue(os.path.isfile(os.path.join(self.temp_output,
+                                                    "theme/font.css")))
+        self.assertTrue(os.path.isfile(os.path.join(self.temp_output,
+                                                    "theme/fonts.css")))
+
     def test_static_excludes(self):
         """Test that StaticGenerator respects STATIC_EXCLUDES.
         """

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -741,6 +741,17 @@ class TestStaticGenerator(unittest.TestCase):
                                                     "theme/css/")))
         self.assertFalse(os.path.isdir(os.path.join(self.temp_output,
                                                     "theme/fonts/")))
+
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.temp_output, "theme/Yanone_Kaffeesatz_400.eot")))
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.temp_output, "theme/Yanone_Kaffeesatz_400.svg")))
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.temp_output, "theme/Yanone_Kaffeesatz_400.ttf")))
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.temp_output, "theme/Yanone_Kaffeesatz_400.woff")))
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.temp_output, "theme/Yanone_Kaffeesatz_400.woff2")))
         self.assertTrue(os.path.isfile(os.path.join(self.temp_output,
                                                     "theme/font.css")))
         self.assertTrue(os.path.isfile(os.path.join(self.temp_output,


### PR DESCRIPTION
(Sorry for opening so many PRs lately. I hope that's okay...)

The documentation implies that `THEME_STATIC_PATHS` should work for files as well, but that was not the case. Fixed that and added a test.

My use case is the following: a [theme I'm using](http://mcss.mosra.cz/) provides multiple CSS color styles and for publishing I need just one of them. So instead of 

```py
THEME_STATIC_PATHS = ['static']
```

I say, for example, just 

```py
THEME_STATIC_PATHS = ['static/m-dark.compiled.css']
```

and thus all the other, unneeded, files from the `static/` dir are ignored.

This PR should be totally harmless without any backward compatibility breakages, so I think it's safe to merge. Thank you.