### PR TITLE
Show article category/tags even if no authors (in the simple theme)

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -39,6 +39,7 @@
           <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
         {% endfor %}
     </address>
+    {% endif %}
     {% if article.category %}
     <div class="category">
         Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
@@ -51,7 +52,6 @@
             <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
         {% endfor %}
     </div>
-    {% endif %}
     {% endif %}
   </footer><!-- /.post-info -->
   <div class="entry-content">


### PR DESCRIPTION
From the commit message:

> Before this commit, the behavior of the simple theme is to hide the category and tags if there is no author defined, even if the category/tags are present. This appears to be unintentional, due to a misplaced `endif`.
>
> Fix this by moving the endif to the right place, so that the other if blocks aren't nested.

I tested this by diffing on the output `samples/content` and found no diffs. (I used the same commands that I used in #2376.)