### PR TITLE
Add pandoc2 support to travis/tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,15 @@ env:
   - TOX_ENV=py27
   - TOX_ENV=py34
   - TOX_ENV=py35
+  - TOX_ENV=py27-pandoc2
+  - TOX_ENV=py34-pandoc2
+  - TOX_ENV=py35-pandoc2
 matrix:
   include:
     - python: 3.6
-      env:
-      - TOX_ENV=py36
+      env: TOX_ENV=py36
+    - python: 3.6
+      env: TOX_ENV=py36-pandoc2
 addons:
   apt_packages:
     - pandoc
@@ -20,6 +24,7 @@ before_install:
   - sudo locale-gen fr_FR.UTF-8 tr_TR.UTF-8
 install:
   - pip install tox==2.5.0
+  - pip install pyopenssl ndg-httpsclient pyasn1
 script: tox -e $TOX_ENV
 notifications:
   irc:

--- a/scripts/install-pandoc2.sh
+++ b/scripts/install-pandoc2.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -ex
+
+PANDOC_VER=2.2.1
+PANDOC_TGZ=pandoc-${PANDOC_VER}-linux.tar.gz
+PARENT_DIR=${1:-.}
+PANDOC_BIN=${PARENT_DIR}/pandoc2/bin/pandoc
+
+if [ -x "$PANDOC_BIN" ]; then
+    echo "pandoc2 already installed"
+    exit 0
+fi
+
+cd "$PARENT_DIR"
+
+wget "https://github.com/jgm/pandoc/releases/download/${PANDOC_VER}/${PANDOC_TGZ}" -O "${PANDOC_TGZ}"
+
+tar -xzvf "${PANDOC_TGZ}"
+
+rm -rf pandoc2
+
+mv "pandoc-${PANDOC_VER}" pandoc2
+
+[ -x "$PANDOC_BIN" ] || exit 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py{27,34,35,36},docs,flake8
+envlist =
+    docs
+    flake8
+    py{27,34,35,36}
+    py{27,34,35,36}-pandoc2
 
 [testenv]
 basepython =
@@ -16,7 +20,10 @@ deps =
     coveralls
     pygments==2.1.3
 
+whitelist_externals=ln
 commands =
+    pandoc2: {toxinidir}/scripts/install-pandoc2.sh /tmp
+    pandoc2: ln -fs /tmp/pandoc2/bin/pandoc {envbindir}/pandoc
     {envpython} --version
     nosetests -sv --with-coverage --cover-package=pelican pelican
     - coveralls


### PR DESCRIPTION
- Install pandoc2 in travis and decide whether to use it or not in tox.
- A symbolic link is created in tox, due to not being able to make
  setenv work like this: `setenv = PATH={toxinidir}:{env:PATH}`
- Install pandoc2 only on pyxx-pandoc2
- Add new inclusion to travis matrix combination
- A build failed with InsecurePlatformWarning on Travis.