### PR TITLE
Remove hardcoded sorting of articles within categories, tags, authors, feeds

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -21,8 +21,9 @@ from pelican import signals
 from pelican.cache import FileStampDataCacher
 from pelican.contents import Article, Page, Static
 from pelican.readers import Readers
-from pelican.utils import (DateFormatter, copy, mkdir_p, posixize_path,
-                           process_translations, python_2_unicode_compatible)
+from pelican.utils import (DateFormatter, copy, mkdir_p, order_content,
+                           posixize_path, process_translations,
+                           python_2_unicode_compatible)
 
 
 logger = logging.getLogger(__name__)
@@ -300,7 +301,8 @@ class ArticlesGenerator(CachingGenerator):
             all_articles = list(self.articles)
             for article in self.articles:
                 all_articles.extend(article.translations)
-            all_articles.sort(key=attrgetter('date'), reverse=True)
+            order_content(all_articles,
+                          order_by=self.settings['ARTICLE_ORDER_BY'])
 
             if self.settings.get('FEED_ALL_ATOM'):
                 writer.write_feed(all_articles, self.context,
@@ -312,7 +314,6 @@ class ArticlesGenerator(CachingGenerator):
                                   feed_type='rss')
 
         for cat, arts in self.categories:
-            arts.sort(key=attrgetter('date'), reverse=True)
             if self.settings.get('CATEGORY_FEED_ATOM'):
                 writer.write_feed(arts, self.context,
                                   self.settings['CATEGORY_FEED_ATOM']
@@ -325,7 +326,6 @@ class ArticlesGenerator(CachingGenerator):
                                   feed_type='rss')
 
         for auth, arts in self.authors:
-            arts.sort(key=attrgetter('date'), reverse=True)
             if self.settings.get('AUTHOR_FEED_ATOM'):
                 writer.write_feed(arts, self.context,
                                   self.settings['AUTHOR_FEED_ATOM']
@@ -340,7 +340,6 @@ class ArticlesGenerator(CachingGenerator):
         if (self.settings.get('TAG_FEED_ATOM') or
                 self.settings.get('TAG_FEED_RSS')):
             for tag, arts in self.tags.items():
-                arts.sort(key=attrgetter('date'), reverse=True)
                 if self.settings.get('TAG_FEED_ATOM'):
                     writer.write_feed(arts, self.context,
                                       self.settings['TAG_FEED_ATOM']
@@ -358,7 +357,8 @@ class ArticlesGenerator(CachingGenerator):
                 translations_feeds[article.lang].append(article)
 
             for lang, items in translations_feeds.items():
-                items.sort(key=attrgetter('date'), reverse=True)
+                items = order_content(
+                    items, order_by=self.settings['ARTICLE_ORDER_BY'])
                 if self.settings.get('TRANSLATION_FEED_ATOM'):
                     writer.write_feed(
                         items, self.context,
@@ -464,7 +464,6 @@ class ArticlesGenerator(CachingGenerator):
         """Generate Tags pages."""
         tag_template = self.get_template('tag')
         for tag, articles in self.tags.items():
-            articles.sort(key=attrgetter('date'), reverse=True)
             dates = [article for article in self.dates if article in articles]
             write(tag.save_as, tag_template, self.context, tag=tag,
                   url=tag.url, articles=articles, dates=dates,
@@ -475,7 +474,6 @@ class ArticlesGenerator(CachingGenerator):
         """Generate category pages."""
         category_template = self.get_template('category')
         for cat, articles in self.categories:
-            articles.sort(key=attrgetter('date'), reverse=True)
             dates = [article for article in self.dates if article in articles]
             write(cat.save_as, category_template, self.context,
                   url=cat.url, category=cat, articles=articles, dates=dates,
@@ -486,7 +484,6 @@ class ArticlesGenerator(CachingGenerator):
         """Generate Author pages."""
         author_template = self.get_template('author')
         for aut, articles in self.authors:
-            articles.sort(key=attrgetter('date'), reverse=True)
             dates = [article for article in self.dates if article in articles]
             write(aut.save_as, author_template, self.context,
                   url=aut.url, author=aut, articles=articles, dates=dates,
@@ -555,8 +552,9 @@ class ArticlesGenerator(CachingGenerator):
                 all_drafts.append(article)
             self.add_source_path(article)
 
-        self.articles, self.translations = process_translations(
-            all_articles,
+        self.articles, self.translations = process_translations(all_articles)
+        self.articles = order_content(
+            self.articles,
             order_by=self.settings['ARTICLE_ORDER_BY'])
         self.drafts, self.drafts_translations = \
             process_translations(all_drafts)
@@ -652,9 +650,8 @@ class PagesGenerator(CachingGenerator):
                 hidden_pages.append(page)
             self.add_source_path(page)
 
-        self.pages, self.translations = process_translations(
-            all_pages,
-            order_by=self.settings['PAGE_ORDER_BY'])
+        self.pages, self.translations = process_translations(all_pages)
+        self.pages = order_content(self.pages, self.settings['PAGE_ORDER_BY'])
         self.hidden_pages, self.hidden_translations = \
             process_translations(hidden_pages)
 


### PR DESCRIPTION
Currently, `ARTICLE_ORDER_BY` only affects the index page, it gets overwritten for category, tag and author pages and feeds. This should fix that. Passes tests under 2.7, 3.4, 3.5 and 3.6.