### PR TITLE
Make pelican-import support pandoc2. Fixes #2255

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -774,7 +774,7 @@ def fields2pelican(
 def is_pandoc2_installed():
     cmd = ['pandoc', '--version']
     try:
-        output = subprocess.check_output(cmd)
+        output = subprocess.check_output(cmd).decode('utf-8')
     except subprocess.CalledProcessError:
         return None
 


### PR DESCRIPTION
This patch allows `pelican-import` to select the correct flags to use based on whether the version of `pandoc` installed is greater than 2.0.

I've only tested with >2.0 on my machine but have tried to ensure that the regex actually works as advertised to support both older Pandoc installs and those that have been upgraded.

This could be simplified if support for Pandoc <2.0 was dropped but I don't have enough info about how frequently various package managers update in order to suggest only supporting a newer major version.