### PR TITLE
Propagate value of DEFAULT_LANG to Docutils reST parser

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -234,6 +234,7 @@ class RstReader(BaseReader):
         extra_params = {'initial_header_level': '2',
                         'syntax_highlight': 'short',
                         'input_encoding': 'utf-8',
+                        'language_code': self.settings.get('DEFAULT_LANG'),
                         'exit_status_level': 2,
                         'embed_stylesheet': False}
         user_params = self.settings.get('DOCUTILS_SETTINGS')


### PR DESCRIPTION
In [m.css](http://mcss.mosra.cz) I'm implementing language-aware smart quotes (as opposed to the builtin `TYPOGRIFY` option, which is hardcoded to English-style quotes AFAIK) and also hyphenation. It [can produce output like this](http://mcss.mosra.cz/plugins/htmlsanity/#typography):

> “A sat­is­fied cus­tomer is the best busi­ness strat­e­gy of all”
>
> „An­dere Län­der, an­dere Sit­ten“
>
> « Autres temps, autres mœurs »

Until now, no default language was given to the docutils parser, so it assumed English. This fixes it now.

A workaround that achieves the same by modifying `pelicanconf.py` is below, however I think this should be done by Pelican itself:

```py
DOCUTILS_SETTINGS = {'language_code': DEFAULT_LANG}
```

I was not sure how to test this, as with vanilla Pelican there's nothing in the processed reST output that would depend on this setting.

~~Also, I'm aware that Pelican has the `:lang:` metadata option that allows to change the language per page. That's still broken (i.e., the overriden language is not propagated properly to the node tree), I will look into it and see what can be done.~~ Can't really be done anything about that, I think. The particular code needs to be aware of the `:lang:` metadata on its own.

Thank you in advance for looking into this.