### PR TITLE
control slug substitutions from settings with regex

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Next release
 
 * New signal: ``feed_generated``
 * Replace Fabric by Invoke and ``fabfile.py`` template by ``tasks.py``.
+* Replace ``SLUG_SUBSTITUTIONS`` (and friends) by ``SLUG_REGEX_SUBSTITUTIONS``
+  for more finegrained control
 
 3.7.1 (2017-01-10)
 ==================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -519,51 +519,12 @@ respectively.
    The URL to use for per-day archives of your posts. Used only if you have the
    ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
 
-.. data:: SLUG_SUBSTITUTIONS = ()
-
-   Substitutions to make prior to stripping out non-alphanumerics when
-   generating slugs. Specified as a list of 3-tuples of ``(from, to, skip)``
-   which are applied in order. ``skip`` is a boolean indicating whether or not
-   to skip replacement of non-alphanumeric characters.  Useful for backward
-   compatibility with existing URLs.
-
-.. data:: AUTHOR_SUBSTITUTIONS = ()
-
-   Substitutions for authors. ``SLUG_SUBSTITUTIONS`` is not taken into account
-   here!
-
-.. data:: CATEGORY_SUBSTITUTIONS = ()
-
-   Added to ``SLUG_SUBSTITUTIONS`` for categories.
-
-.. data:: TAG_SUBSTITUTIONS = ()
-
-   Added to ``SLUG_SUBSTITUTIONS`` for tags.
-
 .. note::
 
     If you do not want one or more of the default pages to be created (e.g.,
     you are the only author on your site and thus do not need an Authors page),
     set the corresponding ``*_SAVE_AS`` setting to ``''`` to prevent the
     relevant page from being generated.
-
-.. note::
-
-    Substitutions are applied in order with the side effect that keeping
-    non-alphanum characters applies to the whole string when a replacement
-    is made.
-
-    For example if you have the following setting::
-
-       SLUG_SUBSTITUTIONS = (('C++', 'cpp'), ('keep dot', 'keep.dot', True))
-
-    the string ``Keep Dot`` will be converted to ``keep.dot``, however
-    ``C++ will keep dot`` will be converted to ``cpp will keep.dot`` instead
-    of ``cpp-will-keep.dot``!
-
-    If you want to keep non-alphanum characters only for tags or categories
-    but not other slugs then configure ``TAG_SUBSTITUTIONS`` and
-    ``CATEGORY_SUBSTITUTIONS`` respectively!
 
 Pelican can optionally create per-year, per-month, and per-day archives of your
 posts. These secondary archives are disabled by default but are automatically
@@ -625,6 +586,33 @@ template.
 URLs for direct template pages are theme-dependent. Some themes use
 corresponding ``*_URL`` setting as string, while others hard-code them:
 ``'archives.html'``, ``'authors.html'``, ``'categories.html'``, ``'tags.html'``.
+
+.. data:: SLUG_REGEX_SUBSTITUTIONS = [
+        (r'[^\w\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars
+        (r'(?u)\A\s*', ''),  # strip leading whitespace
+        (r'(?u)\s*\Z', ''),  # strip trailing whitespace
+        (r'[-\s]+', '-'),  # reduce multiple whitespace or '-' to single '-'
+    ]
+
+   Regex substitutions to make when generating slugs of articles and pages.
+   Specified as a list of pairs of ``(from, to)`` which are applied in order,
+   ignoring case. The default substitutions have the effect of removing
+   non-alphanumeric characters and converting internal whitespace to dashes.
+   Apart from these substitutions, slugs are always converted to lowercase
+   ascii characters and leading and trailing whitespace is stripped. Useful for
+   backward compatibility with existing URLs.
+
+.. data:: AUTHOR_REGEX_SUBSTITUTIONS = SLUG_REGEX_SUBSTITUTIONS
+
+   Regex substitutions for author slugs. Defaults to ``SLUG_REGEX_SUBSTITUTIONS``.
+
+.. data:: CATEGORY_REGEX_SUBSTITUTIONS = SLUG_REGEX_SUBSTITUTIONS
+
+   Regex substitutions for category slugs. Defaults to ``SLUG_REGEX_SUBSTITUTIONS``.
+
+.. data:: TAG_REGEX_SUBSTITUTIONS = SLUG_REGEX_SUBSTITUTIONS
+
+   Regex substitutions for tag slugs. Defaults to ``SLUG_REGEX_SUBSTITUTIONS``.
 
 Time and Date
 =============

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -98,14 +98,16 @@ class Content(object):
         if not hasattr(self, 'slug'):
             if (settings['SLUGIFY_SOURCE'] == 'title' and
                     hasattr(self, 'title')):
-                self.slug = slugify(self.title,
-                                    settings.get('SLUG_SUBSTITUTIONS', ()))
+                self.slug = slugify(
+                    self.title,
+                    regex_subs=settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
             elif (settings['SLUGIFY_SOURCE'] == 'basename' and
                     source_path is not None):
                 basename = os.path.basename(
                     os.path.splitext(source_path)[0])
                 self.slug = slugify(
-                    basename, settings.get('SLUG_SUBSTITUTIONS', ()))
+                    basename,
+                    regex_subs=settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
 
         self.source_path = source_path
 

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -497,7 +497,13 @@ class TestArticle(TestPage):
 
     def test_slugify_category_author(self):
         settings = get_settings()
-        settings['SLUG_SUBSTITUTIONS'] = [('C#', 'csharp')]
+        settings['SLUG_REGEX_SUBSTITUTIONS'] = [
+            (r'C#', 'csharp'),
+            (r'[^\w\s-]', ''),
+            (r'(?u)\A\s*', ''),
+            (r'(?u)\s*\Z', ''),
+            (r'[-\s]+', '-'),
+        ]
         settings['ARTICLE_URL'] = '{author}/{category}/{slug}/'
         settings['ARTICLE_SAVE_AS'] = '{author}/{category}/{slug}/index.html'
         article_kwargs = self._copy_page_kwargs()
@@ -513,9 +519,13 @@ class TestArticle(TestPage):
 
     def test_slugify_with_author_substitutions(self):
         settings = get_settings()
-        settings['AUTHOR_SUBSTITUTIONS'] = [
-                                    ('Alexander Todorov', 'atodorov', False),
-                                    ('Krasimir Tsonev', 'krasimir', False),
+        settings['AUTHOR_REGEX_SUBSTITUTIONS'] = [
+            ('Alexander Todorov', 'atodorov'),
+            ('Krasimir Tsonev', 'krasimir'),
+            (r'[^\w\s-]', ''),
+            (r'(?u)\A\s*', ''),
+            (r'(?u)\s*\Z', ''),
+            (r'[-\s]+', '-'),
         ]
         settings['ARTICLE_URL'] = 'blog/{author}/{slug}/'
         settings['ARTICLE_SAVE_AS'] = 'blog/{author}/{slug}/index.html'
@@ -530,7 +540,9 @@ class TestArticle(TestPage):
 
     def test_slugify_category_with_dots(self):
         settings = get_settings()
-        settings['CATEGORY_SUBSTITUTIONS'] = [('Fedora QA', 'fedora.qa', True)]
+        settings['CATEGORY_REGEX_SUBSTITUTIONS'] = [
+            ('Fedora QA', 'fedora.qa'),
+        ]
         settings['ARTICLE_URL'] = '{category}/{slug}/'
         article_kwargs = self._copy_page_kwargs()
         article_kwargs['metadata']['category'] = Category('Fedora QA',
@@ -542,7 +554,9 @@ class TestArticle(TestPage):
 
     def test_slugify_tags_with_dots(self):
         settings = get_settings()
-        settings['TAG_SUBSTITUTIONS'] = [('Fedora QA', 'fedora.qa', True)]
+        settings['TAG_REGEX_SUBSTITUTIONS'] = [
+            ('Fedora QA', 'fedora.qa'),
+        ]
         settings['ARTICLE_URL'] = '{tag}/{slug}/'
         article_kwargs = self._copy_page_kwargs()
         article_kwargs['metadata']['tag'] = Tag('Fedora QA', settings)

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -6,6 +6,7 @@ import os
 import re
 from codecs import open
 
+from pelican.settings import DEFAULT_CONFIG
 from pelican.tests.support import (mute, skipIfNoExecutable, temporary_folder,
                                    unittest)
 from pelican.tools.pelican_import import (blogger2fields, build_header,
@@ -133,10 +134,11 @@ class TestWordpressXmlImporter(unittest.TestCase):
         with temporary_folder() as temp:
             fnames = list(silent_f2p(test_posts, 'markdown',
                                      temp, dircat=True))
+        subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
         index = 0
         for post in test_posts:
             name = post[2]
-            category = slugify(post[5][0])
+            category = slugify(post[5][0], regex_subs=subs)
             name += '.md'
             filename = os.path.join(category, name)
             out_name = fnames[index]
@@ -208,11 +210,12 @@ class TestWordpressXmlImporter(unittest.TestCase):
         with temporary_folder() as temp:
             fnames = list(silent_f2p(test_posts, 'markdown', temp,
                                      wp_custpost=True, dircat=True))
+        subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
         index = 0
         for post in test_posts:
             name = post[2]
             kind = post[8]
-            category = slugify(post[5][0])
+            category = slugify(post[5][0], regex_subs=subs)
             name += '.md'
             filename = os.path.join(kind, category, name)
             out_name = fnames[index]

--- a/pelican/tests/test_urlwrappers.py
+++ b/pelican/tests/test_urlwrappers.py
@@ -55,30 +55,29 @@ class TestURLWrapper(unittest.TestCase):
         self.assertEqual(author, author_equal)
 
         cat_ascii = Category('指導書', settings={})
-        self.assertEqual(cat_ascii, u'zhi-dao-shu')
+        self.assertEqual(cat_ascii, u'zhi dao shu')
 
     def test_slugify_with_substitutions_and_dots(self):
-        tag = Tag('Tag Dot',
-                  settings={
-                        'TAG_SUBSTITUTIONS': [('Tag Dot', 'tag.dot', True)]
-                    })
+        tag = Tag('Tag Dot', settings={'TAG_REGEX_SUBSTITUTIONS': [
+            ('Tag Dot', 'tag.dot'),
+        ]})
         cat = Category('Category Dot',
-                       settings={
-                        'CATEGORY_SUBSTITUTIONS': (('Category Dot',
-                                                    'cat.dot',
-                                                    True),)
-                        })
+                       settings={'CATEGORY_REGEX_SUBSTITUTIONS': [
+                           ('Category Dot', 'cat.dot'),
+                       ]})
 
         self.assertEqual(tag.slug, 'tag.dot')
         self.assertEqual(cat.slug, 'cat.dot')
 
     def test_author_slug_substitutions(self):
-        settings = {
-            'AUTHOR_SUBSTITUTIONS': [
-                                    ('Alexander Todorov', 'atodorov', False),
-                                    ('Krasimir Tsonev', 'krasimir', False),
-            ]
-        }
+        settings = {'AUTHOR_REGEX_SUBSTITUTIONS': [
+            ('Alexander Todorov', 'atodorov'),
+            ('Krasimir Tsonev', 'krasimir'),
+            (r'[^\w\s-]', ''),
+            (r'(?u)\A\s*', ''),
+            (r'(?u)\s*\Z', ''),
+            (r'[-\s]+', '-'),
+        ]}
 
         author1 = Author('Mr. Senko', settings=settings)
         author2 = Author('Alexander Todorov', settings=settings)

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -119,8 +119,11 @@ class TestUtils(LoggedTestCase):
                    ('大飯原発４号機、１８日夜起動へ',
                     'da-fan-yuan-fa-4hao-ji-18ri-ye-qi-dong-he'),)
 
+        settings = read_settings()
+        subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+
         for value, expected in samples:
-            self.assertEqual(utils.slugify(value), expected)
+            self.assertEqual(utils.slugify(value, regex_subs=subs), expected)
 
     def test_slugify_substitute(self):
 
@@ -129,21 +132,27 @@ class TestUtils(LoggedTestCase):
                    ('c++, c#, C#, C++', 'cpp-c-sharp-c-sharp-cpp'),
                    ('c++-streams', 'cpp-streams'),)
 
-        subs = (('C++', 'CPP'), ('C#', 'C-SHARP'))
+        settings = read_settings()
+        subs = [
+            (r'C\+\+', 'CPP'),
+            (r'C#', 'C-SHARP'),
+        ] + settings['SLUG_REGEX_SUBSTITUTIONS']
         for value, expected in samples:
-            self.assertEqual(utils.slugify(value, subs), expected)
+            self.assertEqual(utils.slugify(value, regex_subs=subs), expected)
 
     def test_slugify_substitute_and_keeping_non_alphanum(self):
 
         samples = (('Fedora QA', 'fedora.qa'),
                    ('C++ is used by Fedora QA', 'cpp is used by fedora.qa'),
-                   ('C++ is based on C', 'cpp-is-based-on-c'),
-                   ('C+++ test C+ test', 'cpp-test-c-test'),)
+                   ('C++ is based on C', 'cpp is based on c'),
+                   ('C+++ test C+ test', 'cpp+ test c+ test'),)
 
-        subs = (('Fedora QA', 'fedora.qa', True),
-                ('c++', 'cpp'),)
+        subs = [
+            (r'Fedora QA', 'fedora.qa'),
+            (r'c\+\+', 'cpp'),
+        ]
         for value, expected in samples:
-            self.assertEqual(utils.slugify(value, subs), expected)
+            self.assertEqual(utils.slugify(value, regex_subs=subs), expected)
 
     def test_get_relative_path(self):
 

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -36,8 +36,9 @@ class URLWrapper(object):
     @property
     def slug(self):
         if self._slug is None:
-            self._slug = slugify(self.name,
-                                 self.settings.get('SLUG_SUBSTITUTIONS', ()))
+            self._slug = slugify(
+                self.name,
+                regex_subs=self.settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
         return self._slug
 
     @slug.setter
@@ -56,8 +57,8 @@ class URLWrapper(object):
         return hash(self.slug)
 
     def _normalize_key(self, key):
-        subs = self.settings.get('SLUG_SUBSTITUTIONS', ())
-        return six.text_type(slugify(key, subs))
+        subs = self.settings.get('SLUG_REGEX_SUBSTITUTIONS', [])
+        return six.text_type(slugify(key, regex_subs=subs))
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -115,10 +116,11 @@ class Category(URLWrapper):
     @property
     def slug(self):
         if self._slug is None:
-            substitutions = self.settings.get('SLUG_SUBSTITUTIONS', ())
-            substitutions += tuple(self.settings.get('CATEGORY_SUBSTITUTIONS',
-                                                     ()))
-            self._slug = slugify(self.name, substitutions)
+            if 'CATEGORY_REGEX_SUBSTITUTIONS' in self.settings:
+                subs = self.settings['CATEGORY_REGEX_SUBSTITUTIONS']
+            else:
+                subs = self.settings.get('SLUG_REGEX_SUBSTITUTIONS', [])
+            self._slug = slugify(self.name, regex_subs=subs)
         return self._slug
 
 
@@ -129,9 +131,11 @@ class Tag(URLWrapper):
     @property
     def slug(self):
         if self._slug is None:
-            substitutions = self.settings.get('SLUG_SUBSTITUTIONS', ())
-            substitutions += tuple(self.settings.get('TAG_SUBSTITUTIONS', ()))
-            self._slug = slugify(self.name, substitutions)
+            if 'TAG_REGEX_SUBSTITUTIONS' in self.settings:
+                subs = self.settings['TAG_REGEX_SUBSTITUTIONS']
+            else:
+                subs = self.settings.get('SLUG_REGEX_SUBSTITUTIONS', [])
+            self._slug = slugify(self.name, regex_subs=subs)
         return self._slug
 
 
@@ -139,6 +143,9 @@ class Author(URLWrapper):
     @property
     def slug(self):
         if self._slug is None:
-            self._slug = slugify(self.name,
-                                 self.settings.get('AUTHOR_SUBSTITUTIONS', ()))
+            if 'AUTHOR_REGEX_SUBSTITUTIONS' in self.settings:
+                subs = self.settings['AUTHOR_REGEX_SUBSTITUTIONS']
+            else:
+                subs = self.settings.get('SLUG_REGEX_SUBSTITUTIONS', [])
+            self._slug = slugify(self.name, regex_subs=subs)
         return self._slug


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican/issues/2316

At present, this is not backwards compatible. I welcome advice on how pelican handles deprecation.