### PR TITLE
Control translation identification scope with new translation_id settings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ Next release
   for more finegrained control
 * ``'{base_name}'`` value in ``PAGINATION_PATTERNS`` setting no longer strips
   ``'bar'`` from ``'foo/bar.html'`` (unless ``'bar' == 'index'``).
+* ``ARTICLE_ORDER_BY`` and ``PAGE_ORDER_BY`` now also affect 1) category, tag
+  and author pages 2) feeds 3) draft and hidden articles and pages
+* New ``ARTICLE_TRANSLATION_ID`` and ``PAGE_TRANSLATION_ID`` settings to specify
+  metadata attributes used to identify translations; or to disable translations
 
 3.7.1 (2017-01-10)
 ==================

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -386,8 +386,9 @@ of available translations for that article.
    language. For such advanced functionality the `i18n_subsites
    plugin`_ can be used.
 
-Pelican uses the article's URL "slug" to determine if two or more articles are
-translations of one another. The slug can be set manually in the file's
+By default, Pelican uses the article's URL "slug" to determine if two or more
+articles are translations of one another. (This can be changed with the
+``ARTICLE_TRANSLATION_ID`` setting.) The slug can be set manually in the file's
 metadata; if not set explicitly, Pelican will auto-generate the slug from the
 title of the article.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1038,6 +1038,18 @@ more information.
 
    The default language to use.
 
+.. data:: ARTICLE_TRANSLATION_ID = 'slug'
+
+   The metadata attribute(s) used to identify which articles are translations
+   of one another. May be a string or a collection of strings. Set to ``None``
+   or ``False`` to disable the identification of translations.
+
+.. data:: PAGE_TRANSLATION_ID = 'slug'
+
+   The metadata attribute(s) used to identify which pages are translations
+   of one another. May be a string or a collection of strings. Set to ``None``
+   or ``False`` to disable the identification of translations.
+
 .. data:: TRANSLATION_FEED_ATOM = 'feeds/all-%s.atom.xml'
 
    The location to save the Atom feed for translations. [3]_

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -597,12 +597,14 @@ class ArticlesGenerator(CachingGenerator):
                 all_drafts.append(article)
             self.add_source_path(article)
 
-        self.articles, self.translations = process_translations(all_articles)
-        self.articles = order_content(
-            self.articles,
-            order_by=self.settings['ARTICLE_ORDER_BY'])
-        self.drafts, self.drafts_translations = \
-            process_translations(all_drafts)
+        def _process(arts):
+            origs, translations = process_translations(
+                arts, translation_id=self.settings['ARTICLE_TRANSLATION_ID'])
+            origs = order_content(origs, self.settings['ARTICLE_ORDER_BY'])
+            return origs, translations
+
+        self.articles, self.translations = _process(all_articles)
+        self.drafts, self.drafts_translations = _process(all_drafts)
 
         signals.article_generator_pretaxonomy.send(self)
 
@@ -701,12 +703,15 @@ class PagesGenerator(CachingGenerator):
                 draft_pages.append(page)
             self.add_source_path(page)
 
-        self.pages, self.translations = process_translations(all_pages)
-        self.pages = order_content(self.pages, self.settings['PAGE_ORDER_BY'])
-        self.hidden_pages, self.hidden_translations = \
-            process_translations(hidden_pages)
-        self.draft_pages, self.draft_translations = \
-            process_translations(draft_pages)
+        def _process(pages):
+            origs, translations = process_translations(
+                pages, translation_id=self.settings['PAGE_TRANSLATION_ID'])
+            origs = order_content(origs, self.settings['PAGE_ORDER_BY'])
+            return origs, translations
+
+        self.pages, self.translations = _process(all_pages)
+        self.hidden_pages, self.hidden_translations = _process(hidden_pages)
+        self.draft_pages, self.draft_translations = _process(draft_pages)
 
         self._update_context(('pages', 'hidden_pages', 'draft_pages'))
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -108,6 +108,8 @@ DEFAULT_CONFIG = {
     'DAY_ARCHIVE_SAVE_AS': '',
     'RELATIVE_URLS': False,
     'DEFAULT_LANG': 'en',
+    'ARTICLE_TRANSLATION_ID': 'slug',
+    'PAGE_TRANSLATION_ID': 'slug',
     'DIRECT_TEMPLATES': ['index', 'tags', 'categories', 'authors', 'archives'],
     'THEME_TEMPLATES_OVERRIDES': [],
     'PAGINATED_TEMPLATES': {'index': None, 'tag': None, 'category': None,

--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -17,6 +17,7 @@ from tempfile import mkdtemp
 from six import StringIO
 
 from pelican.contents import Article
+from pelican.readers import default_metadata
 from pelican.settings import DEFAULT_CONFIG
 
 __all__ = ['get_article', 'unittest', ]
@@ -113,9 +114,10 @@ def mute(returns_output=False):
     return decorator
 
 
-def get_article(title, slug, content, lang, extra_metadata=None):
-    metadata = {'slug': slug, 'title': title, 'lang': lang}
-    if extra_metadata is not None:
+def get_article(title, content, **extra_metadata):
+    metadata = default_metadata(settings=DEFAULT_CONFIG)
+    metadata['title'] = title
+    if extra_metadata:
         metadata.update(extra_metadata)
     return Article(content, metadata=metadata)
 


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican/issues/2303, dependent on https://github.com/getpelican/pelican/pull/2292.

Prevents duplicate slug warnings if the articles belong to different categories. A cursory look at the [i18n_subsites plugin](https://github.com/getpelican/pelican-plugins/tree/master/i18n_subsites) suggests it shouldn't be affected by this, but I'd be happy to receive confirmation from someone more knowledgeable.

@avaris 