### PR TITLE
Normalize formatting of sample theme Jinja templates

### DIFF
--- a/pelican/tests/output/basic/a-markdown-powered-article.html
+++ b/pelican/tests/output/basic/a-markdown-powered-article.html
@@ -1,65 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A markdown powered article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li class="active"><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/a-markdown-powered-article.html" rel="bookmark"
-           title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/a-markdown-powered-article.html" rel="bookmark"
+                   title="Permalink to A markdown powered article">A markdown powered article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+00:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+00:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->            <p>You're mutually oblivious.</p>
 <p><a href="/unbelievable.html">a root-relative link to unbelievable</a>
 <a href="/unbelievable.html">a file-relative link to unbelievable</a></p>
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/archives.html
+++ b/pelican/tests/output/basic/archives.html
@@ -1,68 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-<h1>Archives for A Pelican Blog</h1>
+    <h1>Archives for A Pelican Blog</h1>
 
-<dl>
-    <dt>Fri 30 November 2012</dt>
-    <dd><a href="/filename_metadata-example.html">FILENAME_METADATA example</a></dd>
-    <dt>Wed 29 February 2012</dt>
-    <dd><a href="/second-article.html">Second article</a></dd>
-    <dt>Wed 20 April 2011</dt>
-    <dd><a href="/a-markdown-powered-article.html">A markdown powered article</a></dd>
-    <dt>Thu 17 February 2011</dt>
-    <dd><a href="/article-1.html">Article 1</a></dd>
-    <dt>Thu 17 February 2011</dt>
-    <dd><a href="/article-2.html">Article 2</a></dd>
-    <dt>Thu 17 February 2011</dt>
-    <dd><a href="/article-3.html">Article 3</a></dd>
-    <dt>Thu 02 December 2010</dt>
-    <dd><a href="/this-is-a-super-article.html">This is a super article !</a></dd>
-    <dt>Wed 20 October 2010</dt>
-    <dd><a href="/oh-yeah.html">Oh yeah !</a></dd>
-    <dt>Fri 15 October 2010</dt>
-    <dd><a href="/unbelievable.html">Unbelievable !</a></dd>
-    <dt>Sun 14 March 2010</dt>
-    <dd><a href="/tag/baz.html">The baz tag</a></dd>
-</dl>
+    <dl>
+        <dt>Fri 30 November 2012</dt>
+        <dd><a href="/filename_metadata-example.html">FILENAME_METADATA example</a></dd>
+        <dt>Wed 29 February 2012</dt>
+        <dd><a href="/second-article.html">Second article</a></dd>
+        <dt>Wed 20 April 2011</dt>
+        <dd><a href="/a-markdown-powered-article.html">A markdown powered article</a></dd>
+        <dt>Thu 17 February 2011</dt>
+        <dd><a href="/article-1.html">Article 1</a></dd>
+        <dt>Thu 17 February 2011</dt>
+        <dd><a href="/article-2.html">Article 2</a></dd>
+        <dt>Thu 17 February 2011</dt>
+        <dd><a href="/article-3.html">Article 3</a></dd>
+        <dt>Thu 02 December 2010</dt>
+        <dd><a href="/this-is-a-super-article.html">This is a super article !</a></dd>
+        <dt>Wed 20 October 2010</dt>
+        <dd><a href="/oh-yeah.html">Oh yeah !</a></dd>
+        <dt>Fri 15 October 2010</dt>
+        <dd><a href="/unbelievable.html">Unbelievable !</a></dd>
+        <dt>Sun 14 March 2010</dt>
+        <dd><a href="/tag/baz.html">The baz tag</a></dd>
+    </dl>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/article-1.html
+++ b/pelican/tests/output/basic/article-1.html
@@ -1,64 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 1</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li class="active"><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/article-1.html" rel="bookmark"
-           title="Permalink to Article 1">Article 1</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/article-1.html" rel="bookmark"
+                   title="Permalink to Article 1">Article 1</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 1</p>
+</footer><!-- /.post-info -->            <p>Article 1</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/article-2.html
+++ b/pelican/tests/output/basic/article-2.html
@@ -1,64 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 2</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li class="active"><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/article-2.html" rel="bookmark"
-           title="Permalink to Article 2">Article 2</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/article-2.html" rel="bookmark"
+                   title="Permalink to Article 2">Article 2</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 2</p>
+</footer><!-- /.post-info -->            <p>Article 2</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/article-3.html
+++ b/pelican/tests/output/basic/article-3.html
@@ -1,64 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 3</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li class="active"><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/article-3.html" rel="bookmark"
-           title="Permalink to Article 3">Article 3</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/article-3.html" rel="bookmark"
+                   title="Permalink to Article 3">Article 3</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 3</p>
+</footer><!-- /.post-info -->            <p>Article 3</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/author/alexis-metaireau.html
+++ b/pelican/tests/output/basic/author/alexis-metaireau.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - Alexis Métaireau</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -50,59 +54,67 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/oh-yeah.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/oh-yeah.html" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+00:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+00:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/bar.html">bar</a>.</p>
+    <p>In <a href="/category/bar.html">bar</a>.</p>
 <p>tags: <a href="/tag/oh.html">oh</a> <a href="/tag/bar.html">bar</a> <a href="/tag/yeah.html">yeah</a> </p>
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="/oh-yeah.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="/oh-yeah.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/authors.html
+++ b/pelican/tests/output/basic/authors.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - Authors</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 <section id="content" class="body">
@@ -30,21 +32,21 @@
 
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/categories.html
+++ b/pelican/tests/output/basic/categories.html
@@ -1,49 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - Categories</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
-    <h1>Categories on A Pelican Blog</h1>
-    <ul>
-        <li><a href="/category/bar.html">bar</a> (1)</li>
-        <li><a href="/category/cat1.html">cat1</a> (4)</li>
-        <li><a href="/category/misc.html">misc</a> (4)</li>
-        <li><a href="/category/yeah.html">yeah</a> (1)</li>
-    </ul>
+<h1>Categories on A Pelican Blog</h1>
+<ul>
+    <li><a href="/category/bar.html">bar</a> (1)</li>
+    <li><a href="/category/cat1.html">cat1</a> (4)</li>
+    <li><a href="/category/misc.html">misc</a> (4)</li>
+    <li><a href="/category/yeah.html">yeah</a> (1)</li>
+</ul>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/category/bar.html
+++ b/pelican/tests/output/basic/category/bar.html
@@ -1,64 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - bar</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li class="active"><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li class="active"><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/oh-yeah.html">Oh yeah !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/oh-yeah.html">Oh yeah !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+00:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+00:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/bar.html">bar</a>.</p>
+    <p>In <a href="/category/bar.html">bar</a>.</p>
 <p>tags: <a href="/tag/oh.html">oh</a> <a href="/tag/bar.html">bar</a> <a href="/tag/yeah.html">yeah</a> </p>
+
 </footer><!-- /.post-info --><div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
-                </article>
-            </aside><!-- /#featured -->
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/category/cat1.html
+++ b/pelican/tests/output/basic/category/cat1.html
@@ -1,123 +1,137 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - cat1</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li class="active"><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li class="active"><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/a-markdown-powered-article.html">A markdown powered article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/a-markdown-powered-article.html">A markdown powered article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+00:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+00:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
 </footer><!-- /.post-info --><p>You're mutually oblivious.</p>
 <p><a href="/unbelievable.html">a root-relative link to unbelievable</a>
-<a href="/unbelievable.html">a file-relative link to unbelievable</a></p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<a href="/unbelievable.html">a file-relative link to unbelievable</a></p>    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/article-1.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/article-1.html" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="/article-1.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/article-1.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/article-2.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/article-2.html" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="/article-2.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/article-2.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/article-3.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/article-3.html" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="/article-3.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="/article-3.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/category/misc.html
+++ b/pelican/tests/output/basic/category/misc.html
@@ -1,81 +1,89 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - misc</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/filename_metadata-example.html">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/filename_metadata-example.html">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+00:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+00:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/second-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/second-article.html" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+00:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+00:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
-<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="/category/misc.html">misc</a>.</p>
+<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>
+    Translations:
         <a href="/second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="/second-article.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/second-article.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/unbelievable.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/unbelievable.html" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+00:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+00:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="/a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="/a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -87,48 +95,55 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="/unbelievable.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/unbelievable.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+00:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+00:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="/tag/baz.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="/tag/baz.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/category/yeah.html
+++ b/pelican/tests/output/basic/category/yeah.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - yeah</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li class="active"><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li class="active"><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -50,25 +54,26 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-                </article>
-            </aside><!-- /#featured -->
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/drafts/a-draft-article.html
+++ b/pelican/tests/output/basic/drafts/a-draft-article.html
@@ -1,65 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A draft article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/drafts/a-draft-article.html" rel="bookmark"
-           title="Permalink to A draft article">A draft article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/drafts/a-draft-article.html" rel="bookmark"
+                   title="Permalink to A draft article">A draft article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="9999-12-31T23:59:59.999999">
-                Published: 
-        </abbr>
+    <abbr class="published" title="9999-12-31T23:59:59.999999">
+        Published: 
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>This is a draft article, it should live under the /drafts/ folder and not be
+</footer><!-- /.post-info -->            <p>This is a draft article, it should live under the /drafts/ folder and not be
 listed anywhere else.</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/filename_metadata-example.html
+++ b/pelican/tests/output/basic/filename_metadata-example.html
@@ -1,64 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>FILENAME_METADATA example</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/filename_metadata-example.html" rel="bookmark"
-           title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/filename_metadata-example.html" rel="bookmark"
+                   title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+00:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+00:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Some cool stuff!</p>
+</footer><!-- /.post-info -->            <p>Some cool stuff!</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/index.html
+++ b/pelican/tests/output/basic/index.html
@@ -1,218 +1,248 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/filename_metadata-example.html">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/filename_metadata-example.html">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+00:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+00:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/second-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/second-article.html" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+00:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+00:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
-<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="/category/misc.html">misc</a>.</p>
+<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>
+    Translations:
         <a href="/second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="/second-article.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/second-article.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/a-markdown-powered-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/a-markdown-powered-article.html" rel="bookmark"
                            title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+00:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+00:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->                            <p>You're mutually oblivious.</p>
 <p><a href="/unbelievable.html">a root-relative link to unbelievable</a>
 <a href="/unbelievable.html">a file-relative link to unbelievable</a></p>
-                <a class="readmore" href="/a-markdown-powered-article.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/a-markdown-powered-article.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/article-1.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/article-1.html" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="/article-1.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/article-1.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/article-2.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/article-2.html" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="/article-2.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/article-2.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/article-3.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/article-3.html" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+00:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+00:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
-<p>In <a href="/category/cat1.html">cat1</a>.</p>
+    <p>In <a href="/category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="/article-3.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/article-3.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="/this-is-a-super-article.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/this-is-a-super-article.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/oh-yeah.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/oh-yeah.html" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+00:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+00:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/bar.html">bar</a>.</p>
+    <p>In <a href="/category/bar.html">bar</a>.</p>
 <p>tags: <a href="/tag/oh.html">oh</a> <a href="/tag/bar.html">bar</a> <a href="/tag/yeah.html">yeah</a> </p>
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="/oh-yeah.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/oh-yeah.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/unbelievable.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/unbelievable.html" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+00:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+00:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="/a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="/a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -224,48 +254,55 @@ YEAH !</p>
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="/unbelievable.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/unbelievable.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+00:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+00:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="/tag/baz.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="/tag/baz.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/oh-yeah.html
+++ b/pelican/tests/output/basic/oh-yeah.html
@@ -1,72 +1,77 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Oh yeah !</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li class="active"><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li class="active"><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/oh-yeah.html" rel="bookmark"
-           title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/oh-yeah.html" rel="bookmark"
+                   title="Permalink to Oh yeah !">Oh yeah !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+00:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+00:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/bar.html">bar</a>.</p>
+    <p>In <a href="/category/bar.html">bar</a>.</p>
 <p>tags: <a href="/tag/oh.html">oh</a> <a href="/tag/bar.html">bar</a> <a href="/tag/yeah.html">yeah</a> </p>
-</footer><!-- /.post-info -->      <div class="section" id="why-not">
+
+</footer><!-- /.post-info -->            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/override/index.html
+++ b/pelican/tests/output/basic/override/index.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Override url/save_as</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li class="active"><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li class="active"><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">Override url/save_as</h1>
@@ -29,21 +31,21 @@ at a custom location.</p>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/basic/pages/this-is-a-test-hidden-page.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a test hidden page</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">This is a test hidden page</h1>
@@ -29,21 +31,21 @@ Anyone can see this page but it's not linked to anywhere!</p>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/basic/pages/this-is-a-test-page.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a test page</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li class="active"><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li class="active"><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">This is a test page</h1>
@@ -29,21 +31,21 @@
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/second-article-fr.html
+++ b/pelican/tests/output/basic/second-article-fr.html
@@ -1,68 +1,72 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Deuxième article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-      <link rel="alternate" hreflang="en" href="/second-article.html">
+            <link rel="alternate" hreflang="en" href="/second-article.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/second-article-fr.html" rel="bookmark"
-           title="Permalink to Deuxième article">Deuxième article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/second-article-fr.html" rel="bookmark"
+                   title="Permalink to Deuxième article">Deuxième article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+00:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+00:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
-<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="/category/misc.html">misc</a>.</p>
+<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>
+    Translations:
         <a href="/second-article.html" hreflang="en">en</a>
 
-</footer><!-- /.post-info -->      <p>Ceci est un article, en français.</p>
+</footer><!-- /.post-info -->            <p>Ceci est un article, en français.</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/second-article.html
+++ b/pelican/tests/output/basic/second-article.html
@@ -1,68 +1,72 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Second article</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-      <link rel="alternate" hreflang="fr" href="/second-article-fr.html">
+            <link rel="alternate" hreflang="fr" href="/second-article-fr.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/second-article.html" rel="bookmark"
-           title="Permalink to Second article">Second article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/second-article.html" rel="bookmark"
+                   title="Permalink to Second article">Second article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+00:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+00:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
-<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="/category/misc.html">misc</a>.</p>
+<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>
+    Translations:
         <a href="/second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->      <p>This is some article, in english</p>
+</footer><!-- /.post-info -->            <p>This is some article, in english</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tag/bar.html
+++ b/pelican/tests/output/basic/tag/bar.html
@@ -1,120 +1,136 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - bar</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/second-article.html">Second article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/second-article.html">Second article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+00:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+00:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
-<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="/category/misc.html">misc</a>.</p>
+<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>
+    Translations:
         <a href="/second-article-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><p>This is some article, in english</p>
-                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="/this-is-a-super-article.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="/this-is-a-super-article.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/oh-yeah.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/oh-yeah.html" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+00:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+00:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/bar.html">bar</a>.</p>
+    <p>In <a href="/category/bar.html">bar</a>.</p>
 <p>tags: <a href="/tag/oh.html">oh</a> <a href="/tag/bar.html">bar</a> <a href="/tag/yeah.html">yeah</a> </p>
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="/oh-yeah.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="/oh-yeah.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tag/baz.html
+++ b/pelican/tests/output/basic/tag/baz.html
@@ -1,64 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>The baz tag</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/tag/baz.html" rel="bookmark"
-           title="Permalink to The baz tag">The baz tag</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/tag/baz.html" rel="bookmark"
+                   title="Permalink to The baz tag">The baz tag</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+00:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+00:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tag/foo.html
+++ b/pelican/tests/output/basic/tag/foo.html
@@ -1,92 +1,103 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - foo</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/second-article.html">Second article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/second-article.html">Second article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+00:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+00:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
-<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="/category/misc.html">misc</a>.</p>
+<p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/baz.html">baz</a> </p>
+    Translations:
         <a href="/second-article-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><p>This is some article, in english</p>
-                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="/this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="/this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="/this-is-a-super-article.html">read more</a>
-                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="/this-is-a-super-article.html">read more</a>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tag/foobar.html
+++ b/pelican/tests/output/basic/tag/foobar.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - foobar</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/this-is-a-super-article.html">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -50,25 +54,26 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-                </article>
-            </aside><!-- /#featured -->
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tag/oh.html
+++ b/pelican/tests/output/basic/tag/oh.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Oh Oh Oh</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li class="active"><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li class="active"><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">Oh Oh Oh</h1>
@@ -28,21 +30,21 @@
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tag/yeah.html
+++ b/pelican/tests/output/basic/tag/yeah.html
@@ -1,64 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - yeah</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="/oh-yeah.html">Oh yeah !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="/oh-yeah.html">Oh yeah !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+00:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+00:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/bar.html">bar</a>.</p>
+    <p>In <a href="/category/bar.html">bar</a>.</p>
 <p>tags: <a href="/tag/oh.html">oh</a> <a href="/tag/bar.html">bar</a> <a href="/tag/yeah.html">yeah</a> </p>
+
 </footer><!-- /.post-info --><div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="/pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
-                </article>
-            </aside><!-- /#featured -->
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/tags.html
+++ b/pelican/tests/output/basic/tags.html
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A Pelican Blog - Tags</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 <section id="content" class="body">
@@ -35,21 +37,21 @@
 
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/this-is-a-super-article.html
+++ b/pelican/tests/output/basic/this-is-a-super-article.html
@@ -1,49 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a super article !</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li><a href="/category/misc.html">misc</a></li>
-                    <li class="active"><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li><a href="/category/misc.html">misc</a></li>
+                            <li class="active"><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/this-is-a-super-article.html" rel="bookmark"
-           title="Permalink to This is a super article !">This is a super article !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/this-is-a-super-article.html" rel="bookmark"
+                   title="Permalink to This is a super article !">This is a super article !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+00:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+00:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+00:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+00:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="/author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="/category/yeah.html">yeah</a>.</p>
+    <p>In <a href="/category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="/tag/foo.html">foo</a> <a href="/tag/bar.html">bar</a> <a href="/tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->      <p>Some content here !</p>
+
+</footer><!-- /.post-info -->            <p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
 <p>And here comes the cool <a class="reference external" href="http://books.couchdb.org/relax/design-documents/views">stuff</a>.</p>
@@ -56,27 +61,27 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/basic/unbelievable.html
+++ b/pelican/tests/output/basic/unbelievable.html
@@ -1,42 +1,45 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Unbelievable !</title>
         <link rel="stylesheet" href="/theme/css/main.css" />
         <link href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="A Pelican Blog Atom Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="/">A Pelican Blog </a></h1>
-                <nav><ul>
-                    <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="/override/">Override url/save_as</a></li>
-                    <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="/category/bar.html">bar</a></li>
-                    <li><a href="/category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="/category/misc.html">misc</a></li>
-                    <li><a href="/category/yeah.html">yeah</a></li>
-                </ul></nav>
+            <h1><a href="/">A Pelican Blog </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="/tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="/override/">Override url/save_as</a></li>
+                            <li><a href="/pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="/category/bar.html">bar</a></li>
+                            <li><a href="/category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="/category/misc.html">misc</a></li>
+                            <li><a href="/category/yeah.html">yeah</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="/unbelievable.html" rel="bookmark"
-           title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="/unbelievable.html" rel="bookmark"
+                   title="Permalink to Unbelievable !">Unbelievable !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+00:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+00:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
-<p>In <a href="/category/misc.html">misc</a>.</p>
+    <p>In <a href="/category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="/a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="/a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -70,27 +73,27 @@ pelican.conf, it will have nothing in default.</p>
 <p>Lovely.</p>
 </div>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
 
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/a-markdown-powered-article.html
+++ b/pelican/tests/output/custom/a-markdown-powered-article.html
@@ -1,101 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A markdown powered article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li class="active"><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./a-markdown-powered-article.html" rel="bookmark"
-           title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./a-markdown-powered-article.html" rel="bookmark"
+                   title="Permalink to A markdown powered article">A markdown powered article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->            <p>You're mutually oblivious.</p>
 <p><a href="./unbelievable.html">a root-relative link to unbelievable</a>
 <a href="./unbelievable.html">a file-relative link to unbelievable</a></p>
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'a-markdown-powered-article.html';
-        var disqus_url = './a-markdown-powered-article.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'a-markdown-powered-article.html';
+                var disqus_url = './a-markdown-powered-article.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -107,5 +111,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/archives.html
+++ b/pelican/tests/output/custom/archives.html
@@ -1,86 +1,88 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-<h1>Archives for Alexis' log</h1>
+    <h1>Archives for Alexis' log</h1>
 
-<dl>
-    <dt>Fri 30 November 2012</dt>
-    <dd><a href="./filename_metadata-example.html">FILENAME_METADATA example</a></dd>
-    <dt>Wed 29 February 2012</dt>
-    <dd><a href="./second-article.html">Second article</a></dd>
-    <dt>Wed 20 April 2011</dt>
-    <dd><a href="./a-markdown-powered-article.html">A markdown powered article</a></dd>
-    <dt>Thu 17 February 2011</dt>
-    <dd><a href="./article-1.html">Article 1</a></dd>
-    <dt>Thu 17 February 2011</dt>
-    <dd><a href="./article-2.html">Article 2</a></dd>
-    <dt>Thu 17 February 2011</dt>
-    <dd><a href="./article-3.html">Article 3</a></dd>
-    <dt>Thu 02 December 2010</dt>
-    <dd><a href="./this-is-a-super-article.html">This is a super article !</a></dd>
-    <dt>Wed 20 October 2010</dt>
-    <dd><a href="./oh-yeah.html">Oh yeah !</a></dd>
-    <dt>Fri 15 October 2010</dt>
-    <dd><a href="./unbelievable.html">Unbelievable !</a></dd>
-    <dt>Sun 14 March 2010</dt>
-    <dd><a href="./tag/baz.html">The baz tag</a></dd>
-</dl>
+    <dl>
+        <dt>Fri 30 November 2012</dt>
+        <dd><a href="./filename_metadata-example.html">FILENAME_METADATA example</a></dd>
+        <dt>Wed 29 February 2012</dt>
+        <dd><a href="./second-article.html">Second article</a></dd>
+        <dt>Wed 20 April 2011</dt>
+        <dd><a href="./a-markdown-powered-article.html">A markdown powered article</a></dd>
+        <dt>Thu 17 February 2011</dt>
+        <dd><a href="./article-1.html">Article 1</a></dd>
+        <dt>Thu 17 February 2011</dt>
+        <dd><a href="./article-2.html">Article 2</a></dd>
+        <dt>Thu 17 February 2011</dt>
+        <dd><a href="./article-3.html">Article 3</a></dd>
+        <dt>Thu 02 December 2010</dt>
+        <dd><a href="./this-is-a-super-article.html">This is a super article !</a></dd>
+        <dt>Wed 20 October 2010</dt>
+        <dd><a href="./oh-yeah.html">Oh yeah !</a></dd>
+        <dt>Fri 15 October 2010</dt>
+        <dd><a href="./unbelievable.html">Unbelievable !</a></dd>
+        <dt>Sun 14 March 2010</dt>
+        <dd><a href="./tag/baz.html">The baz tag</a></dd>
+    </dl>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -92,5 +94,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/article-1.html
+++ b/pelican/tests/output/custom/article-1.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 1</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li class="active"><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./article-1.html" rel="bookmark"
-           title="Permalink to Article 1">Article 1</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./article-1.html" rel="bookmark"
+                   title="Permalink to Article 1">Article 1</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 1</p>
+</footer><!-- /.post-info -->            <p>Article 1</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'article-1.html';
-        var disqus_url = './article-1.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'article-1.html';
+                var disqus_url = './article-1.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/article-2.html
+++ b/pelican/tests/output/custom/article-2.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 2</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li class="active"><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./article-2.html" rel="bookmark"
-           title="Permalink to Article 2">Article 2</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./article-2.html" rel="bookmark"
+                   title="Permalink to Article 2">Article 2</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 2</p>
+</footer><!-- /.post-info -->            <p>Article 2</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'article-2.html';
-        var disqus_url = './article-2.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'article-2.html';
+                var disqus_url = './article-2.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/article-3.html
+++ b/pelican/tests/output/custom/article-3.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 3</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li class="active"><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li class="active"><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./article-3.html" rel="bookmark"
-           title="Permalink to Article 3">Article 3</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./article-3.html" rel="bookmark"
+                   title="Permalink to Article 3">Article 3</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 3</p>
+</footer><!-- /.post-info -->            <p>Article 3</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'article-3.html';
-        var disqus_url = './article-3.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'article-3.html';
+                var disqus_url = './article-3.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau.html
@@ -1,159 +1,182 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../filename_metadata-example.html">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../filename_metadata-example.html">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-<p>There are <a href="../filename_metadata-example.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../filename_metadata-example.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../second-article.html" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="../second-article.html">read more</a>
-<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../second-article.html">read more</a>
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../a-markdown-powered-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../a-markdown-powered-article.html" rel="bookmark"
                            title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->                            <p>You're mutually oblivious.</p>
 <p><a href="../unbelievable.html">a root-relative link to unbelievable</a>
 <a href="../unbelievable.html">a file-relative link to unbelievable</a></p>
-                <a class="readmore" href="../a-markdown-powered-article.html">read more</a>
-<p>There are <a href="../a-markdown-powered-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../a-markdown-powered-article.html">read more</a>
+<p>There are <a href="../a-markdown-powered-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-1.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../article-1.html" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="../article-1.html">read more</a>
-<p>There are <a href="../article-1.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="../article-1.html">read more</a>
+<p>There are <a href="../article-1.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
     Page 1 / 3
         <a href="../author/alexis-metaireau2.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -165,5 +188,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau2.html
@@ -1,173 +1,199 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-2.html" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../article-2.html" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="../article-2.html">read more</a>
-<p>There are <a href="../article-2.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../article-2.html">read more</a>
+<p>There are <a href="../article-2.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-3.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../article-3.html" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="../article-3.html">read more</a>
-<p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../article-3.html">read more</a>
+<p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="../this-is-a-super-article.html">read more</a>
-<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../this-is-a-super-article.html">read more</a>
+<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../oh-yeah.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../oh-yeah.html" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="../oh-yeah.html">read more</a>
-<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="../oh-yeah.html">read more</a>
+<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="../author/alexis-metaireau.html">&laquo;</a>
     Page 2 / 3
         <a href="../author/alexis-metaireau3.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -179,5 +205,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -1,50 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../unbelievable.html" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../unbelievable.html" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="../a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="../a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -56,69 +60,79 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="../unbelievable.html">read more</a>
-<p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../unbelievable.html">read more</a>
+<p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="../tag/baz.html">read more</a>
-<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="../tag/baz.html">read more</a>
+<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="../author/alexis-metaireau2.html">&laquo;</a>
     Page 3 / 3
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -130,5 +144,5 @@ pelican.conf, it will …</p></div>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/authors.html
+++ b/pelican/tests/output/custom/authors.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Authors</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 <section id="content" class="body">
@@ -33,36 +35,36 @@
 </section>
 
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -74,5 +76,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/categories.html
+++ b/pelican/tests/output/custom/categories.html
@@ -1,67 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Categories</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
-    <h1>Categories on Alexis' log</h1>
-    <ul>
-        <li><a href="./category/bar.html">bar</a> (1)</li>
-        <li><a href="./category/cat1.html">cat1</a> (4)</li>
-        <li><a href="./category/misc.html">misc</a> (4)</li>
-        <li><a href="./category/yeah.html">yeah</a> (1)</li>
-    </ul>
+<h1>Categories on Alexis' log</h1>
+<ul>
+    <li><a href="./category/bar.html">bar</a> (1)</li>
+    <li><a href="./category/cat1.html">cat1</a> (4)</li>
+    <li><a href="./category/misc.html">misc</a> (4)</li>
+    <li><a href="./category/yeah.html">yeah</a> (1)</li>
+</ul>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/category/bar.html
+++ b/pelican/tests/output/custom/category/bar.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../oh-yeah.html">Oh yeah !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../oh-yeah.html">Oh yeah !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><div class="section" id="why-not">
@@ -46,39 +50,41 @@
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
-<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -90,5 +96,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/category/cat1.html
+++ b/pelican/tests/output/custom/category/cat1.html
@@ -1,153 +1,175 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - cat1</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li class="active"><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li class="active"><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../a-markdown-powered-article.html">A markdown powered article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../a-markdown-powered-article.html">A markdown powered article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
 </footer><!-- /.post-info --><p>You're mutually oblivious.</p>
 <p><a href="../unbelievable.html">a root-relative link to unbelievable</a>
-<a href="../unbelievable.html">a file-relative link to unbelievable</a></p><p>There are <a href="../a-markdown-powered-article.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<a href="../unbelievable.html">a file-relative link to unbelievable</a></p><p>There are <a href="../a-markdown-powered-article.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-1.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../article-1.html" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="../article-1.html">read more</a>
-<p>There are <a href="../article-1.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../article-1.html">read more</a>
+<p>There are <a href="../article-1.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-2.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../article-2.html" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="../article-2.html">read more</a>
-<p>There are <a href="../article-2.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../article-2.html">read more</a>
+<p>There are <a href="../article-2.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../article-3.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../article-3.html" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="../article-3.html">read more</a>
-<p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../article-3.html">read more</a>
+<p>There are <a href="../article-3.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -159,5 +181,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -1,94 +1,107 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - misc</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../filename_metadata-example.html">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../filename_metadata-example.html">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-<p>There are <a href="../filename_metadata-example.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../filename_metadata-example.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../second-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../second-article.html" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="../second-article.html">read more</a>
-<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../second-article.html">read more</a>
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../unbelievable.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../unbelievable.html" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="../a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="../a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -100,65 +113,75 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="../unbelievable.html">read more</a>
-<p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../unbelievable.html">read more</a>
+<p>There are <a href="../unbelievable.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="../tag/baz.html">read more</a>
-<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../tag/baz.html">read more</a>
+<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -170,5 +193,5 @@ pelican.conf, it will …</p></div>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/category/yeah.html
+++ b/pelican/tests/output/custom/category/yeah.html
@@ -1,47 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li class="active"><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li class="active"><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../this-is-a-super-article.html">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../this-is-a-super-article.html">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -54,39 +58,41 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -98,5 +104,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom/drafts/a-draft-article.html
@@ -1,86 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A draft article</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../drafts/a-draft-article.html" rel="bookmark"
-           title="Permalink to A draft article">A draft article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../drafts/a-draft-article.html" rel="bookmark"
+                   title="Permalink to A draft article">A draft article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-03-02T14:01:01+01:00">
-                Published: Fri 02 March 2012
-        </abbr>
+    <abbr class="published" title="2012-03-02T14:01:01+01:00">
+        Published: Fri 02 March 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>This is a draft article, it should live under the /drafts/ folder and not be
+</footer><!-- /.post-info -->            <p>This is a draft article, it should live under the /drafts/ folder and not be
 listed anywhere else.</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -92,5 +96,5 @@ listed anywhere else.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/filename_metadata-example.html
+++ b/pelican/tests/output/custom/filename_metadata-example.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>FILENAME_METADATA example</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./filename_metadata-example.html" rel="bookmark"
-           title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./filename_metadata-example.html" rel="bookmark"
+                   title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Some cool stuff!</p>
+</footer><!-- /.post-info -->            <p>Some cool stuff!</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'filename_metadata-example.html';
-        var disqus_url = './filename_metadata-example.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'filename_metadata-example.html';
+                var disqus_url = './filename_metadata-example.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/index.html
+++ b/pelican/tests/output/custom/index.html
@@ -1,159 +1,182 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="./filename_metadata-example.html">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="./filename_metadata-example.html">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: Fri 30 November 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: Fri 30 November 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-<p>There are <a href="./filename_metadata-example.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="./filename_metadata-example.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./second-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./second-article.html" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>
+    Translations:
         <a href="./second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="./second-article.html">read more</a>
-<p>There are <a href="./second-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./second-article.html">read more</a>
+<p>There are <a href="./second-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./a-markdown-powered-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./a-markdown-powered-article.html" rel="bookmark"
                            title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: Wed 20 April 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: Wed 20 April 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->                            <p>You're mutually oblivious.</p>
 <p><a href="./unbelievable.html">a root-relative link to unbelievable</a>
 <a href="./unbelievable.html">a file-relative link to unbelievable</a></p>
-                <a class="readmore" href="./a-markdown-powered-article.html">read more</a>
-<p>There are <a href="./a-markdown-powered-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./a-markdown-powered-article.html">read more</a>
+<p>There are <a href="./a-markdown-powered-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./article-1.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./article-1.html" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="./article-1.html">read more</a>
-<p>There are <a href="./article-1.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="./article-1.html">read more</a>
+<p>There are <a href="./article-1.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
     Page 1 / 3
         <a href="./index2.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -165,5 +188,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/index2.html
+++ b/pelican/tests/output/custom/index2.html
@@ -1,173 +1,199 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./article-2.html" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./article-2.html" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="./article-2.html">read more</a>
-<p>There are <a href="./article-2.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./article-2.html">read more</a>
+<p>There are <a href="./article-2.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./article-3.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./article-3.html" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: Thu 17 February 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: Thu 17 February 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="./article-3.html">read more</a>
-<p>There are <a href="./article-3.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./article-3.html">read more</a>
+<p>There are <a href="./article-3.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/yeah.html">yeah</a>.</p>
+    <p>In <a href="./category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="./this-is-a-super-article.html">read more</a>
-<p>There are <a href="./this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./this-is-a-super-article.html">read more</a>
+<p>There are <a href="./this-is-a-super-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./oh-yeah.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./oh-yeah.html" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/bar.html">bar</a>.</p>
-<p>tags: <a href="./tag/oh.html">oh</a> <a href="./tag/bar.html">bar</a> <a href="./tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="./category/bar.html">bar</a>.</p>
+<p>tags: <a href="./tag/oh.html">oh</a> <a href="./tag/bar.html">bar</a> <a href="./tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="./oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="./pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="./oh-yeah.html">read more</a>
-<p>There are <a href="./oh-yeah.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="./oh-yeah.html">read more</a>
+<p>There are <a href="./oh-yeah.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="./index.html">&laquo;</a>
     Page 2 / 3
         <a href="./index3.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -179,5 +205,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -1,50 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./unbelievable.html" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./unbelievable.html" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="./a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="./a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -56,69 +60,79 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="./unbelievable.html">read more</a>
-<p>There are <a href="./unbelievable.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./unbelievable.html">read more</a>
+<p>There are <a href="./unbelievable.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="./tag/baz.html">read more</a>
-<p>There are <a href="./tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="./tag/baz.html">read more</a>
+<p>There are <a href="./tag/baz.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="./index2.html">&laquo;</a>
     Page 3 / 3
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -130,5 +144,5 @@ pelican.conf, it will …</p></div>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/jinja2_template.html
+++ b/pelican/tests/output/custom/jinja2_template.html
@@ -1,63 +1,65 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 Some text
 
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -69,5 +71,5 @@ Some text
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/oh-yeah-fr.html
+++ b/pelican/tests/output/custom/oh-yeah-fr.html
@@ -1,104 +1,108 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Trop bien !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="en" href="./oh-yeah.html">
+            <link rel="alternate" hreflang="en" href="./oh-yeah.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./oh-yeah-fr.html" rel="bookmark"
-           title="Permalink to Trop bien !">Trop bien !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./oh-yeah-fr.html" rel="bookmark"
+                   title="Permalink to Trop bien !">Trop bien !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-03-02T14:01:01+01:00">
-                Published: Fri 02 March 2012
-        </abbr>
+    <abbr class="published" title="2012-03-02T14:01:01+01:00">
+        Published: Fri 02 March 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+    Translations:
         <a href="./oh-yeah.html" hreflang="en">en</a>
 
-</footer><!-- /.post-info -->      <p>Et voila du contenu en français</p>
+</footer><!-- /.post-info -->            <p>Et voila du contenu en français</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'oh-yeah-fr.html';
-        var disqus_url = './oh-yeah-fr.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'oh-yeah-fr.html';
+                var disqus_url = './oh-yeah-fr.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -110,5 +114,5 @@ Translations:
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/oh-yeah.html
+++ b/pelican/tests/output/custom/oh-yeah.html
@@ -1,109 +1,114 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Oh yeah !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="fr" href="./oh-yeah-fr.html">
+            <link rel="alternate" hreflang="fr" href="./oh-yeah-fr.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./oh-yeah.html" rel="bookmark"
-           title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./oh-yeah.html" rel="bookmark"
+                   title="Permalink to Oh yeah !">Oh yeah !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/bar.html">bar</a>.</p>
-<p>tags: <a href="./tag/oh.html">oh</a> <a href="./tag/bar.html">bar</a> <a href="./tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="./category/bar.html">bar</a>.</p>
+<p>tags: <a href="./tag/oh.html">oh</a> <a href="./tag/bar.html">bar</a> <a href="./tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="./oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->      <div class="section" id="why-not">
+</footer><!-- /.post-info -->            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="./pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'oh-yeah.html';
-        var disqus_url = './oh-yeah.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'oh-yeah.html';
+                var disqus_url = './oh-yeah.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -115,5 +120,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/override/index.html
+++ b/pelican/tests/output/custom/override/index.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Override url/save_as</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li class="active"><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li class="active"><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">Override url/save_as</h1>
@@ -32,36 +34,36 @@ at a custom location.</p>
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@ at a custom location.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a test hidden page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">This is a test hidden page</h1>
@@ -32,36 +34,36 @@ Anyone can see this page but it's not linked to anywhere!</p>
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@ Anyone can see this page but it's not linked to anywhere!</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-page.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a test page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li class="active"><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li class="active"><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">This is a test page</h1>
@@ -32,36 +34,36 @@
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/second-article-fr.html
+++ b/pelican/tests/output/custom/second-article-fr.html
@@ -1,104 +1,109 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Deuxième article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="en" href="./second-article.html">
+            <link rel="alternate" hreflang="en" href="./second-article.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./second-article-fr.html" rel="bookmark"
-           title="Permalink to Deuxième article">Deuxième article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./second-article-fr.html" rel="bookmark"
+                   title="Permalink to Deuxième article">Deuxième article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>
+    Translations:
         <a href="./second-article.html" hreflang="en">en</a>
 
-</footer><!-- /.post-info -->      <p>Ceci est un article, en français.</p>
+</footer><!-- /.post-info -->            <p>Ceci est un article, en français.</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'second-article-fr.html';
-        var disqus_url = './second-article-fr.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'second-article-fr.html';
+                var disqus_url = './second-article-fr.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -110,5 +115,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/second-article.html
+++ b/pelican/tests/output/custom/second-article.html
@@ -1,104 +1,109 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Second article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="fr" href="./second-article-fr.html">
+            <link rel="alternate" hreflang="fr" href="./second-article-fr.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./second-article.html" rel="bookmark"
-           title="Permalink to Second article">Second article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./second-article.html" rel="bookmark"
+                   title="Permalink to Second article">Second article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>
+    Translations:
         <a href="./second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->      <p>This is some article, in english</p>
+</footer><!-- /.post-info -->            <p>This is some article, in english</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'second-article.html';
-        var disqus_url = './second-article.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'second-article.html';
+                var disqus_url = './second-article.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -110,5 +115,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -1,143 +1,163 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><p>This is some article, in english</p>
-<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="../this-is-a-super-article.html">read more</a>
-<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../this-is-a-super-article.html">read more</a>
+<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../oh-yeah.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../oh-yeah.html" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="../oh-yeah.html">read more</a>
-<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../oh-yeah.html">read more</a>
+<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -149,5 +169,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tag/baz.html
+++ b/pelican/tests/output/custom/tag/baz.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>The baz tag</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../tag/baz.html" rel="bookmark"
-           title="Permalink to The baz tag">The baz tag</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../tag/baz.html" rel="bookmark"
+                   title="Permalink to The baz tag">The baz tag</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: Sun 14 March 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: Sun 14 March 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'tag/baz.html';
-        var disqus_url = '../tag/baz.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'tag/baz.html';
+                var disqus_url = '../tag/baz.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -1,113 +1,127 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - foo</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../second-article.html">Second article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: Wed 29 February 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: Wed 29 February 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><p>This is some article, in english</p>
-<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../second-article.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../this-is-a-super-article.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../this-is-a-super-article.html" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="../this-is-a-super-article.html">read more</a>
-<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../this-is-a-super-article.html">read more</a>
+<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -119,5 +133,5 @@ as well as <strong>inline markup</strong>.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tag/foobar.html
+++ b/pelican/tests/output/custom/tag/foobar.html
@@ -1,47 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - foobar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../this-is-a-super-article.html">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../this-is-a-super-article.html">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -54,39 +58,41 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../this-is-a-super-article.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -98,5 +104,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tag/oh.html
+++ b/pelican/tests/output/custom/tag/oh.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Oh Oh Oh</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li class="active"><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li class="active"><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">Oh Oh Oh</h1>
@@ -31,36 +33,36 @@
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -72,5 +74,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tag/yeah.html
+++ b/pelican/tests/output/custom/tag/yeah.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../oh-yeah.html">Oh yeah !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../oh-yeah.html">Oh yeah !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: Wed 20 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: Wed 20 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><div class="section" id="why-not">
@@ -46,39 +50,41 @@
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
-<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../oh-yeah.html#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -90,5 +96,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/tags.html
+++ b/pelican/tests/output/custom/tags.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Tags</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 <section id="content" class="body">
@@ -38,36 +40,36 @@
 </section>
 
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -79,5 +81,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/this-is-a-super-article.html
+++ b/pelican/tests/output/custom/this-is-a-super-article.html
@@ -1,53 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a super article !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li class="active"><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li class="active"><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./this-is-a-super-article.html" rel="bookmark"
-           title="Permalink to This is a super article !">This is a super article !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./this-is-a-super-article.html" rel="bookmark"
+                   title="Permalink to This is a super article !">This is a super article !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: Thu 02 December 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: Sun 17 November 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: Thu 02 December 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: Sun 17 November 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/yeah.html">yeah</a>.</p>
+    <p>In <a href="./category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->      <p>Some content here !</p>
+
+</footer><!-- /.post-info -->            <p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
 <p>And here comes the cool <a class="reference external" href="http://books.couchdb.org/relax/design-documents/views">stuff</a>.</p>
@@ -60,56 +65,56 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'this-is-a-super-article.html';
-        var disqus_url = './this-is-a-super-article.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'this-is-a-super-article.html';
+                var disqus_url = './this-is-a-super-article.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -121,5 +126,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom/unbelievable.html
+++ b/pelican/tests/output/custom/unbelievable.html
@@ -1,49 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Unbelievable !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./unbelievable.html" rel="bookmark"
-           title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./unbelievable.html" rel="bookmark"
+                   title="Permalink to Unbelievable !">Unbelievable !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: Fri 15 October 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: Fri 15 October 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="./a-markdown-powered-article.html">a root-relative link to markdown-article</a>
 <a class="reference external" href="./a-markdown-powered-article.html">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -77,56 +81,56 @@ pelican.conf, it will have nothing in default.</p>
 <p>Lovely.</p>
 </div>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'unbelievable.html';
-        var disqus_url = './unbelievable.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'unbelievable.html';
+                var disqus_url = './unbelievable.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -138,5 +142,5 @@ pelican.conf, it will have nothing in default.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/archives.html
+++ b/pelican/tests/output/custom_locale/archives.html
@@ -1,86 +1,88 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-<h1>Archives for Alexis' log</h1>
+    <h1>Archives for Alexis' log</h1>
 
-<dl>
-    <dt>30 novembre 2012</dt>
-    <dd><a href="./posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></dd>
-    <dt>29 février 2012</dt>
-    <dd><a href="./posts/2012/février/29/second-article/">Second article</a></dd>
-    <dt>20 avril 2011</dt>
-    <dd><a href="./posts/2011/avril/20/a-markdown-powered-article/">A markdown powered article</a></dd>
-    <dt>17 février 2011</dt>
-    <dd><a href="./posts/2011/février/17/article-1/">Article 1</a></dd>
-    <dt>17 février 2011</dt>
-    <dd><a href="./posts/2011/février/17/article-2/">Article 2</a></dd>
-    <dt>17 février 2011</dt>
-    <dd><a href="./posts/2011/février/17/article-3/">Article 3</a></dd>
-    <dt>02 décembre 2010</dt>
-    <dd><a href="./posts/2010/décembre/02/this-is-a-super-article/">This is a super article !</a></dd>
-    <dt>20 octobre 2010</dt>
-    <dd><a href="./posts/2010/octobre/20/oh-yeah/">Oh yeah !</a></dd>
-    <dt>15 octobre 2010</dt>
-    <dd><a href="./posts/2010/octobre/15/unbelievable/">Unbelievable !</a></dd>
-    <dt>14 mars 2010</dt>
-    <dd><a href="./tag/baz.html">The baz tag</a></dd>
-</dl>
+    <dl>
+        <dt>30 novembre 2012</dt>
+        <dd><a href="./posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></dd>
+        <dt>29 février 2012</dt>
+        <dd><a href="./posts/2012/février/29/second-article/">Second article</a></dd>
+        <dt>20 avril 2011</dt>
+        <dd><a href="./posts/2011/avril/20/a-markdown-powered-article/">A markdown powered article</a></dd>
+        <dt>17 février 2011</dt>
+        <dd><a href="./posts/2011/février/17/article-1/">Article 1</a></dd>
+        <dt>17 février 2011</dt>
+        <dd><a href="./posts/2011/février/17/article-2/">Article 2</a></dd>
+        <dt>17 février 2011</dt>
+        <dd><a href="./posts/2011/février/17/article-3/">Article 3</a></dd>
+        <dt>02 décembre 2010</dt>
+        <dd><a href="./posts/2010/décembre/02/this-is-a-super-article/">This is a super article !</a></dd>
+        <dt>20 octobre 2010</dt>
+        <dd><a href="./posts/2010/octobre/20/oh-yeah/">Oh yeah !</a></dd>
+        <dt>15 octobre 2010</dt>
+        <dd><a href="./posts/2010/octobre/15/unbelievable/">Unbelievable !</a></dd>
+        <dt>14 mars 2010</dt>
+        <dd><a href="./tag/baz.html">The baz tag</a></dd>
+    </dl>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -92,5 +94,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau.html
@@ -1,159 +1,182 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: 30 novembre 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: 30 novembre 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-<p>There are <a href="../posts/2012/novembre/30/filename_metadata-example/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../posts/2012/novembre/30/filename_metadata-example/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2012/février/29/second-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2012/février/29/second-article/" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="../posts/2012/février/29/second-article/">read more</a>
-<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2012/février/29/second-article/">read more</a>
+<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/avril/20/a-markdown-powered-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/avril/20/a-markdown-powered-article/" rel="bookmark"
                            title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: 20 avril 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: 20 avril 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->                            <p>You're mutually oblivious.</p>
 <p><a href="../posts/2010/octobre/15/unbelievable/">a root-relative link to unbelievable</a>
 <a href="../posts/2010/octobre/15/unbelievable/">a file-relative link to unbelievable</a></p>
-                <a class="readmore" href="../posts/2011/avril/20/a-markdown-powered-article/">read more</a>
-<p>There are <a href="../posts/2011/avril/20/a-markdown-powered-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2011/avril/20/a-markdown-powered-article/">read more</a>
+<p>There are <a href="../posts/2011/avril/20/a-markdown-powered-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/février/17/article-1/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/février/17/article-1/" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="../posts/2011/février/17/article-1/">read more</a>
-<p>There are <a href="../posts/2011/février/17/article-1/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="../posts/2011/février/17/article-1/">read more</a>
+<p>There are <a href="../posts/2011/février/17/article-1/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
     Page 1 / 3
         <a href="../author/alexis-metaireau2.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -165,5 +188,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
@@ -1,173 +1,199 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/février/17/article-2/" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/février/17/article-2/" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="../posts/2011/février/17/article-2/">read more</a>
-<p>There are <a href="../posts/2011/février/17/article-2/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2011/février/17/article-2/">read more</a>
+<p>There are <a href="../posts/2011/février/17/article-2/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/février/17/article-3/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/février/17/article-3/" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="../posts/2011/février/17/article-3/">read more</a>
-<p>There are <a href="../posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2011/février/17/article-3/">read more</a>
+<p>There are <a href="../posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="../posts/2010/décembre/02/this-is-a-super-article/">read more</a>
-<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2010/décembre/02/this-is-a-super-article/">read more</a>
+<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/octobre/20/oh-yeah/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/octobre/20/oh-yeah/" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: 20 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: 20 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="../posts/2010/octobre/20/oh-yeah/">read more</a>
-<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="../posts/2010/octobre/20/oh-yeah/">read more</a>
+<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="../author/alexis-metaireau.html">&laquo;</a>
     Page 2 / 3
         <a href="../author/alexis-metaireau3.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -179,5 +205,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
@@ -1,50 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Alexis Métaireau</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/octobre/15/unbelievable/" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/octobre/15/unbelievable/" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: 15 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: 15 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="../posts/2011/avril/20/a-markdown-powered-article/">a root-relative link to markdown-article</a>
 <a class="reference external" href="../posts/2011/avril/20/a-markdown-powered-article/">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -56,69 +60,79 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
-<p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
+<p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: 14 mars 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: 14 mars 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="../tag/baz.html">read more</a>
-<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="../tag/baz.html">read more</a>
+<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="../author/alexis-metaireau2.html">&laquo;</a>
     Page 3 / 3
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -130,5 +144,5 @@ pelican.conf, it will …</p></div>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/authors.html
+++ b/pelican/tests/output/custom_locale/authors.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Authors</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 <section id="content" class="body">
@@ -33,36 +35,36 @@
 </section>
 
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -74,5 +76,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/categories.html
+++ b/pelican/tests/output/custom_locale/categories.html
@@ -1,67 +1,69 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Categories</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
-    <h1>Categories on Alexis' log</h1>
-    <ul>
-        <li><a href="./category/bar.html">bar</a> (1)</li>
-        <li><a href="./category/cat1.html">cat1</a> (4)</li>
-        <li><a href="./category/misc.html">misc</a> (4)</li>
-        <li><a href="./category/yeah.html">yeah</a> (1)</li>
-    </ul>
+<h1>Categories on Alexis' log</h1>
+<ul>
+    <li><a href="./category/bar.html">bar</a> (1)</li>
+    <li><a href="./category/cat1.html">cat1</a> (4)</li>
+    <li><a href="./category/misc.html">misc</a> (4)</li>
+    <li><a href="./category/yeah.html">yeah</a> (1)</li>
+</ul>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/category/bar.html
+++ b/pelican/tests/output/custom_locale/category/bar.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2010/octobre/20/oh-yeah/">Oh yeah !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2010/octobre/20/oh-yeah/">Oh yeah !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: 20 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: 20 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><div class="section" id="why-not">
@@ -46,39 +50,41 @@
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
-<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -90,5 +96,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/category/cat1.html
+++ b/pelican/tests/output/custom_locale/category/cat1.html
@@ -1,153 +1,175 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - cat1</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li class="active"><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li class="active"><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2011/avril/20/a-markdown-powered-article/">A markdown powered article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2011/avril/20/a-markdown-powered-article/">A markdown powered article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: 20 avril 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: 20 avril 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
 </footer><!-- /.post-info --><p>You're mutually oblivious.</p>
 <p><a href="../posts/2010/octobre/15/unbelievable/">a root-relative link to unbelievable</a>
-<a href="../posts/2010/octobre/15/unbelievable/">a file-relative link to unbelievable</a></p><p>There are <a href="../posts/2011/avril/20/a-markdown-powered-article/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<a href="../posts/2010/octobre/15/unbelievable/">a file-relative link to unbelievable</a></p><p>There are <a href="../posts/2011/avril/20/a-markdown-powered-article/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/février/17/article-1/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/février/17/article-1/" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="../posts/2011/février/17/article-1/">read more</a>
-<p>There are <a href="../posts/2011/février/17/article-1/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2011/février/17/article-1/">read more</a>
+<p>There are <a href="../posts/2011/février/17/article-1/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/février/17/article-2/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/février/17/article-2/" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="../posts/2011/février/17/article-2/">read more</a>
-<p>There are <a href="../posts/2011/février/17/article-2/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2011/février/17/article-2/">read more</a>
+<p>There are <a href="../posts/2011/février/17/article-2/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2011/février/17/article-3/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2011/février/17/article-3/" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="../posts/2011/février/17/article-3/">read more</a>
-<p>There are <a href="../posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../posts/2011/février/17/article-3/">read more</a>
+<p>There are <a href="../posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -159,5 +181,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -1,94 +1,107 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - misc</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: 30 novembre 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: 30 novembre 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-<p>There are <a href="../posts/2012/novembre/30/filename_metadata-example/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../posts/2012/novembre/30/filename_metadata-example/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2012/février/29/second-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2012/février/29/second-article/" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="../posts/2012/février/29/second-article/">read more</a>
-<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2012/février/29/second-article/">read more</a>
+<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/octobre/15/unbelievable/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/octobre/15/unbelievable/" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: 15 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: 15 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="../posts/2011/avril/20/a-markdown-powered-article/">a root-relative link to markdown-article</a>
 <a class="reference external" href="../posts/2011/avril/20/a-markdown-powered-article/">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -100,65 +113,75 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
-<p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2010/octobre/15/unbelievable/">read more</a>
+<p>There are <a href="../posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: 14 mars 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: 14 mars 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="../tag/baz.html">read more</a>
-<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../tag/baz.html">read more</a>
+<p>There are <a href="../tag/baz.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -170,5 +193,5 @@ pelican.conf, it will …</p></div>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/category/yeah.html
+++ b/pelican/tests/output/custom_locale/category/yeah.html
@@ -1,47 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li class="active"><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li class="active"><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2010/décembre/02/this-is-a-super-article/">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2010/décembre/02/this-is-a-super-article/">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -54,39 +58,41 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -98,5 +104,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom_locale/drafts/a-draft-article.html
@@ -1,86 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A draft article</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../drafts/a-draft-article.html" rel="bookmark"
-           title="Permalink to A draft article">A draft article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../drafts/a-draft-article.html" rel="bookmark"
+                   title="Permalink to A draft article">A draft article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-03-02T14:01:01+01:00">
-                Published: 02 mars 2012
-        </abbr>
+    <abbr class="published" title="2012-03-02T14:01:01+01:00">
+        Published: 02 mars 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>This is a draft article, it should live under the /drafts/ folder and not be
+</footer><!-- /.post-info -->            <p>This is a draft article, it should live under the /drafts/ folder and not be
 listed anywhere else.</p>
 
-    </div><!-- /.entry-content -->
+        </div><!-- /.entry-content -->
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -92,5 +96,5 @@ listed anywhere else.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/index.html
+++ b/pelican/tests/output/custom_locale/index.html
@@ -1,159 +1,182 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="./posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="./posts/2012/novembre/30/filename_metadata-example/">FILENAME_METADATA example</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: 30 novembre 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: 30 novembre 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
 </footer><!-- /.post-info --><p>Some cool stuff!</p>
-<p>There are <a href="./posts/2012/novembre/30/filename_metadata-example/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="./posts/2012/novembre/30/filename_metadata-example/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2012/février/29/second-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2012/février/29/second-article/" rel="bookmark"
                            title="Permalink to Second article">Second article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>
+    Translations:
         <a href="./second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <p>This is some article, in english</p>
+</footer><!-- /.post-info -->                            <p>This is some article, in english</p>
 
-                <a class="readmore" href="./posts/2012/février/29/second-article/">read more</a>
-<p>There are <a href="./posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./posts/2012/février/29/second-article/">read more</a>
+<p>There are <a href="./posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2011/avril/20/a-markdown-powered-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2011/avril/20/a-markdown-powered-article/" rel="bookmark"
                            title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: 20 avril 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: 20 avril 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->                            <p>You're mutually oblivious.</p>
 <p><a href="./posts/2010/octobre/15/unbelievable/">a root-relative link to unbelievable</a>
 <a href="./posts/2010/octobre/15/unbelievable/">a file-relative link to unbelievable</a></p>
-                <a class="readmore" href="./posts/2011/avril/20/a-markdown-powered-article/">read more</a>
-<p>There are <a href="./posts/2011/avril/20/a-markdown-powered-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./posts/2011/avril/20/a-markdown-powered-article/">read more</a>
+<p>There are <a href="./posts/2011/avril/20/a-markdown-powered-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2011/février/17/article-1/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2011/février/17/article-1/" rel="bookmark"
                            title="Permalink to Article 1">Article 1</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 1</p>
+</footer><!-- /.post-info -->                            <p>Article 1</p>
 
-                <a class="readmore" href="./posts/2011/février/17/article-1/">read more</a>
-<p>There are <a href="./posts/2011/février/17/article-1/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="./posts/2011/février/17/article-1/">read more</a>
+<p>There are <a href="./posts/2011/février/17/article-1/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
     Page 1 / 3
         <a href="./index2.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -165,5 +188,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/index2.html
+++ b/pelican/tests/output/custom_locale/index2.html
@@ -1,173 +1,199 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2011/février/17/article-2/" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2011/février/17/article-2/" rel="bookmark"
                            title="Permalink to Article 2">Article 2</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 2</p>
+</footer><!-- /.post-info -->                            <p>Article 2</p>
 
-                <a class="readmore" href="./posts/2011/février/17/article-2/">read more</a>
-<p>There are <a href="./posts/2011/février/17/article-2/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./posts/2011/février/17/article-2/">read more</a>
+<p>There are <a href="./posts/2011/février/17/article-2/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2011/février/17/article-3/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2011/février/17/article-3/" rel="bookmark"
                            title="Permalink to Article 3">Article 3</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/cat1.html">cat1</a>.</p>
+    <p>In <a href="./category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Article 3</p>
+</footer><!-- /.post-info -->                            <p>Article 3</p>
 
-                <a class="readmore" href="./posts/2011/février/17/article-3/">read more</a>
-<p>There are <a href="./posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./posts/2011/février/17/article-3/">read more</a>
+<p>There are <a href="./posts/2011/février/17/article-3/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/yeah.html">yeah</a>.</p>
+    <p>In <a href="./category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="./posts/2010/décembre/02/this-is-a-super-article/">read more</a>
-<p>There are <a href="./posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./posts/2010/décembre/02/this-is-a-super-article/">read more</a>
+<p>There are <a href="./posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2010/octobre/20/oh-yeah/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2010/octobre/20/oh-yeah/" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: 20 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: 20 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/bar.html">bar</a>.</p>
-<p>tags: <a href="./tag/oh.html">oh</a> <a href="./tag/bar.html">bar</a> <a href="./tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="./category/bar.html">bar</a>.</p>
+<p>tags: <a href="./tag/oh.html">oh</a> <a href="./tag/bar.html">bar</a> <a href="./tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="./oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="./pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="./posts/2010/octobre/20/oh-yeah/">read more</a>
-<p>There are <a href="./posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="./posts/2010/octobre/20/oh-yeah/">read more</a>
+<p>There are <a href="./posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="./index.html">&laquo;</a>
     Page 2 / 3
         <a href="./index3.html">&raquo;</a>
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -179,5 +205,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/index3.html
+++ b/pelican/tests/output/custom_locale/index3.html
@@ -1,50 +1,54 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="3">
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./posts/2010/octobre/15/unbelievable/" rel="bookmark"
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="3">
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./posts/2010/octobre/15/unbelievable/" rel="bookmark"
                            title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: 15 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: 15 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->                            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="./posts/2011/avril/20/a-markdown-powered-article/">a root-relative link to markdown-article</a>
 <a class="reference external" href="./posts/2011/avril/20/a-markdown-powered-article/">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -56,69 +60,79 @@
 <h2>Testing another case</h2>
 <p>This will now have a line number in 'custom' since it's the default in
 pelican.conf, it will …</p></div>
-                <a class="readmore" href="./posts/2010/octobre/15/unbelievable/">read more</a>
-<p>There are <a href="./posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="./posts/2010/octobre/15/unbelievable/">read more</a>
+<p>There are <a href="./posts/2010/octobre/15/unbelievable/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="./tag/baz.html" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="./tag/baz.html" rel="bookmark"
                            title="Permalink to The baz tag">The baz tag</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: 14 mars 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: 14 mars 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
+    <p>In <a href="./category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->                <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->                            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-                <a class="readmore" href="./tag/baz.html">read more</a>
-<p>There are <a href="./tag/baz.html#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
+                            <a class="readmore" href="./tag/baz.html">read more</a>
+<p>There are <a href="./tag/baz.html#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
 <p class="paginator">
         <a href="./index2.html">&laquo;</a>
     Page 3 / 3
 </p>
-                </section><!-- /#content -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -130,5 +144,5 @@ pelican.conf, it will …</p></div>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/jinja2_template.html
+++ b/pelican/tests/output/custom_locale/jinja2_template.html
@@ -1,63 +1,65 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 Some text
 
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -69,5 +71,5 @@ Some text
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/oh-yeah-fr.html
+++ b/pelican/tests/output/custom_locale/oh-yeah-fr.html
@@ -1,104 +1,108 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Trop bien !</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="en" href="./posts/2010/octobre/20/oh-yeah/">
+            <link rel="alternate" hreflang="en" href="./posts/2010/octobre/20/oh-yeah/">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./oh-yeah-fr.html" rel="bookmark"
-           title="Permalink to Trop bien !">Trop bien !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./oh-yeah-fr.html" rel="bookmark"
+                   title="Permalink to Trop bien !">Trop bien !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-03-02T14:01:01+01:00">
-                Published: 02 mars 2012
-        </abbr>
+    <abbr class="published" title="2012-03-02T14:01:01+01:00">
+        Published: 02 mars 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+    Translations:
         <a href="./posts/2010/octobre/20/oh-yeah/" hreflang="en">en</a>
 
-</footer><!-- /.post-info -->      <p>Et voila du contenu en français</p>
+</footer><!-- /.post-info -->            <p>Et voila du contenu en français</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'oh-yeah-fr.html';
-        var disqus_url = './oh-yeah-fr.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'oh-yeah-fr.html';
+                var disqus_url = './oh-yeah-fr.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -110,5 +114,5 @@ Translations:
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/override/index.html
+++ b/pelican/tests/output/custom_locale/override/index.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Override url/save_as</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li class="active"><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li class="active"><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">Override url/save_as</h1>
@@ -32,36 +34,36 @@ at a custom location.</p>
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@ at a custom location.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a test hidden page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">This is a test hidden page</h1>
@@ -32,36 +34,36 @@ Anyone can see this page but it's not linked to anywhere!</p>
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@ Anyone can see this page but it's not linked to anywhere!</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a test page</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li class="active"><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li class="active"><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">This is a test page</h1>
@@ -32,36 +34,36 @@
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -73,5 +75,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
@@ -1,53 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>This is a super article !</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li class="active"><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li><a href="../../../../../category/misc.html">misc</a></li>
-                    <li><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li class="active"><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li><a href="../../../../../category/misc.html">misc</a></li>
+                            <li><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
-           title="Permalink to This is a super article !">This is a super article !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
+                   title="Permalink to This is a super article !">This is a super article !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../../../../../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../../../../../tag/foo.html">foo</a> <a href="../../../../../tag/bar.html">bar</a> <a href="../../../../../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->      <p>Some content here !</p>
+
+</footer><!-- /.post-info -->            <p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
 <p>And here comes the cool <a class="reference external" href="http://books.couchdb.org/relax/design-documents/views">stuff</a>.</p>
@@ -60,56 +65,56 @@
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2010/décembre/02/this-is-a-super-article/';
-        var disqus_url = '../../../../../posts/2010/décembre/02/this-is-a-super-article/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2010/décembre/02/this-is-a-super-article/';
+                var disqus_url = '../../../../../posts/2010/décembre/02/this-is-a-super-article/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -121,5 +126,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
@@ -1,49 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Unbelievable !</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../../../../../category/misc.html">misc</a></li>
-                    <li><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../../../../../category/misc.html">misc</a></li>
+                            <li><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2010/octobre/15/unbelievable/" rel="bookmark"
-           title="Permalink to Unbelievable !">Unbelievable !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2010/octobre/15/unbelievable/" rel="bookmark"
+                   title="Permalink to Unbelievable !">Unbelievable !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-15T20:30:00+02:00">
-                Published: 15 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-15T20:30:00+02:00">
+        Published: 15 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/misc.html">misc</a>.</p>
+    <p>In <a href="../../../../../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Or completely awesome. Depends the needs.</p>
+</footer><!-- /.post-info -->            <p>Or completely awesome. Depends the needs.</p>
 <p><a class="reference external" href="../../../../../posts/2011/avril/20/a-markdown-powered-article/">a root-relative link to markdown-article</a>
 <a class="reference external" href="../../../../../posts/2011/avril/20/a-markdown-powered-article/">a file-relative link to markdown-article</a></p>
 <div class="section" id="testing-sourcecode-directive">
@@ -77,56 +81,56 @@ pelican.conf, it will have nothing in default.</p>
 <p>Lovely.</p>
 </div>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2010/octobre/15/unbelievable/';
-        var disqus_url = '../../../../../posts/2010/octobre/15/unbelievable/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2010/octobre/15/unbelievable/';
+                var disqus_url = '../../../../../posts/2010/octobre/15/unbelievable/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -138,5 +142,5 @@ pelican.conf, it will have nothing in default.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
@@ -1,109 +1,114 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Oh yeah !</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="fr" href="../../../../../oh-yeah-fr.html">
+            <link rel="alternate" hreflang="fr" href="../../../../../oh-yeah-fr.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li><a href="../../../../../category/misc.html">misc</a></li>
-                    <li><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li class="active"><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li><a href="../../../../../category/misc.html">misc</a></li>
+                            <li><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li class="active"><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2010/octobre/20/oh-yeah/" rel="bookmark"
-           title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2010/octobre/20/oh-yeah/" rel="bookmark"
+                   title="Permalink to Oh yeah !">Oh yeah !</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: 20 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: 20 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../../../../../tag/oh.html">oh</a> <a href="../../../../../tag/bar.html">bar</a> <a href="../../../../../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../../../../../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../../../../../tag/oh.html">oh</a> <a href="../../../../../tag/bar.html">bar</a> <a href="../../../../../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../../../../../oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->      <div class="section" id="why-not">
+</footer><!-- /.post-info -->            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="../../../../../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2010/octobre/20/oh-yeah/';
-        var disqus_url = '../../../../../posts/2010/octobre/20/oh-yeah/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2010/octobre/20/oh-yeah/';
+                var disqus_url = '../../../../../posts/2010/octobre/20/oh-yeah/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -115,5 +120,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
@@ -1,101 +1,105 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>A markdown powered article</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li><a href="../../../../../category/misc.html">misc</a></li>
-                    <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li><a href="../../../../../category/misc.html">misc</a></li>
+                            <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2011/avril/20/a-markdown-powered-article/" rel="bookmark"
-           title="Permalink to A markdown powered article">A markdown powered article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2011/avril/20/a-markdown-powered-article/" rel="bookmark"
+                   title="Permalink to A markdown powered article">A markdown powered article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-04-20T00:00:00+02:00">
-                Published: 20 avril 2011
-        </abbr>
+    <abbr class="published" title="2011-04-20T00:00:00+02:00">
+        Published: 20 avril 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>You're mutually oblivious.</p>
+</footer><!-- /.post-info -->            <p>You're mutually oblivious.</p>
 <p><a href="../../../../../posts/2010/octobre/15/unbelievable/">a root-relative link to unbelievable</a>
 <a href="../../../../../posts/2010/octobre/15/unbelievable/">a file-relative link to unbelievable</a></p>
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2011/avril/20/a-markdown-powered-article/';
-        var disqus_url = '../../../../../posts/2011/avril/20/a-markdown-powered-article/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2011/avril/20/a-markdown-powered-article/';
+                var disqus_url = '../../../../../posts/2011/avril/20/a-markdown-powered-article/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -107,5 +111,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 1</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li><a href="../../../../../category/misc.html">misc</a></li>
-                    <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li><a href="../../../../../category/misc.html">misc</a></li>
+                            <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2011/février/17/article-1/" rel="bookmark"
-           title="Permalink to Article 1">Article 1</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2011/février/17/article-1/" rel="bookmark"
+                   title="Permalink to Article 1">Article 1</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 1</p>
+</footer><!-- /.post-info -->            <p>Article 1</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2011/février/17/article-1/';
-        var disqus_url = '../../../../../posts/2011/février/17/article-1/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2011/février/17/article-1/';
+                var disqus_url = '../../../../../posts/2011/février/17/article-1/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 2</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li><a href="../../../../../category/misc.html">misc</a></li>
-                    <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li><a href="../../../../../category/misc.html">misc</a></li>
+                            <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2011/février/17/article-2/" rel="bookmark"
-           title="Permalink to Article 2">Article 2</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2011/février/17/article-2/" rel="bookmark"
+                   title="Permalink to Article 2">Article 2</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 2</p>
+</footer><!-- /.post-info -->            <p>Article 2</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2011/février/17/article-2/';
-        var disqus_url = '../../../../../posts/2011/février/17/article-2/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2011/février/17/article-2/';
+                var disqus_url = '../../../../../posts/2011/février/17/article-2/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Article 3</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li><a href="../../../../../category/misc.html">misc</a></li>
-                    <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li><a href="../../../../../category/misc.html">misc</a></li>
+                            <li class="active"><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2011/février/17/article-3/" rel="bookmark"
-           title="Permalink to Article 3">Article 3</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2011/février/17/article-3/" rel="bookmark"
+                   title="Permalink to Article 3">Article 3</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2011-02-17T00:00:00+01:00">
-                Published: 17 février 2011
-        </abbr>
+    <abbr class="published" title="2011-02-17T00:00:00+01:00">
+        Published: 17 février 2011
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
+    <p>In <a href="../../../../../category/cat1.html">cat1</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Article 3</p>
+</footer><!-- /.post-info -->            <p>Article 3</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2011/février/17/article-3/';
-        var disqus_url = '../../../../../posts/2011/février/17/article-3/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2011/février/17/article-3/';
+                var disqus_url = '../../../../../posts/2011/février/17/article-3/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
@@ -1,104 +1,109 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Second article</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="fr" href="../../../../../second-article-fr.html">
+            <link rel="alternate" hreflang="fr" href="../../../../../second-article-fr.html">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../../../../../category/misc.html">misc</a></li>
-                    <li><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../../../../../category/misc.html">misc</a></li>
+                            <li><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2012/février/29/second-article/" rel="bookmark"
-           title="Permalink to Second article">Second article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2012/février/29/second-article/" rel="bookmark"
+                   title="Permalink to Second article">Second article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../../../../../tag/foo.html">foo</a> <a href="../../../../../tag/bar.html">bar</a> <a href="../../../../../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../../../../../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../../../../../tag/foo.html">foo</a> <a href="../../../../../tag/bar.html">bar</a> <a href="../../../../../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../../../../../second-article-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->      <p>This is some article, in english</p>
+</footer><!-- /.post-info -->            <p>This is some article, in english</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2012/février/29/second-article/';
-        var disqus_url = '../../../../../posts/2012/février/29/second-article/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2012/février/29/second-article/';
+                var disqus_url = '../../../../../posts/2012/février/29/second-article/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -110,5 +115,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>FILENAME_METADATA example</title>
         <link rel="stylesheet" href="../../../../../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../../../../../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../../../../../override/">Override url/save_as</a></li>
-                    <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../../../../../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../../../../../category/misc.html">misc</a></li>
-                    <li><a href="../../../../../category/cat1.html">cat1</a></li>
-                    <li><a href="../../../../../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../../../../../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../../../../../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../../../../../override/">Override url/save_as</a></li>
+                            <li><a href="../../../../../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../../../../../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../../../../../category/misc.html">misc</a></li>
+                            <li><a href="../../../../../category/cat1.html">cat1</a></li>
+                            <li><a href="../../../../../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../../../../../posts/2012/novembre/30/filename_metadata-example/" rel="bookmark"
-           title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../../../../../posts/2012/novembre/30/filename_metadata-example/" rel="bookmark"
+                   title="Permalink to FILENAME_METADATA example">FILENAME_METADATA example</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-11-30T00:00:00+01:00">
-                Published: 30 novembre 2012
-        </abbr>
+    <abbr class="published" title="2012-11-30T00:00:00+01:00">
+        Published: 30 novembre 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../../../../../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../../../../../category/misc.html">misc</a>.</p>
+    <p>In <a href="../../../../../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>Some cool stuff!</p>
+</footer><!-- /.post-info -->            <p>Some cool stuff!</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'posts/2012/novembre/30/filename_metadata-example/';
-        var disqus_url = '../../../../../posts/2012/novembre/30/filename_metadata-example/';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'posts/2012/novembre/30/filename_metadata-example/';
+                var disqus_url = '../../../../../posts/2012/novembre/30/filename_metadata-example/';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/second-article-fr.html
+++ b/pelican/tests/output/custom_locale/second-article-fr.html
@@ -1,104 +1,109 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Deuxième article</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-      <link rel="alternate" hreflang="en" href="./posts/2012/février/29/second-article/">
+            <link rel="alternate" hreflang="en" href="./posts/2012/février/29/second-article/">
 
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="./second-article-fr.html" rel="bookmark"
-           title="Permalink to Deuxième article">Deuxième article</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="./second-article-fr.html" rel="bookmark"
+                   title="Permalink to Deuxième article">Deuxième article</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="./author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="./category/misc.html">misc</a>.</p>
-<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="./category/misc.html">misc</a>.</p>
+<p>tags: <a href="./tag/foo.html">foo</a> <a href="./tag/bar.html">bar</a> <a href="./tag/baz.html">baz</a> </p>
+    Translations:
         <a href="./posts/2012/février/29/second-article/" hreflang="en">en</a>
 
-</footer><!-- /.post-info -->      <p>Ceci est un article, en français.</p>
+</footer><!-- /.post-info -->            <p>Ceci est un article, en français.</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'second-article-fr.html';
-        var disqus_url = './second-article-fr.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'second-article-fr.html';
+                var disqus_url = './second-article-fr.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -110,5 +115,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tag/bar.html
+++ b/pelican/tests/output/custom_locale/tag/bar.html
@@ -1,143 +1,163 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - bar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2012/février/29/second-article/">Second article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2012/février/29/second-article/">Second article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><p>This is some article, in english</p>
-<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="../posts/2010/décembre/02/this-is-a-super-article/">read more</a>
-<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
+                            <a class="readmore" href="../posts/2010/décembre/02/this-is-a-super-article/">read more</a>
+<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/octobre/20/oh-yeah/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/octobre/20/oh-yeah/" rel="bookmark"
                            title="Permalink to Oh yeah !">Oh yeah !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: 20 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: 20 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
-</footer><!-- /.post-info -->                <div class="section" id="why-not">
+</footer><!-- /.post-info -->                            <div class="section" id="why-not">
 <h2>Why not ?</h2>
 <p>After all, why not ? It's pretty simple to do it, and it will allow me to write my blogposts in rst !
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
 
-                <a class="readmore" href="../posts/2010/octobre/20/oh-yeah/">read more</a>
-<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../posts/2010/octobre/20/oh-yeah/">read more</a>
+<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -149,5 +169,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tag/baz.html
+++ b/pelican/tests/output/custom_locale/tag/baz.html
@@ -1,100 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>The baz tag</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li class="active"><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li class="active"><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="../tag/baz.html" rel="bookmark"
-           title="Permalink to The baz tag">The baz tag</a></h1>
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="../tag/baz.html" rel="bookmark"
+                   title="Permalink to The baz tag">The baz tag</a>
+            </h1>
+        </header>
 
-    <div class="entry-content">
+        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-03-14T00:00:00+01:00">
-                Published: 14 mars 2010
-        </abbr>
+    <abbr class="published" title="2010-03-14T00:00:00+01:00">
+        Published: 14 mars 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
+    <p>In <a href="../category/misc.html">misc</a>.</p>
 
-</footer><!-- /.post-info -->      <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
+</footer><!-- /.post-info -->            <p>This article overrides the listening of the articles under the <em>baz</em> tag.</p>
 
-    </div><!-- /.entry-content -->
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = 'blog-notmyidea';
-        var disqus_identifier = 'tag/baz.html';
-        var disqus_url = '../tag/baz.html';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//blog-notmyidea.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
+        </div><!-- /.entry-content -->
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = 'blog-notmyidea';
+                var disqus_identifier = 'tag/baz.html';
+                var disqus_url = '../tag/baz.html';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//blog-notmyidea.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
 
-  </article>
+    </article>
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -106,5 +110,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tag/foo.html
+++ b/pelican/tests/output/custom_locale/tag/foo.html
@@ -1,113 +1,127 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - foo</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2012/février/29/second-article/">Second article</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2012/février/29/second-article/">Second article</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2012-02-29T00:00:00+01:00">
-                Published: 29 février 2012
-        </abbr>
+    <abbr class="published" title="2012-02-29T00:00:00+01:00">
+        Published: 29 février 2012
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/misc.html">misc</a>.</p>
-<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>Translations:
+    <p>In <a href="../category/misc.html">misc</a>.</p>
+<p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/baz.html">baz</a> </p>
+    Translations:
         <a href="../second-article-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><p>This is some article, in english</p>
-<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
+<p>There are <a href="../posts/2012/février/29/second-article/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
 
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="../posts/2010/décembre/02/this-is-a-super-article/" rel="bookmark"
                            title="Permalink to This is a super article !">This is a super article !</a></h1>
-                </header>
+                        </header>
 
-                <div class="entry-content">
+                        <div class="entry-content">
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
-</footer><!-- /.post-info -->                <p class="first last">Multi-line metadata should be supported
+
+</footer><!-- /.post-info -->                            <p class="first last">Multi-line metadata should be supported
 as well as <strong>inline markup</strong>.</p>
 
-                <a class="readmore" href="../posts/2010/décembre/02/this-is-a-super-article/">read more</a>
-<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </div><!-- /.entry-content -->
-            </article></li>
-                </ol><!-- /#posts-list -->
-                </section><!-- /#content -->
+                            <a class="readmore" href="../posts/2010/décembre/02/this-is-a-super-article/">read more</a>
+<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+            </ol>
+            <!-- /#posts-list -->
+        </section>
+        <!-- /#content -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -119,5 +133,5 @@ as well as <strong>inline markup</strong>.</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tag/foobar.html
+++ b/pelican/tests/output/custom_locale/tag/foobar.html
@@ -1,47 +1,51 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - foobar</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2010/décembre/02/this-is-a-super-article/">This is a super article !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2010/décembre/02/this-is-a-super-article/">This is a super article !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-12-02T10:14:00+01:00">
-                Published: 02 décembre 2010
-        </abbr>
-		<br />
-        <abbr class="modified" title="2013-11-17T23:29:00+01:00">
-                Updated: 17 novembre 2013
-        </abbr>
+    <abbr class="published" title="2010-12-02T10:14:00+01:00">
+        Published: 02 décembre 2010
+    </abbr>
+    <br />
+    <abbr class="modified" title="2013-11-17T23:29:00+01:00">
+        Updated: 17 novembre 2013
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/yeah.html">yeah</a>.</p>
+    <p>In <a href="../category/yeah.html">yeah</a>.</p>
 <p>tags: <a href="../tag/foo.html">foo</a> <a href="../tag/bar.html">bar</a> <a href="../tag/foobar.html">foobar</a> </p>
+
 </footer><!-- /.post-info --><p>Some content here !</p>
 <div class="section" id="this-is-a-simple-title">
 <h2>This is a simple title</h2>
@@ -54,39 +58,41 @@
 </pre>
 <p>→ And now try with some utf8 hell: ééé</p>
 </div>
-<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../posts/2010/décembre/02/this-is-a-super-article/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -98,5 +104,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tag/oh.html
+++ b/pelican/tests/output/custom_locale/tag/oh.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Oh Oh Oh</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li class="active"><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li class="active"><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 <section id="content" class="body">
     <h1 class="entry-title">Oh Oh Oh</h1>
@@ -31,36 +33,36 @@
 
 </section>
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -72,5 +74,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tag/yeah.html
+++ b/pelican/tests/output/custom_locale/tag/yeah.html
@@ -1,43 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - yeah</title>
         <link rel="stylesheet" href="../theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="../">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="../override/">Override url/save_as</a></li>
-                    <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="../category/yeah.html">yeah</a></li>
-                    <li><a href="../category/misc.html">misc</a></li>
-                    <li><a href="../category/cat1.html">cat1</a></li>
-                    <li><a href="../category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="../">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="../tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="../override/">Override url/save_as</a></li>
+                            <li><a href="../pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="../category/yeah.html">yeah</a></li>
+                            <li><a href="../category/misc.html">misc</a></li>
+                            <li><a href="../category/cat1.html">cat1</a></li>
+                            <li><a href="../category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="../posts/2010/octobre/20/oh-yeah/">Oh yeah !</a></h1>
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="../posts/2010/octobre/20/oh-yeah/">Oh yeah !</a></h1>
 <footer class="post-info">
-        <abbr class="published" title="2010-10-20T10:14:00+02:00">
-                Published: 20 octobre 2010
-        </abbr>
+    <abbr class="published" title="2010-10-20T10:14:00+02:00">
+        Published: 20 octobre 2010
+    </abbr>
 
         <address class="vcard author">
-                By                         <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
+            By
+                <a class="url fn" href="../author/alexis-metaireau.html">Alexis Métaireau</a>
         </address>
-<p>In <a href="../category/bar.html">bar</a>.</p>
-<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>Translations:
+    <p>In <a href="../category/bar.html">bar</a>.</p>
+<p>tags: <a href="../tag/oh.html">oh</a> <a href="../tag/bar.html">bar</a> <a href="../tag/yeah.html">yeah</a> </p>
+    Translations:
         <a href="../oh-yeah-fr.html" hreflang="fr">fr</a>
 
 </footer><!-- /.post-info --><div class="section" id="why-not">
@@ -46,39 +50,41 @@
 YEAH !</p>
 <img alt="alternate text" src="../pictures/Sushi.jpg" style="width: 600px; height: 450px;" />
 </div>
-<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>                </article>
-            </aside><!-- /#featured -->
+<p>There are <a href="../posts/2010/octobre/20/oh-yeah/#disqus_thread">comments</a>.</p>
+    </article>
+</aside>
+<!-- /#featured -->
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -90,5 +96,5 @@ YEAH !</p>
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/tests/output/custom_locale/tags.html
+++ b/pelican/tests/output/custom_locale/tags.html
@@ -1,28 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>Alexis' log - Tags</title>
         <link rel="stylesheet" href="./theme/css/main.css" />
         <link href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate" title="Alexis' log Atom Feed" />
         <link href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate" title="Alexis' log RSS Feed" />
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
 <a href="http://github.com/ametaireau/">
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
 </a>
         <header id="banner" class="body">
-                <h1><a href="./">Alexis' log </a></h1>
-                <nav><ul>
-                    <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
-                    <li><a href="./override/">Override url/save_as</a></li>
-                    <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
-                    <li><a href="./category/yeah.html">yeah</a></li>
-                    <li><a href="./category/misc.html">misc</a></li>
-                    <li><a href="./category/cat1.html">cat1</a></li>
-                    <li><a href="./category/bar.html">bar</a></li>
-                </ul></nav>
+            <h1><a href="./">Alexis' log </a></h1>
+            <nav>
+                <ul>
+                            <li><a href="./tag/oh.html">Oh Oh Oh</a></li>
+                            <li><a href="./override/">Override url/save_as</a></li>
+                            <li><a href="./pages/this-is-a-test-page.html">This is a test page</a></li>
+                            <li><a href="./category/yeah.html">yeah</a></li>
+                            <li><a href="./category/misc.html">misc</a></li>
+                            <li><a href="./category/cat1.html">cat1</a></li>
+                            <li><a href="./category/bar.html">bar</a></li>
+                </ul>
+            </nav>
         </header><!-- /#banner -->
 
 <section id="content" class="body">
@@ -38,36 +40,36 @@
 </section>
 
         <section id="extras" class="body">
-                <div class="blogroll">
-                        <h2>links</h2>
-                        <ul>
-                            <li><a href="http://biologeek.org">Biologeek</a></li>
-                            <li><a href="http://filyb.info/">Filyb</a></li>
-                            <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
-                            <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
-                            <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
-                            <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
-                        </ul>
-                </div><!-- /.blogroll -->
+            <div class="blogroll">
+                <h2>links</h2>
+                <ul>
+                    <li><a href="http://biologeek.org">Biologeek</a></li>
+                    <li><a href="http://filyb.info/">Filyb</a></li>
+                    <li><a href="http://www.libert-fr.com">Libert-fr</a></li>
+                    <li><a href="http://prendreuncafe.com/blog/">N1k0</a></li>
+                    <li><a href="http://ziade.org/blog">Tarek Ziadé</a></li>
+                    <li><a href="http://zubin71.wordpress.com/">Zubin Mithra</a></li>
+                </ul>
+            </div><!-- /.blogroll -->
                 <div class="social">
-                        <h2>social</h2>
-                        <ul>
+                    <h2>social</h2>
+                    <ul>
                             <li><a href="http://blog.notmyidea.org/feeds/all.atom.xml" type="application/atom+xml" rel="alternate">atom feed</a></li>
                             <li><a href="http://blog.notmyidea.org/feeds/all.rss.xml" type="application/rss+xml" rel="alternate">rss feed</a></li>
 
                             <li><a href="http://twitter.com/ametaireau">twitter</a></li>
                             <li><a href="http://lastfm.com/user/akounet">lastfm</a></li>
                             <li><a href="http://github.com/ametaireau">github</a></li>
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
 <script type="text/javascript">
@@ -79,5 +81,5 @@
         (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
 </script>
-</body>
+    </body>
 </html>

--- a/pelican/themes/notmyidea/templates/analytics.html
+++ b/pelican/themes/notmyidea/templates/analytics.html
@@ -1,45 +1,44 @@
 {% if GOOGLE_ANALYTICS %}
     <script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', '{{GOOGLE_ANALYTICS}}', '{{GA_COOKIE_DOMAIN if GA_COOKIE_DOMAIN else 'auto'}}');
-    ga('send', 'pageview');
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{GOOGLE_ANALYTICS}}', '{{GA_COOKIE_DOMAIN if GA_COOKIE_DOMAIN else 'auto'}}');
+        ga('send', 'pageview');
     </script>
 {% endif %}
 {% if GAUGES %}
     <script type="text/javascript">
-    var _gauges = _gauges || [];
-    (function() {
-        var t   = document.createElement('script');
-        t.type  = 'text/javascript';
-        t.async = true;
-        t.id    = 'gauges-tracker';
-        t.setAttribute('data-site-id', '{{GAUGES}}');
-        t.src = '//secure.gaug.es/track.js';
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(t, s);
-    })();
+        var _gauges = _gauges || [];
+        (function() {
+            var t   = document.createElement('script');
+            t.type  = 'text/javascript';
+            t.async = true;
+            t.id    = 'gauges-tracker';
+            t.setAttribute('data-site-id', '{{GAUGES}}');
+            t.src = '//secure.gaug.es/track.js';
+            var s = document.getElementsByTagName('script')[0];
+            s.parentNode.insertBefore(t, s);
+        })();
     </script>
 {% endif %}
 {% if PIWIK_URL and PIWIK_SITE_ID %}
     <script type="text/javascript">
-    {% if PIWIK_SSL_URL %}
-        var pkBaseURL = "{{ PIWIK_SSL_URL }}";
-    {% else %}
-        var pkBaseURL = "{{ PIWIK_URL }}";
-    {% endif %}
-    var _paq = _paq || [];
-    _paq.push(["trackPageView"]);
-    _paq.push(["enableLinkTracking"]);
-    (function() {
-        var u=(("https:" == document.location.protocol) ? "https" : "http")+"://"+pkBaseURL+"/";
-        _paq.push(["setTrackerUrl", u+"piwik.php"]);
-        _paq.push(["setSiteId", "{{ PIWIK_SITE_ID }}"]);
-        var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
-        g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
-    })();
+        {% if PIWIK_SSL_URL %}
+            var pkBaseURL = "{{ PIWIK_SSL_URL }}";
+        {% else %}
+            var pkBaseURL = "{{ PIWIK_URL }}";
+        {% endif %}
+        var _paq = _paq || [];
+        _paq.push(["trackPageView"]);
+        _paq.push(["enableLinkTracking"]);
+        (function() {
+            var u=(("https:" == document.location.protocol) ? "https" : "http")+"://"+pkBaseURL+"/";
+            _paq.push(["setTrackerUrl", u+"piwik.php"]);
+            _paq.push(["setSiteId", "{{ PIWIK_SITE_ID }}"]);
+            var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
+            g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
+        })();
     </script>
 {% endif %}

--- a/pelican/themes/notmyidea/templates/archives.html
+++ b/pelican/themes/notmyidea/templates/archives.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
 <section id="content" class="body">
-<h1>Archives for {{ SITENAME }}</h1>
+    <h1>Archives for {{ SITENAME }}</h1>
 
-<dl>
-{% for article in dates %}
-    <dt>{{ article.locale_date }}</dt>
-    <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
-{% endfor %}
-</dl>
+    <dl>
+    {% for article in dates %}
+        <dt>{{ article.locale_date }}</dt>
+        <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+    {% endfor %}
+    </dl>
 </section>
 {% endblock %}

--- a/pelican/themes/notmyidea/templates/article.html
+++ b/pelican/themes/notmyidea/templates/article.html
@@ -5,42 +5,43 @@
 {% block extra_head %}
 {% import 'translations.html' as translations with context %}
 {% if translations.entry_hreflang(article) %}
-  {{ translations.entry_hreflang(article) }}
+    {{ translations.entry_hreflang(article) }}
 {% endif %}
 {% endblock %}
 
 {% block content %}
 <section id="content" class="body">
-  <article>
-    <header>
-      <h1 class="entry-title">
-        <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
-           title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h1>
-      {% include 'twitter.html' %}
-    </header>
+    <article>
+        <header>
+            <h1 class="entry-title">
+                <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
+                   title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a>
+            </h1>
+            {% include 'twitter.html' %}
+        </header>
 
-    <div class="entry-content">
-      {% include 'article_infos.html' %}
-      {{ article.content }}
-    </div><!-- /.entry-content -->
-    {% if DISQUS_SITENAME and SITEURL and article.status != "draft" %}
-    <div class="comments">
-      <h2>Comments !</h2>
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        var disqus_shortname = '{{ DISQUS_SITENAME }}';
-        var disqus_identifier = '{{ article.url }}';
-        var disqus_url = '{{ SITEURL }}/{{ article.url }}';
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the comments.</noscript>
-    </div>
-    {% endif %}
+        <div class="entry-content">
+            {% include 'article_infos.html' %}
+            {{ article.content }}
+        </div><!-- /.entry-content -->
+        {% if DISQUS_SITENAME and SITEURL and article.status != "draft" %}
+        <div class="comments">
+            <h2>Comments!</h2>
+            <div id="disqus_thread"></div>
+            <script type="text/javascript">
+                var disqus_shortname = '{{ DISQUS_SITENAME }}';
+                var disqus_identifier = '{{ article.url }}';
+                var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+                (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                })();
+            </script>
+            <noscript>Please enable JavaScript to view the comments.</noscript>
+        </div>
+        {% endif %}
 
-  </article>
+    </article>
 </section>
 {% endblock %}

--- a/pelican/themes/notmyidea/templates/article_infos.html
+++ b/pelican/themes/notmyidea/templates/article_infos.html
@@ -1,23 +1,24 @@
 <footer class="post-info">
-        <abbr class="published" title="{{ article.date.isoformat() }}">
-                Published: {{ article.locale_date }}
-        </abbr>
-        {% if article.modified %}
-		<br />
-        <abbr class="modified" title="{{ article.modified.isoformat() }}">
-                Updated: {{ article.locale_modified }}
-        </abbr>
-        {% endif %}
+    <abbr class="published" title="{{ article.date.isoformat() }}">
+        Published: {{ article.locale_date }}
+    </abbr>
+    {% if article.modified %}
+    <br />
+    <abbr class="modified" title="{{ article.modified.isoformat() }}">
+        Updated: {{ article.locale_modified }}
+    </abbr>
+    {% endif %}
 
-        {% if article.authors %}
+    {% if article.authors %}
         <address class="vcard author">
-                By {% for author in article.authors %}
-                        <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
-                {% endfor %}
+            By
+            {% for author in article.authors %}
+                <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
+            {% endfor %}
         </address>
-        {% endif %}
-<p>In <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>.</p>
-{% include 'taglist.html' %}
-{% import 'translations.html' as translations with context %}
-{{ translations.translations_for(article) }}
+    {% endif %}
+    <p>In <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>.</p>
+    {% include 'taglist.html' %}
+    {% import 'translations.html' as translations with context %}
+    {{- translations.translations_for(article) }}
 </footer><!-- /.post-info -->

--- a/pelican/themes/notmyidea/templates/base.html
+++ b/pelican/themes/notmyidea/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="{% block html_lang %}{{ DEFAULT_LANG }}{% endblock html_lang %}">
-<head>
+    <head>
         <meta charset="utf-8" />
         <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
         <link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/{{ CSS_FILE }}" />
@@ -11,69 +11,71 @@
         <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
         {% endif %}
         {% block extra_head %}{% endblock extra_head %}
-</head>
+    </head>
 
-<body id="index" class="home">
-{% include 'github.html' %}
+    <body id="index" class="home">
+        {% include 'github.html' %}
         <header id="banner" class="body">
-                <h1><a href="{{ SITEURL }}/">{{ SITENAME }} {% if SITESUBTITLE %}<strong>{{ SITESUBTITLE }}</strong>{% endif %}</a></h1>
-                <nav><ul>
-                {% for title, link in MENUITEMS %}
-                    <li><a href="{{ link }}">{{ title }}</a></li>
-                {% endfor %}
-                {% if DISPLAY_PAGES_ON_MENU -%}
-                {% for pg in pages %}
-                    <li{% if pg == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
-                {% endfor %}
-                {% endif %}
-                {% if DISPLAY_CATEGORIES_ON_MENU -%}
-                {% for cat, null in categories %}
-                    <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
-                {% endfor %}
-                {% endif %}
-                </ul></nav>
+            <h1><a href="{{ SITEURL }}/">{{ SITENAME }} {% if SITESUBTITLE %}<strong>{{ SITESUBTITLE }}</strong>{% endif %}</a></h1>
+            <nav>
+                <ul>
+                    {% for title, link in MENUITEMS %}
+                        <li><a href="{{ link }}">{{ title }}</a></li>
+                    {% endfor %}
+                    {% if DISPLAY_PAGES_ON_MENU -%}
+                        {% for pg in pages %}
+                            <li{% if pg == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ pg.url }}">{{ pg.title }}</a></li>
+                        {% endfor %}
+                    {% endif %}
+                    {% if DISPLAY_CATEGORIES_ON_MENU -%}
+                        {% for cat, null in categories %}
+                            <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
+                        {% endfor %}
+                    {% endif %}
+                </ul>
+            </nav>
         </header><!-- /#banner -->
         {% block content %}
         {% endblock %}
         <section id="extras" class="body">
-        {% if LINKS %}
-                <div class="blogroll">
-                        <h2>{{ LINKS_WIDGET_NAME | default('links') }}</h2>
-                        <ul>
-                        {% for name, link in LINKS %}
-                            <li><a href="{{ link }}">{{ name }}</a></li>
-                        {% endfor %}
-                        </ul>
-                </div><!-- /.blogroll -->
-        {% endif %}
-        {% if SOCIAL or FEED_ALL_ATOM or FEED_ALL_RSS %}
+            {% if LINKS %}
+            <div class="blogroll">
+                <h2>{{ LINKS_WIDGET_NAME | default('links') }}</h2>
+                <ul>
+                {% for name, link in LINKS %}
+                    <li><a href="{{ link }}">{{ name }}</a></li>
+                {% endfor %}
+                </ul>
+            </div><!-- /.blogroll -->
+            {% endif %}
+            {% if SOCIAL or FEED_ALL_ATOM or FEED_ALL_RSS %}
                 <div class="social">
-                        <h2>{{ SOCIAL_WIDGET_NAME | default('social') }}</h2>
-                        <ul>
-                            {% if FEED_ALL_ATOM %}
+                    <h2>{{ SOCIAL_WIDGET_NAME | default('social') }}</h2>
+                    <ul>
+                        {% if FEED_ALL_ATOM %}
                             <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate">atom feed</a></li>
-                            {% endif %}
-                            {% if FEED_ALL_RSS %}
+                        {% endif %}
+                        {% if FEED_ALL_RSS %}
                             <li><a href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate">rss feed</a></li>
-                            {% endif %}
+                        {% endif %}
 
                         {% for name, link in SOCIAL %}
                             <li><a href="{{ link }}">{{ name }}</a></li>
                         {% endfor %}
-                        </ul>
+                    </ul>
                 </div><!-- /.social -->
-        {% endif %}
+            {% endif %}
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>, which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
 
-                <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
+            <p>The theme is by <a href="http://coding.smashingmagazine.com/2009/08/04/designing-a-html-5-layout-from-scratch/">Smashing Magazine</a>, thanks!</p>
         </footer><!-- /#contentinfo -->
 
-{% include 'analytics.html' %}
-{% include 'disqus_script.html' %}
-</body>
+        {% include 'analytics.html' %}
+        {% include 'disqus_script.html' %}
+    </body>
 </html>

--- a/pelican/themes/notmyidea/templates/comments.html
+++ b/pelican/themes/notmyidea/templates/comments.html
@@ -1,1 +1,3 @@
-{% if DISQUS_SITENAME %}<p>There are <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">comments</a>.</p>{% endif %}
+{% if DISQUS_SITENAME %}
+<p>There are <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">comments</a>.</p>
+{% endif %}

--- a/pelican/themes/notmyidea/templates/github.html
+++ b/pelican/themes/notmyidea/templates/github.html
@@ -1,9 +1,9 @@
 {% if GITHUB_URL %}
 <a href="{{ GITHUB_URL }}">
-{% if GITHUB_POSITION != "left" %}
-<img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
-{% else %}
-<img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_white_ffffff.png" alt="Fork me on GitHub" />
-{% endif %}
+    {% if GITHUB_POSITION != "left" %}
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+    {% else %}
+    <img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_white_ffffff.png" alt="Fork me on GitHub" />
+    {% endif %}
 </a>
 {% endif %}

--- a/pelican/themes/notmyidea/templates/index.html
+++ b/pelican/themes/notmyidea/templates/index.html
@@ -1,59 +1,67 @@
+{# NOTE: To better show the structure of the output HTML, this template is
+indented ignoring Jinja blocks. #}
 {% extends "base.html" %}
 {% block content_title %}{% endblock %}
 {% block content %}
 {% if articles %}
-    {% for article in articles_page.object_list %}
+{% for article in articles_page.object_list %}
 
-        {# First item #}
-        {% if loop.first and not articles_page.has_previous() %}
-            <aside id="featured" class="body">
-                <article>
-                    <h1 class="entry-title"><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
-                    {% include 'article_infos.html' %}{{ article.content }}{% include 'comments.html' %}
-                </article>
-            </aside><!-- /#featured -->
-            {% if loop.length > 1 %}
-                <section id="content" class="body">
-                    <h1>Other articles</h1>
-                    <hr />
-                    <ol id="posts-list" class="hfeed">
-            {% endif %}
+{# First item #}
+{% if loop.first and not articles_page.has_previous() %}
+<aside id="featured" class="body">
+    <article>
+        <h1 class="entry-title"><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
+        {% include 'article_infos.html' %}{{ article.content }}{% include 'comments.html' %}
+    </article>
+</aside>
+<!-- /#featured -->
+{% if loop.length > 1 %}
+<section id="content" class="body">
+    <h1>Other articles</h1>
+    <hr />
+    <ol id="posts-list" class="hfeed">
+        {% endif %}
         {# other items #}
         {% else %}
-            {% if loop.first %}
-                <section id="content" class="body">
-                    <ol id="posts-list" class="hfeed" start="{{ articles_paginator.per_page -1 }}">
-            {% endif %}
-            <li><article class="hentry">
-                <header>
-                    <h1><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
-                           title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h1>
-                </header>
-
-                <div class="entry-content">
-                {% include 'article_infos.html' %}
-                {{ article.summary }}
-                <a class="readmore" href="{{ SITEURL }}/{{ article.url }}">read more</a>
-                {% include 'comments.html' %}
-                </div><!-- /.entry-content -->
-            </article></li>
-        {% endif %}
-        {% if loop.last %}
-            {% if loop.length > 1 or articles_page.has_other_pages() %}
-                </ol><!-- /#posts-list -->
-                {% if articles_page.has_other_pages() %}
-                    {% include 'pagination.html' %}
+        {% if loop.first %}
+        <section id="content" class="body">
+            <ol id="posts-list" class="hfeed" start="{{ articles_paginator.per_page -1 }}">
                 {% endif %}
-                </section><!-- /#content -->
+                <li>
+                    <article class="hentry">
+                        <header>
+                            <h1><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
+                           title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h1>
+                        </header>
+
+                        <div class="entry-content">
+                            {% include 'article_infos.html' %}
+                            {{ article.summary }}
+                            <a class="readmore" href="{{ SITEURL }}/{{ article.url }}">read more</a>
+                            {% include 'comments.html' %}
+                        </div>
+                        <!-- /.entry-content -->
+                    </article>
+                </li>
+                {% endif %}
+                {% if loop.last %}
+                {% if loop.length > 1 or articles_page.has_other_pages() %}
+            </ol>
+            <!-- /#posts-list -->
+            {% if articles_page.has_other_pages() %}
+            {% include 'pagination.html' %}
             {% endif %}
+        </section>
+        <!-- /#content -->
         {% endif %}
-    {% endfor %}
-{% else %}
-<section id="content" class="body">
-<h2>Pages</h2>
-    {% for page in pages %}
-        <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
-    {% endfor %}
-</section>
-{% endif %}
+        {% endif %}
+        {% endfor %}
+        {% else %}
+        <section id="content" class="body">
+            <h2>Pages</h2>
+            {% for page in pages %}
+            <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
+            {% endfor %}
+        </section>
+        {% endif %}
 {% endblock content %}

--- a/pelican/themes/notmyidea/templates/page.html
+++ b/pelican/themes/notmyidea/templates/page.html
@@ -5,7 +5,7 @@
 {% block extra_head %}
 {% import 'translations.html' as translations with context %}
 {% if translations.entry_hreflang(page) %}
-  {{ translations.entry_hreflang(page) }}
+    {{ translations.entry_hreflang(page) }}
 {% endif %}
 {% endblock %}
 

--- a/pelican/themes/notmyidea/templates/period_archives.html
+++ b/pelican/themes/notmyidea/templates/period_archives.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
 <section id="content" class="body">
-<h1>Archives for {{ period | reverse | join(' ') }}</h1>
+    <h1>Archives for {{ period | reverse | join(' ') }}</h1>
 
-<dl>
-{% for article in dates %}
-    <dt>{{ article.locale_date }}</dt>
-    <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
-{% endfor %}
-</dl>
+    <dl>
+    {% for article in dates %}
+        <dt>{{ article.locale_date }}</dt>
+        <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
+    {% endfor %}
+    </dl>
 </section>
 {% endblock %}

--- a/pelican/themes/notmyidea/templates/taglist.html
+++ b/pelican/themes/notmyidea/templates/taglist.html
@@ -1,1 +1,3 @@
-{% if article.tags %}<p>tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag | escape }}</a> {% endfor %}</p>{% endif %}
+{% if article.tags %}
+<p>tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag | escape }}</a> {% endfor %}</p>
+{% endif %}

--- a/pelican/themes/notmyidea/templates/translations.html
+++ b/pelican/themes/notmyidea/templates/translations.html
@@ -1,6 +1,6 @@
 {% macro translations_for(article) %}
 {% if article.translations %}
-Translations:
+    Translations:
     {% for translation in article.translations %}
         <a href="{{ SITEURL }}/{{ translation.url }}" hreflang="{{ translation.lang }}">{{ translation.lang }}</a>
     {% endfor %}
@@ -9,8 +9,8 @@ Translations:
 
 {% macro entry_hreflang(entry) %}
 {% if entry.translations %}
-  {% for translation in entry.translations %}
-    <link rel="alternate" hreflang="{{ translation.lang }}" href="{{ SITEURL }}/{{ translation.url }}">
-  {% endfor %}
+    {% for translation in entry.translations %}
+        <link rel="alternate" hreflang="{{ translation.lang }}" href="{{ SITEURL }}/{{ translation.url }}">
+    {% endfor %}
 {% endif %}
 {% endmacro %}

--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -4,64 +4,65 @@
 {% block title %}{{ SITENAME }} - {{ article.title }}{% endblock %}
 
 {% block head %}
-  {{ super() }}
+{{ super() }}
 
-  {% import 'translations.html' as translations with context %}
-  {% if translations.entry_hreflang(article) %}
+{% import 'translations.html' as translations with context %}
+{% if translations.entry_hreflang(article) %}
     {{ translations.entry_hreflang(article) }}
-  {% endif %}
+{% endif %}
 
-  {% if article.description %}
+{% if article.description %}
     <meta name="description" content="{{article.description}}" />
-  {% endif %}
+{% endif %}
 
-  {% for tag in article.tags %}
+{% for tag in article.tags %}
     <meta name="tags" content="{{tag}}" />
-  {% endfor %}
+{% endfor %}
 
 {% endblock %}
 
 {% block content %}
 <section id="content" class="body">
-  <header>
-    <h2 class="entry-title">
-      <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
-         title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2>
- {% import 'translations.html' as translations with context %}
- {{ translations.translations_for(article) }}
-  </header>
-  <footer class="post-info">
-    <time class="published" datetime="{{ article.date.isoformat() }}">
-      {{ article.locale_date }}
-    </time>
-    {% if article.modified %}
-    <time class="modified" datetime="{{ article.modified.isoformat() }}">
-      {{ article.locale_modified }}
-    </time>
-    {% endif %}
-    {% if article.authors %}
-    <address class="vcard author">
-      By {% for author in article.authors %}
-          <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
-        {% endfor %}
-    </address>
-    {% endif %}
-    {% if article.category %}
-    <div class="category">
-        Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
-    </div>
-    {% endif %}
-    {% if article.tags %}
-    <div class="tags">
-        Tags:
-        {% for tag in article.tags %}
-            <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
-        {% endfor %}
-    </div>
-    {% endif %}
-  </footer><!-- /.post-info -->
-  <div class="entry-content">
-    {{ article.content }}
-  </div><!-- /.entry-content -->
+    <header>
+        <h2 class="entry-title">
+            <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
+               title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a>
+        </h2>
+        {% import 'translations.html' as translations with context %}
+        {{ translations.translations_for(article) }}
+    </header>
+    <footer class="post-info">
+        <time class="published" datetime="{{ article.date.isoformat() }}">
+            {{ article.locale_date }}
+        </time>
+        {% if article.modified %}
+            <time class="modified" datetime="{{ article.modified.isoformat() }}">
+                {{ article.locale_modified }}
+            </time>
+        {% endif %}
+        {% if article.authors %}
+            <address class="vcard author">
+                By {% for author in article.authors %}
+                <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
+                {% endfor %}
+            </address>
+        {% endif %}
+        {% if article.category %}
+            <div class="category">
+                Category: <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
+            </div>
+        {% endif %}
+        {% if article.tags %}
+            <div class="tags">
+                Tags:
+                {% for tag in article.tags %}
+                    <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </footer><!-- /.post-info -->
+    <div class="entry-content">
+        {{ article.content }}
+    </div><!-- /.entry-content -->
 </section>
 {% endblock %}

--- a/pelican/themes/simple/templates/author.html
+++ b/pelican/themes/simple/templates/author.html
@@ -5,4 +5,3 @@
 {% block content_title %}
 <h2>Articles by {{ author }}</h2>
 {% endblock %}
-

--- a/pelican/themes/simple/templates/authors.html
+++ b/pelican/themes/simple/templates/authors.html
@@ -3,10 +3,10 @@
 {% block title %}{{ SITENAME }} - Authors{% endblock %}
 
 {% block content %}
-    <h1>Authors on {{ SITENAME }}</h1>
-    <ul>
-    {% for author, articles in authors|sort %}
-        <li><a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a> ({{ articles|count }})</li>
-    {% endfor %}
-    </ul>
+<h1>Authors on {{ SITENAME }}</h1>
+<ul>
+{% for author, articles in authors|sort %}
+    <li><a href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a> ({{ articles|count }})</li>
+{% endfor %}
+</ul>
 {% endblock %}

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -1,62 +1,65 @@
 <!DOCTYPE html>
 <html lang="{% block html_lang %}{{ DEFAULT_LANG }}{% endblock html_lang %}">
-<head>
+    <head>
         {% block head %}
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta charset="utf-8" />
         {% if FEED_ALL_ATOM %}
-        <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
         {% endif %}
         {% if FEED_ALL_RSS %}
-        <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Full RSS Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_RSS_URL %}{{ FEED_ALL_RSS_URL }}{% else %}{{ FEED_ALL_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Full RSS Feed" />
         {% endif %}
         {% if FEED_ATOM %}
-        <link href="{{ FEED_DOMAIN }}/{%if FEED_ATOM_URL %}{{ FEED_ATOM_URL }}{% else %}{{ FEED_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
+            <link href="{{ FEED_DOMAIN }}/{%if FEED_ATOM_URL %}{{ FEED_ATOM_URL }}{% else %}{{ FEED_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
         {% endif %}
         {% if FEED_RSS %}
-        <link href="{{ FEED_DOMAIN }}/{% if FEED_RSS_URL %}{{ FEED_RSS_URL }}{% else %}{{ FEED_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if FEED_RSS_URL %}{{ FEED_RSS_URL }}{% else %}{{ FEED_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
         {% endif %}
         {% if CATEGORY_FEED_ATOM and category %}
-        <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_ATOM_URL %}{{ CATEGORY_FEED_ATOM_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_ATOM|format(category.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_ATOM_URL %}{{ CATEGORY_FEED_ATOM_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_ATOM|format(category.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
         {% endif %}
         {% if CATEGORY_FEED_RSS and category %}
-        <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_RSS_URL %}{{ CATEGORY_FEED_RSS_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_RSS|format(category.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_RSS_URL %}{{ CATEGORY_FEED_RSS_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_RSS|format(category.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
         {% endif %}
         {% if TAG_FEED_ATOM and tag %}
-        <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_ATOM_URL %}{{ TAG_FEED_ATOM_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_ATOM|format(tag.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_ATOM_URL %}{{ TAG_FEED_ATOM_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_ATOM|format(tag.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
         {% endif %}
         {% if TAG_FEED_RSS and tag %}
-        <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_RSS_URL %}{{ TAG_FEED_RSS_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_RSS|format(tag.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
+            <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_RSS_URL %}{{ TAG_FEED_RSS_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_RSS|format(tag.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
         {% endif %}
         {% endblock head %}
-</head>
+    </head>
 
-<body id="index" class="home">
+    <body id="index" class="home">
         <header id="banner" class="body">
-                <h1><a href="{{ SITEURL }}/">{{ SITENAME }} <strong>{{ SITESUBTITLE }}</strong></a></h1>
+            <h1><a href="{{ SITEURL }}/">{{ SITENAME }} <strong>{{ SITESUBTITLE }}</strong></a></h1>
         </header><!-- /#banner -->
-        <nav id="menu"><ul>
-        {% for title, link in MENUITEMS %}
-            <li><a href="{{ link }}">{{ title }}</a></li>
-        {% endfor %}
-        {% if DISPLAY_PAGES_ON_MENU %}
-          {% for p in pages %}
-            <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
-          {% endfor %}
-        {% endif %}
-        {% if DISPLAY_CATEGORIES_ON_MENU %}
-          {% for cat, null in categories %}
-            <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
-          {% endfor %}
-        {% endif %}
-        </ul></nav><!-- /#menu -->
+        <nav id="menu">
+            <ul>
+            {% for title, link in MENUITEMS %}
+                <li><a href="{{ link }}">{{ title }}</a></li>
+            {% endfor %}
+            {% if DISPLAY_PAGES_ON_MENU %}
+                {% for p in pages %}
+                    <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
+                {% endfor %}
+            {% else %}
+                {% if DISPLAY_CATEGORIES_ON_MENU %}
+                    {% for cat, null in categories %}
+                        <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
+                    {% endfor %}
+                {% endif %}
+            {% endif %}
+            </ul>
+        </nav><!-- /#menu -->
         {% block content %}
         {% endblock %}
         <footer id="contentinfo" class="body">
-                <address id="about" class="vcard body">
+            <address id="about" class="vcard body">
                 Proudly powered by <a href="http://getpelican.com/">Pelican</a>,
                 which takes great advantage of <a href="http://python.org">Python</a>.
-                </address><!-- /#about -->
+            </address><!-- /#about -->
         </footer><!-- /#contentinfo -->
-</body>
+    </body>
 </html>

--- a/pelican/themes/simple/templates/categories.html
+++ b/pelican/themes/simple/templates/categories.html
@@ -3,10 +3,10 @@
 {% block title %}{{ SITENAME }} - Categories{% endblock %}
 
 {% block content %}
-    <h1>Categories on {{ SITENAME }}</h1>
-    <ul>
-    {% for category, articles in categories|sort %}
-        <li><a href="{{ SITEURL }}/{{ category.url }}">{{ category }}</a> ({{ articles|count }})</li>
-    {% endfor %}
-    </ul>
+<h1>Categories on {{ SITENAME }}</h1>
+<ul>
+{% for category, articles in categories|sort %}
+    <li><a href="{{ SITEURL }}/{{ category.url }}">{{ category }}</a> ({{ articles|count }})</li>
+{% endfor %}
+</ul>
 {% endblock %}

--- a/pelican/themes/simple/templates/category.html
+++ b/pelican/themes/simple/templates/category.html
@@ -5,4 +5,3 @@
 {% block content_title %}
 <h2>Articles in the {{ category }} category</h2>
 {% endblock %}
-

--- a/pelican/themes/simple/templates/index.html
+++ b/pelican/themes/simple/templates/index.html
@@ -1,28 +1,33 @@
 {% extends "base.html" %}
 {% block content %}
 <section id="content">
-{% block content_title %}
-<h2>All articles</h2>
-{% endblock %}
+    {% block content_title %}
+    <h2>All articles</h2>
+    {% endblock %}
 
-<ol id="post-list">
-{% for article in articles_page.object_list %}
-        <li><article class="hentry">
-                <header> <h2 class="entry-title"><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2> </header>
+    <ol id="post-list">
+    {% for article in articles_page.object_list %}
+        <li>
+            <article class="hentry">
+                <header>
+                    <h2 class="entry-title"><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2>
+                </header>
                 <footer class="post-info">
                     <time class="published" datetime="{{ article.date.isoformat() }}"> {{ article.locale_date }} </time>
-                    <address class="vcard author">By
-                    {% for author in article.authors %}
-                        <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
-                    {% endfor %}
+                    <address class="vcard author">
+                        By
+                        {% for author in article.authors %}
+                            <a class="url fn" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
+                        {% endfor %}
                     </address>
                 </footer><!-- /.post-info -->
                 <div class="entry-content"> {{ article.summary }} </div><!-- /.entry-content -->
-        </article></li>
-{% endfor %}
-</ol><!-- /#posts-list -->
-{% if articles_page.has_other_pages() %}
-    {% include 'pagination.html' %}
-{% endif %}
+            </article>
+        </li>
+    {% endfor %}
+    </ol><!-- /#posts-list -->
+    {% if articles_page.has_other_pages() %}
+        {% include 'pagination.html' %}
+    {% endif %}
 </section><!-- /#content -->
 {% endblock content %}

--- a/pelican/themes/simple/templates/page.html
+++ b/pelican/themes/simple/templates/page.html
@@ -4,24 +4,22 @@
 {% block title %}{{ SITENAME }} - {{ page.title }}{%endblock%}
 
 {% block head %}
-  {{ super() }}
+{{ super() }}
 
-  {% import 'translations.html' as translations with context %}
-  {% if translations.entry_hreflang(page) %}
+{% import 'translations.html' as translations with context %}
+{% if translations.entry_hreflang(page) %}
     {{ translations.entry_hreflang(page) }}
-  {% endif %}
+{% endif %}
 {% endblock %}
 
 {% block content %}
-    <h1>{{ page.title }}</h1>
-    {% import 'translations.html' as translations with context %}
-    {{ translations.translations_for(page) }}
+<h1>{{ page.title }}</h1>
+{% import 'translations.html' as translations with context %}
+{{ translations.translations_for(page) }}
 
-    {{ page.content }}
+{{ page.content }}
 
-    {% if page.modified %}
-        <p>
-        Last updated: {{ page.locale_modified }}
-        </p>
-    {% endif %}
+{% if page.modified %}
+    <p>Last updated: {{ page.locale_modified }}</p>
+{% endif %}
 {% endblock %}

--- a/pelican/themes/simple/templates/tags.html
+++ b/pelican/themes/simple/templates/tags.html
@@ -3,10 +3,10 @@
 {% block title %}{{ SITENAME }} - Tags{% endblock %}
 
 {% block content %}
-    <h1>Tags for {{ SITENAME }}</h1>
-    <ul>
-    {% for tag, articles in tags|sort %}
-        <li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a> ({{ articles|count }})</li>
-    {% endfor %}
-    </ul>
+<h1>Tags for {{ SITENAME }}</h1>
+<ul>
+{% for tag, articles in tags|sort %}
+    <li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a> ({{ articles|count }})</li>
+{% endfor %}
+</ul>
 {% endblock %}

--- a/pelican/themes/simple/templates/translations.html
+++ b/pelican/themes/simple/templates/translations.html
@@ -1,16 +1,16 @@
 {% macro translations_for(article) %}
-{% if article.translations %}
-Translations:
-{% for translation in article.translations %}
-<a href="{{ SITEURL }}/{{ translation.url }}" hreflang="{{ translation.lang }}">{{ translation.lang }}</a>
-{% endfor %}
-{% endif %}
+    {% if article.translations %}
+        Translations:
+        {% for translation in article.translations %}
+            <a href="{{ SITEURL }}/{{ translation.url }}" hreflang="{{ translation.lang }}">{{ translation.lang }}</a>
+        {% endfor %}
+    {% endif %}
 {% endmacro %}
 
 {% macro entry_hreflang(entry) %}
 {% if entry.translations %}
-  {% for translation in entry.translations %}
-    <link rel="alternate" hreflang="{{ translation.lang }}" href="{{ SITEURL }}/{{ translation.url }}">
-  {% endfor %}
+    {% for translation in entry.translations %}
+        <link rel="alternate" hreflang="{{ translation.lang }}" href="{{ SITEURL }}/{{ translation.url }}">
+    {% endfor %}
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Description

This PR normalizes the formatting of the Jinja templates in the `simple` and `notmyidea` themes, making them easier to read and indentation rules clearer for future contributors. The diff is huge, but the changes are entirely mechanical/whitespace-related. As far as I'm aware, only the following changes are applied.

1. 4-space indentation (there was a small amount of 2-space indentation). No "exceptions" like content inside `<body>` or `<section>`.
1. Conform to the conventions that are used in the examples in the [official Jinja template documentation](http://jinja.pocoo.org/docs/2.10/templates/). I have listed the rules as I understand them in the commit message of 59750b3.
1. Multiline nested tags like
    ```html
    <tag1><tag2>
        ... nested content ...
    </tag2></tag1>
    ```
    are broken up into
    ```html
    <tag1>
        <tag2>
            ... nested content ...
        </tag2>
    </tag1>
    ```

    but nested tags on one line like
    ```html
    <li><a href="...">...</a></li>
    ```

    are untouched/allowed.

Other stuff like CSS is untouched.

To maintain your sanity, I would recommend focusing on just the templates in the themes themselves (grouped together at the bottom of the diffs and also separated into one commit for each theme) and not the html output, then doing a pass with `git diff -w` or checking "Hide whitepsace changes" on the Github diff to ignore whitespace changes (which will only show changes like rule 3).

Note that this doesn't make the output html pretty at all due to the fact that nested Jinja templates are not aware of indentation level at all.

## Testing

I tested this by generating the output for both the simple and notmyidea themes and running the diff tests, then also inspecting the output in a browser to make sure everything looks the same.

## Implementation note

Unfortunately, there doesn't seem to be a good standalone Jinja template formatter (the most recommended option I found when searching was [atom-beautify](https://atom.io/packages/atom-beautify), which is part of Atom, of course). I used the tool [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier), but had to apply a lot of Jinja-specific rules manually on top.