### PR TITLE
Retain non-alphanumeric characters in slug

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -299,10 +299,8 @@ def slugify(value, substitutions=()):
     for src, dst, skip in substitutions:
         orig_value = value
         value = value.replace(src.lower(), dst.lower())
-        # if replacement was made then skip non-alphanum
-        # replacement if instructed to do so
-        if value != orig_value:
-            replace = replace and not skip
+        # skip non-alphanum replacement if instructed to do so
+        replace = replace and not skip
 
     if replace:
         value = re.sub(r'[^\w\s-]', '', value).strip()


### PR DESCRIPTION
Currently, users are unable to retain non-alphanumeric characters in their URLs unless a substitution specified in their SLUG_SUBSTITUTIONS setting effects a change in their URL. With this change users will be able to use non-alphanumeric characters without having to jump through an extra hoop. This may require a rework (placement into a different setting?) because it will break backwards compatibility for some users who rely on this behavior.