### PR TITLE
Add ARTICLE_RESTRICT_TO_TAGS setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -179,6 +179,12 @@ Basic settings
    A list of directories to exclude when looking for articles in addition to
    ``PAGE_PATHS``.
 
+.. data:: ARTICLE_RESTRICT_TO_TAGS = []
+
+    All articles that do not have all tags in this list will be excluded from
+    the output. This is useful, for example, for generating multiple versions
+    of a site with overlapping content--e.g. a professional and a personal one.
+
 .. data:: OUTPUT_SOURCES = False
 
    Set to True if you want to copy the articles and pages in their original

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -564,6 +564,9 @@ class ArticlesGenerator(CachingGenerator):
     def generate_context(self):
         """Add the articles into the shared context"""
 
+        restrict_all_articles_to_tags = set(
+                self.settings.get("ARTICLES_RESTRICT_TO_TAGS", []))
+
         all_articles = []
         all_drafts = []
         for f in self.get_files(
@@ -591,6 +594,10 @@ class ArticlesGenerator(CachingGenerator):
                     continue
 
                 self.cache_data(f, article)
+
+            if not restrict_all_articles_to_tags <= set(
+                    getattr(article, 'tags', [])):
+                continue
 
             if article.status == "published":
                 all_articles.append(article)


### PR DESCRIPTION
This allows restricting the set of articles considered for publishing with the help of a set of tags.This is useful, for example, for generating multiple versions of a site with overlapping content--e.g. a professional and a personal one.