### PR TITLE
Multiple reST headers yields "could not find information about 'date'"

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -203,11 +203,18 @@ class RstReader(BaseReader):
     def __init__(self, *args, **kwargs):
         super(RstReader, self).__init__(*args, **kwargs)
 
-    def _parse_metadata(self, document):
+    def _parse_metadata(self, document, source_path):
         """Return the dict containing document metadata"""
         formatted_fields = self.settings['FORMATTED_FIELDS']
 
         output = {}
+
+        if document.first_child_matching_class(docutils.nodes.title) is None:
+            logger.warning(
+                'Document title missing in file %s: '
+                'Ensure exactly one top level section',
+                source_path)
+
         for docinfo in document.traverse(docutils.nodes.docinfo):
             for element in docinfo.children:
                 if element.tagname == 'field':  # custom fields (e.g. summary)
@@ -257,7 +264,7 @@ class RstReader(BaseReader):
         parts = pub.writer.parts
         content = parts.get('body')
 
-        metadata = self._parse_metadata(pub.document)
+        metadata = self._parse_metadata(pub.document, source_path)
         metadata.setdefault('title', parts.get('title'))
 
         return content, metadata


### PR DESCRIPTION
When defining posts using ReStructuredText, if one specified more than one chapter header, pelican issues the error:

```
ERROR: Skipping meta/pelican-fail.rst: could not find information about 'date'
```

This error message is particularly opaque when trying to diagnose and repair the underlying issue.

For further testing / validation, here is a failing and succeeding test case that issue the above error (or not):

# Fail

```restructuredtext
Title Line
==========

:slug: pelican-fail
:date: 2018-01-01 12:13:14+00:00
:tags: meta
:category: meta

Test file

Section Header
==============

Content
```

# Succeed

```restructuredtext
Title Line
==========

:slug: pelican-succeed
:date: 2018-01-01 12:13:14+00:00
:tags: meta
:category: meta

Test file

Section Header
--------------

Content
```

The notable difference is the character used to underline "Section Header"