### PR TITLE
Adding support for ctags generation through GENERATE_CTAGS setting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Next release
 ============
 
 * New signal: ``feed_generated``
+* New setting: ``GENERATE_CTAGS`` to generate a "tags" file following the CTags format and containing all articles tags.
 
 3.7.1 (2017-01-10)
 ==================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -328,6 +328,9 @@ Basic settings
    A list of metadata fields containing reST/Markdown content to be parsed and
    translated to HTML.
 
+.. data:: GENERATE_CTAGS = False
+
+    Whether to generate a "tags" file following the CTags format and containing all articles tags.
 
 URL settings
 ============

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -150,6 +150,7 @@ DEFAULT_CONFIG = {
     'LOAD_CONTENT_CACHE': False,
     'WRITE_SELECTED': [],
     'FORMATTED_FIELDS': ['summary'],
+    'GENERATE_CTAGS': False
 }
 
 PYGMENTS_RST_OPTIONS = None

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -573,6 +573,34 @@ class TestArticlesGenerator(unittest.TestCase):
         articles = [article.title for article in generator.articles]
         self.assertEqual(articles, list(reversed(expected)))
 
+    def test_generate_ctags(self):
+        settings = get_settings(filenames={})
+        settings['GENERATE_CTAGS'] = True
+
+        generator = ArticlesGenerator(
+            context=settings.copy(), settings=settings,
+            path=CONTENT_DIR, theme=settings['THEME'], output_path=None)
+        generator.generate_context()
+
+        writer = Writer(None, settings=settings)
+        generator.generate_ctags(writer)
+
+        output_path = os.path.join(CONTENT_DIR, 'tags')
+        self.assertTrue(os.path.exists(output_path))
+
+        try:
+            # output content is correct
+            with open(output_path, 'r') as output_file:
+                ctags = [l.split('\t')[0] for l in output_file.readlines()]
+                self.assertEqual([
+                        'bar', 'bar', 'bar', 'bar', 'bar',
+                        'foo', 'foo', 'foo', 'foo', 'foo',
+                        'foobar', 'foobar', 'foobar', 'foobar', 'foobar',
+                        'マック', 'パイソン'
+                ], ctags)
+        finally:
+            os.remove(output_path)
+
 
 class TestPageGenerator(unittest.TestCase):
     # Note: Every time you want to test for a new field; Make sure the test


### PR DESCRIPTION
The goal is to provide tags autocompletion in all editors that support ctags (e.g. `vim` natively).

Here is an example of simple integration of such tags completion in Notepad++ using the "Python Script" plugin:
```
import os
ctags_filepath = os.path.join(os.path.dirname(notepad.getCurrentFilename()), 'tags')
if os.path.exists(ctags_filepath):
    with open(ctags_filepath) as ctags_file:
        ctags = set(line.split('\t')[0] for line in ctags_file.readlines())
    editor.autoCShow(0, ' '.join(sorted(ctags)))
```

When bound to a shortcut, this will provide autocompletion of existing articles tags.