### PR TITLE
Allow develop_server.sh to work with paths containing spaces

### DIFF
--- a/pelican/tools/templates/develop_server.sh.jinja2
+++ b/pelican/tools/templates/develop_server.sh.jinja2
@@ -7,16 +7,16 @@ PELICAN=${PELICAN:-pelican}
 PELICANOPTS={{pelicanopts}}
 
 BASEDIR=$(pwd)
-INPUTDIR=$BASEDIR/content
-OUTPUTDIR=$BASEDIR/output
-CONFFILE=$BASEDIR/pelicanconf.py
+INPUTDIR="$BASEDIR"/content
+OUTPUTDIR="$BASEDIR"/output
+CONFFILE="$BASEDIR"/pelicanconf.py
 
 ###
 # Don't change stuff below here unless you are sure
 ###
 
-SRV_PID=$BASEDIR/srv.pid
-PELICAN_PID=$BASEDIR/pelican.pid
+SRV_PID="$BASEDIR"/srv.pid
+PELICAN_PID="$BASEDIR"/pelican.pid
 
 function usage(){
   echo "usage: $0 (stop) (start) (restart) [port]"
@@ -32,7 +32,7 @@ function alive() {
 }
 
 function shut_down(){
-  PID=$(cat $SRV_PID)
+  PID=$(cat "$SRV_PID")
   if [[ $? -eq 0 ]]; then
     if alive $PID; then
       echo "Stopping HTTP server"
@@ -40,12 +40,12 @@ function shut_down(){
     else
       echo "Stale PID, deleting"
     fi
-    rm $SRV_PID
+    rm "$SRV_PID"
   else
     echo "HTTP server PIDFile not found"
   fi
 
-  PID=$(cat $PELICAN_PID)
+  PID=$(cat "$PELICAN_PID")
   if [[ $? -eq 0 ]]; then
     if alive $PID; then
       echo "Killing Pelican"
@@ -53,7 +53,7 @@ function shut_down(){
     else
       echo "Stale PID, deleting"
     fi
-    rm $PELICAN_PID
+    rm "$PELICAN_PID"
   else
     echo "Pelican PIDFile not found"
   fi
@@ -63,14 +63,14 @@ function start_up(){
   local port=$1
   echo "Starting up Pelican and HTTP server"
   shift
-  $PELICAN --debug --autoreload -r $INPUTDIR -o $OUTPUTDIR -s $CONFFILE $PELICANOPTS &
+  $PELICAN --debug --autoreload -r "$INPUT"DIR -o "$OUTPUT"DIR -s "$CONFFILE" $PELICANOPTS &
   pelican_pid=$!
-  echo $pelican_pid > $PELICAN_PID
-  mkdir -p $OUTPUTDIR && cd $OUTPUTDIR
+  echo $pelican_pid > "$PELICAN_PID"
+  mkdir -p "$OUTPUT"DIR && cd "$OUTPUT"DIR
   $PY -m pelican.server $port &
   srv_pid=$!
-  echo $srv_pid > $SRV_PID
-  cd $BASEDIR
+  echo $srv_pid > "$SRV_PID"
+  cd "$BASEDIR"
   sleep 1
   if ! alive $pelican_pid ; then
     echo "Pelican didn't start. Is the Pelican package installed?"

--- a/pelican/tools/templates/develop_server.sh.jinja2
+++ b/pelican/tools/templates/develop_server.sh.jinja2
@@ -63,10 +63,10 @@ function start_up(){
   local port=$1
   echo "Starting up Pelican and HTTP server"
   shift
-  $PELICAN --debug --autoreload -r "$INPUT"DIR -o "$OUTPUT"DIR -s "$CONFFILE" $PELICANOPTS &
+  $PELICAN --debug --autoreload -r "$INPUT"DIR -o "$OUTPUTDIR" -s "$CONFFILE" $PELICANOPTS &
   pelican_pid=$!
   echo $pelican_pid > "$PELICAN_PID"
-  mkdir -p "$OUTPUT"DIR && cd "$OUTPUT"DIR
+  mkdir -p "$OUTPUTDIR" && cd "$OUTPUTDIR"
   $PY -m pelican.server $port &
   srv_pid=$!
   echo $srv_pid > "$SRV_PID"


### PR DESCRIPTION
This avoid to the develop_server.sh script to get confused if the working directory is a sub-folder of a folder containing spaces in its name.

I simply escaped the paths with quotation marks. Successfully tested on my case.

Here are the error messages you may have in such case :
```shell
Starting up Pelican and HTTP server
./develop_server.sh: ligne 68: $PELICAN_PID : ambigious redirection
./develop_server.sh: ligne 69 : cd: too much arguments
./develop_server.sh: ligne 72: $SRV_PID : ambigious redirection
./develop_server.sh: ligne 73 : cd: too much arguments
usage: pelican [-h] [-t THEME] [-o OUTPUT] [-s SETTINGS] [-d] [-v] [-q] [-D]
               [--version] [-r] [--relative-urls] [--cache-path CACHE_PATH]
               [--ignore-cache] [-w SELECTED_PATHS] [--fatal errors|warnings]
               [path]
pelican: error: unrecognized arguments: ending-part/sub-folder/content starting-part/sub-folder/output starting-part/sub-folder/pelicanconf.py
Pelican didn't start. Is the Pelican package installed?
cat: /home/user/starting-part: is a folder
cat: starting-part/sub-folder/srv.pid: No such file or directory
HTTP server PIDFile not found
cat: /home/user/starting-part/ is a folder
cat: starting-part/sub-folder/pelican.pid: No such file or directory
Pelican PIDFile not found
```