### PR TITLE
Replaces develop_server.sh with .bat script. Fixes #2308

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -386,22 +386,34 @@ needed by Pelican.
             if isinstance(value, six.string_types) and ' ' in value:
                 value = '"' + value.replace('"', '\\"') + '"'
             conf_shell[key] = value
-        try:
-            with codecs.open(os.path.join(CONF['basedir'],
+        if sys.platform == 'win32':
+            try:
+                with codecs.open(os.path.join(CONF['basedir'],
+                                          'develop_server.bat'),
+                                'w', 'utf-8') as fd:
+                    py_v = 'python'
+                    _template = _jinja_env.get_template('develop_server.bat.jinja2')
+                    fd.write(_template.render(py_v=py_v, **conf_shell))
+                    fd.close()
+            except OSError as e:
+                print('Error: {}'.format(e))
+        else:
+            try:
+                with codecs.open(os.path.join(CONF['basedir'],
                                           'develop_server.sh'),
-                             'w', 'utf-8') as fd:
-                py_v = '${PY:-python}'
-                if six.PY3:
-                    py_v = '${PY:-python3}'
-                _template = _jinja_env.get_template('develop_server.sh.jinja2')
-                fd.write(_template.render(py_v=py_v, **conf_shell))
-                fd.close()
+                                'w', 'utf-8') as fd:
+                    py_v = '${PY:-python}'
+                    if six.PY3:
+                        py_v = '${PY:-python3}'
+                    _template = _jinja_env.get_template('develop_server.sh.jinja2')
+                    fd.write(_template.render(py_v=py_v, **conf_shell))
+                    fd.close()
 
-                # mode 0o755
-                os.chmod((os.path.join(CONF['basedir'],
+                    # mode 0o755
+                    os.chmod((os.path.join(CONF['basedir'],
                                        'develop_server.sh')), 493)
-        except OSError as e:
-            print('Error: {0}'.format(e))
+            except OSError as e:
+                print('Error: {0}'.format(e))
 
     print('Done. Your new project is available at %s' % CONF['basedir'])
 

--- a/pelican/tools/templates/develop_server.bat.jinja2
+++ b/pelican/tools/templates/develop_server.bat.jinja2
@@ -1,0 +1,14 @@
+SETLOCAL
+
+set _PY={{py_v}}
+set _PELICANOPTS={{pelicanopts}}
+
+set _BASEDIR=%cd%
+set _INPUTDIR=%_BASEDIR%/content
+set _OUTPUTDIR=%_BASEDIR%/output
+set _CONFFILE=%_BASEDIR%/pelicanconf.py
+
+start pelican --debug --autoreload -r %_INPUTDIR% -o %_OUTPUTDIR% -s %_CONFFILE% %_PELICANOPTS%
+pushd output
+%_PY% -m pelican.server
+popd


### PR DESCRIPTION
As stated in issue #2308 Windows users have no usage of the develop_server.sh script being created when running pelican-quickstart, this fix should address that.

develop_server.bat will run the pelican server and spawn a new window running the pelican command that deploys the content folder.

This has been tested and verified on Windows 10 running Python 3.6.4 and 2.7.14
Tests has also been done on Debian 8 (jessie) running Python 3.4.2 and 2.7.9 to make sure other functionality was not broken.
