### PR TITLE
Support SSL with pelican.server by adding --ssl , --cert and --key options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tags
 htmlcov
 six-*.egg/
 *.orig
+venv
+samples/output
+*.pem

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -147,3 +147,25 @@ embed videos in the markup. You can use `reST video directive
 <https://gist.github.com/dbrgn/2922648>`_ for reST or `mdx_video plugin
 <https://github.com/italomaia/mdx-video>`_ for Markdown.
 
+
+Develop Locally Using SSL
+==================================
+
+Here's how you can set up your local pelican server to support SSL.
+
+First, create a self-signed certificate and key using ``openssl`` (this creates ``cert.pem`` and ``key.pem``)::
+
+    $ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
+
+And use this command to launch the server (the server starts within your ``output`` directory)::
+
+    python -m pelican.server 8443 --key=../key.pem --cert=../cert.pem
+
+If you are using ``develop-server.sh``,  add this to the top::
+
+    CERT="$BASEDIR/cert.pem"
+    KEY="$BASEDIR/key.pem"
+
+and modify the ``pelican.server`` line as follows::
+
+    $PY -m pelican.server $port --ssl --cert="$CERT" --key="$KEY" &


### PR DESCRIPTION
## Updated 4/1/2018
`pelican.server` now supports `--ssl` , `--cert` and `--key`.  see `tips.rst` for documentation

## Intro
This WIP PR adds SSL support to the local devserver (`make devserver` or `python -m pelican.server`).  SSL is turned on for any port ending in `443` e.g. `8443` .   Set `PORT=8443` in your sites `Makefile`. Otherwise HTTP is used. 

## Motivation
Testing with SSL helps catch SSL-only bugs.  Dev & prod should be as similar as possible.

## Setup & Testing

#### Steps to Enable HTTPS
1. Create self-signed cert & key (see below)
1. add `PORT=8443` to your site's Makefile
1. update `pelicanconf.py` , `SITEURL=https://localhost:8443/` 
1. `make devserver`

#### Generating the self-signed certificates:

```
# openssl will prompt for the "FQHN" -- use the hostname part of your `SITEURL` from `pelicanconf.py`
$ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
$ make html
$ cp *pem output/
$ make devserver
```

## Discussion
Do you like the idea?  If so, I can add a `pelican createcert` command to wrap `openssl`.  Let me know the UX you'd like.


