### PR TITLE
Control pagination per template

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -755,10 +755,6 @@ Template pages
    ``DIRECT_TEMPLATES`` are searched for over paths maintained in
    ``THEME_TEMPLATES_OVERRIDES``.
 
-.. data:: PAGINATED_DIRECT_TEMPLATES = ['index']
-
-   Provides the direct templates that should be paginated.
-
 
 Metadata
 ========
@@ -999,6 +995,11 @@ You can use the following settings to configure the pagination.
 
    The maximum number of articles to include on a page, not including orphans.
    False to disable pagination.
+
+.. data:: PAGINATED_TEMPLATES = {'index': None, 'tag': None, 'category': None, 'author': None}
+
+   The templates to use pagination with, and the number of articles to include
+   on a page. If this value is ``None``, it defaults to ``DEFAULT_PAGINATION``.
 
 .. data:: PAGINATION_PATTERNS
 

--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -17,15 +17,14 @@ PaginationRule = namedtuple(
 
 
 class Paginator(object):
-    def __init__(self, name, url, object_list, settings):
+    def __init__(self, name, url, object_list, settings, per_page=None):
         self.name = name
         self.url = url
         self.object_list = object_list
         self.settings = settings
-
-        if settings.get('DEFAULT_PAGINATION'):
-            self.per_page = settings.get('DEFAULT_PAGINATION')
-            self.orphans = settings.get('DEFAULT_ORPHANS')
+        if per_page:
+            self.per_page = per_page
+            self.orphans = settings['DEFAULT_ORPHANS']
         else:
             self.per_page = len(object_list)
             self.orphans = 0

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -108,7 +108,8 @@ DEFAULT_CONFIG = {
     'DEFAULT_LANG': 'en',
     'DIRECT_TEMPLATES': ['index', 'tags', 'categories', 'authors', 'archives'],
     'THEME_TEMPLATES_OVERRIDES': [],
-    'PAGINATED_DIRECT_TEMPLATES': ['index'],
+    'PAGINATED_TEMPLATES': {'index': None, 'tag': None, 'category': None,
+                            'author': None},
     'PELICAN_CLASS': 'pelican.Pelican',
     'DEFAULT_DATE_FORMAT': '%a %d %B %Y',
     'DATE_FORMATS': {},
@@ -454,5 +455,15 @@ def configure_settings(settings):
             if doc:
                 message += ', see {} for details'.format(doc)
             logger.warning(message)
+
+    if 'PAGINATED_DIRECT_TEMPLATES' in settings:
+        message = 'The {} setting has been removed in favor of {}'.format(
+            'PAGINATED_DIRECT_TEMPLATES', 'PAGINATED_TEMPLATES')
+        logger.warning(message)
+
+        for t in settings['PAGINATED_DIRECT_TEMPLATES']:
+            if t not in settings['PAGINATED_TEMPLATES']:
+                settings['PAGINATED_TEMPLATES'][t] = None
+        del settings['PAGINATED_DIRECT_TEMPLATES']
 
     return settings

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -337,8 +337,10 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_direct_templates(write)
         write.assert_called_with("archives.html",
                                  generator.get_template("archives"), settings,
-                                 blog=True, paginated={}, page_name='archives',
-                                 url="archives.html")
+                                 articles=generator.articles,
+                                 dates=generator.dates, blog=True,
+                                 template_name='archives',
+                                 page_name='archives', url="archives.html")
 
     @unittest.skipUnless(MagicMock, 'Needs Mock module')
     def test_direct_templates_save_as_url_modified(self):
@@ -355,7 +357,9 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_direct_templates(write)
         write.assert_called_with("archives/index.html",
                                  generator.get_template("archives"), settings,
-                                 blog=True, paginated={},
+                                 articles=generator.articles,
+                                 dates=generator.dates, blog=True,
+                                 template_name='archives',
                                  page_name='archives/index',
                                  url="archives/")
 
@@ -404,13 +408,15 @@ class TestArticlesGenerator(unittest.TestCase):
         write = MagicMock()
         generator.generate_period_archives(write)
         dates = [d for d in generator.dates if d.date.year == 1970]
+        articles = [d for d in generator.articles if d.date.year == 1970]
         self.assertEqual(len(dates), 1)
         # among other things it must have at least been called with this
         settings["period"] = (1970,)
         write.assert_called_with("posts/1970/index.html",
                                  generator.get_template("period_archives"),
-                                 settings,
-                                 blog=True, dates=dates, url="posts/1970/")
+                                 settings, blog=True, articles=articles,
+                                 dates=dates, template_name='period_archives',
+                                 url="posts/1970/")
 
         del settings["period"]
         settings['MONTH_ARCHIVE_SAVE_AS'] = \
@@ -425,13 +431,16 @@ class TestArticlesGenerator(unittest.TestCase):
         generator.generate_period_archives(write)
         dates = [d for d in generator.dates
                  if d.date.year == 1970 and d.date.month == 1]
+        articles = [d for d in generator.articles
+                    if d.date.year == 1970 and d.date.month == 1]
         self.assertEqual(len(dates), 1)
         settings["period"] = (1970, "January")
         # among other things it must have at least been called with this
         write.assert_called_with("posts/1970/Jan/index.html",
                                  generator.get_template("period_archives"),
-                                 settings,
-                                 blog=True, dates=dates, url="posts/1970/Jan/")
+                                 settings, blog=True, articles=articles,
+                                 dates=dates, template_name='period_archives',
+                                 url="posts/1970/Jan/")
 
         del settings["period"]
         settings['DAY_ARCHIVE_SAVE_AS'] = \
@@ -450,13 +459,19 @@ class TestArticlesGenerator(unittest.TestCase):
             d.date.month == 1 and
             d.date.day == 1
         ]
+        articles = [
+            d for d in generator.articles if
+            d.date.year == 1970 and
+            d.date.month == 1 and
+            d.date.day == 1
+        ]
         self.assertEqual(len(dates), 1)
         settings["period"] = (1970, "January", 1)
         # among other things it must have at least been called with this
         write.assert_called_with("posts/1970/Jan/01/index.html",
                                  generator.get_template("period_archives"),
-                                 settings,
-                                 blog=True, dates=dates,
+                                 settings, blog=True, articles=articles,
+                                 dates=dates, template_name='period_archives',
                                  url="posts/1970/Jan/01/")
         locale.setlocale(locale.LC_ALL, old_locale)
 

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -66,13 +66,12 @@ class TestPage(unittest.TestCase):
             (1, '/{url}', '{base_name}/index.html'),
             (2, '/{url}{number}/', '{base_name}/{number}/index.html')
         ]]
-        settings['DEFAULT_PAGINATION'] = 1
 
         self.page_kwargs['metadata']['author'] = Author('Blogger', settings)
         object_list = [Article(**self.page_kwargs),
                        Article(**self.page_kwargs)]
         paginator = Paginator('blog/index.html', '//blog.my.site/',
-                              object_list, settings)
+                              object_list, settings, 1)
         page1 = paginator.page(1)
         self.assertEqual(page1.save_as, 'blog/index.html')
         self.assertEqual(page1.url, '//blog.my.site/')

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -177,6 +177,15 @@ class TestSettingsConfiguration(unittest.TestCase):
                          ['/foo/bar', '/ha'])
         self.assertNotIn('EXTRA_TEMPLATES_PATHS', settings)
 
+    def test_deprecated_paginated_direct_templates(self):
+        settings = self.settings
+        settings['PAGINATED_DIRECT_TEMPLATES'] = ['index', 'archives']
+        settings['PAGINATED_TEMPLATES'] = {'index': 10, 'category': None}
+        settings = configure_settings(settings)
+        self.assertEqual(settings['PAGINATED_TEMPLATES'],
+                         {'index': 10, 'category': None, 'archives': None})
+        self.assertNotIn('PAGINATED_DIRECT_TEMPLATES', settings)
+
     def test_theme_and_extra_templates_exception(self):
         settings = self.settings
         settings['EXTRA_TEMPLATES_PATHS'] = ['/ha']


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican/issues/735

* Enables different pagination values per template
* Enables pagination for period archives (useful when `period_archives.html` inherits from `index.html`)
* Enables control over pagination for tags, categories and authors independently of `index.html`