### PR TITLE
correct suffix order in ComplexHTTPRequestHandler

### DIFF
--- a/pelican/tests/test_server.py
+++ b/pelican/tests/test_server.py
@@ -1,0 +1,58 @@
+import os
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from six import BytesIO
+
+from pelican.server import ComplexHTTPRequestHandler
+from pelican.tests.support import unittest
+
+
+class MockRequest(object):
+    def makefile(self, *args, **kwargs):
+        return BytesIO(b"")
+
+
+class MockServer(object):
+    pass
+
+
+class TestServer(unittest.TestCase):
+
+    def setUp(self):
+        self.server = MockServer()
+        self.temp_output = mkdtemp(prefix='pelicantests.')
+        self.old_cwd = os.getcwd()
+        os.chdir(self.temp_output)
+
+    def tearDown(self):
+        rmtree(self.temp_output)
+        os.chdir(self.old_cwd)
+
+    def test_get_path_that_exists(self):
+
+        handler = ComplexHTTPRequestHandler(MockRequest(), ('0.0.0.0', 8888),
+                                            self.server)
+        handler.base_path = self.temp_output
+
+        os.mknod(os.path.join(self.temp_output, 'foo.html'))
+        os.mkdir(os.path.join(self.temp_output, 'foo'))
+        os.mknod(os.path.join(self.temp_output, 'foo', 'index.html'))
+
+        os.mkdir(os.path.join(self.temp_output, 'bar'))
+        os.mknod(os.path.join(self.temp_output, 'bar', 'index.html'))
+
+        os.mkdir(os.path.join(self.temp_output, 'baz'))
+
+        for suffix in ['', '/']:
+            path = handler.get_path_that_exists('foo' + suffix)
+            self.assertEqual(path, 'foo.html')
+
+            path = handler.get_path_that_exists('bar' + suffix)
+            self.assertEqual(path, 'bar/index.html')
+
+            path = handler.get_path_that_exists('baz' + suffix)
+            self.assertEqual(path, 'baz/')
+
+            path = handler.get_path_that_exists('quux' + suffix)
+            self.assertIsNone(path)


### PR DESCRIPTION
https://github.com/getpelican/pelican/pull/1040 introduced functionality to the dev server to resolve a `'foo/bar'` get request to `'foo/bar.html'` or `'foo/bar/index.html'`, but it is not working as intended because when  `os.path.exists(path + '/index.html')`, then also `os.path.exists(path + '')`. The reason why it nonetheless seems to resolve to `'foo/bar/index.html'` is because `SimpleHTTPRequestHandler.send_head` goes looking for index files if the path in the get request is a directory.

https://github.com/getpelican/pelican/pull/1441 added functionality to strip a trailing `'/'` before applying the suffixes, but it did this by adding a second for loop, for a total of six combination, whereas one more pass in the original for loop would have been sufficient.

This fixes both these issues.

In fact, it is not strictly necessary to include `'/'` in `SUFFIXES`, but this avoids a permanent redirect from `'foo/bar'` to `'foo/bar/'` by `SimpleHTTPRequestHandler.send_head` which would be permanently stored in the browser cache and is non-trivial to undo.