### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,13 @@ if sys.version_info.major < 3:
 setup(
     name='pelican',
     version='3.7.2.dev0',
-    url='http://getpelican.com/',
+    url='https://getpelican.com/',
     author='Alexis Metaireau',
     maintainer='Justin Mayer',
     author_email='authors@getpelican.com',
     description="Static site generator supporting reStructuredText and "
                 "Markdown source content.",
+    license='AGPLv3',
     long_description=description,
     packages=['pelican', 'pelican.tools'],
     package_data={
@@ -64,6 +65,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
- Add license metadata
- Add `Programming Language :: Python :: 3.7` classifier
- Use HTTPS in the website link

## Why did I add the license metadata?

Because if we don't add it some people may think Pelican is proprietary if they read `License: UNKNOWN`, see below:

```
19:11 $ pip3 show pelican
Name: pelican
Version: 3.7.1
Summary: Static site generator supporting reStructuredText and Markdown source content.
Home-page: http://getpelican.com/
Author: Justin Mayer
Author-email: authors@getpelican.com
License: UNKNOWN
```

## But Python 3.7 is not yet released

I know, but the [classifier is available](https://pypi.python.org/pypi?%3Aaction=list_classifiers) and Pelican works with Python 3.7 and it will be supported in the future.