### PR TITLE
Fixed pandoc invocation while importing feeds

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -728,8 +728,7 @@ def fields2pelican(
                 fp.write(new_content)
 
             parse_raw = '--parse-raw' if not strip_raw else ''
-            cmd = ('pandoc --normalize {0} --from=html'
-                   ' --to={1} -o "{2}" "{3}"')
+            cmd = ('pandoc --from=html --to={1} -o "{2}" "{3}"')
             cmd = cmd.format(parse_raw, out_markup,
                              out_filename, html_filename)
 


### PR DESCRIPTION
Newer version of `pandoc` normalize by default. If this legacy option is present, `pandoc` fails to run.