### PR TITLE
Add Blogger XML backup importer

### DIFF
--- a/docs/importer.rst
+++ b/docs/importer.rst
@@ -9,10 +9,11 @@ Description
 ``pelican-import`` is a command-line tool for converting articles from other
 software to reStructuredText or Markdown. The supported import formats are:
 
-- WordPress XML export
+- Blogger XML export
 - Dotclear export
 - Posterous API
 - Tumblr API
+- WordPress XML export
 - RSS/Atom feed
 
 The conversion from HTML to reStructuredText or Markdown relies on `Pandoc`_.
@@ -40,8 +41,8 @@ Usage
 
 ::
 
-    pelican-import [-h] [--wpfile] [--dotclear] [--posterous] [--tumblr] [--feed] [-o OUTPUT]
-                   [-m MARKUP] [--dir-cat] [--dir-page] [--strip-raw] [--wp-custpost]
+    pelican-import [-h] [--blogger] [--dotclear] [--posterous] [--tumblr] [--wpfile] [--feed]
+                   [-o OUTPUT] [-m MARKUP] [--dir-cat] [--dir-page] [--strip-raw] [--wp-custpost]
                    [--wp-attach] [--disable-slugs] [-e EMAIL] [-p PASSWORD] [-b BLOGNAME]
                    input|api_token|api_key
 
@@ -57,10 +58,11 @@ Optional arguments
 ------------------
 
   -h, --help            Show this help message and exit
-  --wpfile              WordPress XML export (default: False)
+  --blogger             Blogger XML export (default: False)
   --dotclear            Dotclear export (default: False)
   --posterous           Posterous API (default: False)
   --tumblr              Tumblr API (default: False)
+  --wpfile              WordPress XML export (default: False)
   --feed                Feed to parse (default: False)
   -o OUTPUT, --output OUTPUT
                         Output path (default: content)
@@ -70,7 +72,8 @@ Optional arguments
   --dir-cat             Put files in directories with categories name
                         (default: False)
   --dir-page            Put files recognised as pages in "pages/" sub-
-                          directory (wordpress import only) (default: False)
+                          directory (blogger and wordpress import only)
+                          (default: False)
   --filter-author       Import only post from the specified author
   --strip-raw           Strip raw HTML code that can't be converted to markup
                         such as flash embeds or iframes (wordpress import
@@ -102,9 +105,9 @@ Optional arguments
 Examples
 ========
 
-For WordPress::
+For Blogger::
 
-    $ pelican-import --wpfile -o ~/output ~/posts.xml
+    $ pelican-import --blogger -o ~/output ~/posts.xml
 
 For Dotclear::
 
@@ -117,6 +120,10 @@ for Posterous::
 For Tumblr::
 
     $ pelican-import --tumblr -o ~/output --blogname=<blogname> <api_token>
+
+For WordPress::
+
+    $ pelican-import --wpfile -o ~/output ~/posts.xml
 
 Tests
 =====

--- a/pelican/tests/content/bloggerexport.xml
+++ b/pelican/tests/content/bloggerexport.xml
@@ -1,0 +1,1067 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="https://www.blogger.com/styles/atom.css" type="text/css"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:gd="http://schemas.google.com/g/2005" xmlns:georss="http://www.georss.org/georss" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/" xmlns:thr="http://purl.org/syndication/thread/1.0">
+ <id>tag:blogger.com,1999:blog-6303278419262689239.archive
+ </id>
+ <updated>2018-08-02T12:38:27.320-07:00
+ </updated>
+ <title type="text">Notes of a Young Doctor </title>
+ <link href="https://www.blogger.com/feeds/6303278419262689239/archive" rel="http://schemas.google.com/g/2005#feed" type="application/atom+xml"/>
+ <link href="https://www.blogger.com/feeds/6303278419262689239/archive" rel="self" type="application/atom+xml"/>
+ <link href="https://www.blogger.com/feeds/6303278419262689239/archive" rel="http://schemas.google.com/g/2005#post" type="application/atom+xml"/>
+ <link href="http://youngdoctornotes.blogspot.com/" rel="alternate" type="text/html"/>
+ <author>
+  <name>Mikhail Afanasyevich Bulgakov
+  </name>
+  <uri>https://www.blogger.com/profile/000082957
+  </uri>
+  <email>noreply@blogger.com
+  </email>
+  <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+ </author>
+ <generator uri="https://www.blogger.com" version="7.00">Blogger
+ </generator>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.layout</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#template"/>
+  <title type="text">Template: Notes of a Young Doctor</title>
+  <content type="text">[Over 2000 lines of mostly css that we don't need here.]</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/template/default" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/template/default" rel="self" type="application/atom+xml"/>
+  <link href="http://youngdoctornotes.blogspot.com/" rel="alternate" type="text/html"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_PUBLISHING_MODE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het type publicatie voor deze blog.</title>
+  <content type="text">PUBLISH_MODE_BLOGSPOT</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_PUBLISHING_MODE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_PUBLISHING_MODE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_ADMIN_PERMISSION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De lijst van e-mails van beheerders voor de blog.</title>
+  <content type="text">mikhail.afanasyevich.bulgakov@gmail.com</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ADMIN_PERMISSION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ADMIN_PERMISSION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_ADULT_CONTENT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of deze blog content voor volwassenen bevat</title>
+  <content type="text">false</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ADULT_CONTENT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ADULT_CONTENT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_ALTERNATE_JSRENDER_ALLOWED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of alternatieve weergaven in JavaScript zijn toegestaan</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ALTERNATE_JSRENDER_ALLOWED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ALTERNATE_JSRENDER_ALLOWED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_ANALYTICS_ACCOUNT_NUMBER</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Google Analytics-accountnummer voor een blog</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ANALYTICS_ACCOUNT_NUMBER" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ANALYTICS_ACCOUNT_NUMBER" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_ARCHIVE_DATE_FORMAT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het getal van de datumnotatie voor de archiefindex</title>
+  <content type="text">9</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ARCHIVE_DATE_FORMAT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ARCHIVE_DATE_FORMAT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_ARCHIVE_FREQUENCY</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hoe vaak deze blog moet worden gearchiveerd</title>
+  <content type="text">MONTHLY</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ARCHIVE_FREQUENCY" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_ARCHIVE_FREQUENCY" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_AUTHOR_PERMISSION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De lijst van e-mails van auteurs die toestemming hebben om te publiceren.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_AUTHOR_PERMISSION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_AUTHOR_PERMISSION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_BACKLINKS_ALLOWED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of reactiebacklinks op de blog moeten worden getoond</title>
+  <content type="text">false</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_BACKLINKS_ALLOWED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_BACKLINKS_ALLOWED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_BY_POST_ARCHIVING</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of iedere post moet worden voorzien van een archiefpagina</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_BY_POST_ARCHIVING" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_BY_POST_ARCHIVING" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_ACCESS</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Wie kan reacties achterlaten</title>
+  <content type="text">BLOGGERS</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_ACCESS" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_ACCESS" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_CAPTCHA</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of personen die reacties geven, een Captcha (woordverificatie) moeten invullen</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_CAPTCHA" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_CAPTCHA" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_EMAIL</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Lijst met e-mailadressen om meldingen van nieuwe reacties naar te sturen</title>
+  <content type="text">mikhail.afanasyevich.bulgakov@gmail.com</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_EMAIL" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_EMAIL" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_FEED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het type feed dat voor blogreacties moet worden gegeven</title>
+  <content type="text">FULL</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_FEED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_FEED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_FORM_LOCATION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Locatie van formulier voor blogreacties</title>
+  <content type="text">EMBEDDED_IFRAME</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_FORM_LOCATION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_FORM_LOCATION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_MESSAGE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Bericht bij blogreactie</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MESSAGE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MESSAGE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_MODERATION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of het modereren van reacties moet worden ingeschakeld</title>
+  <content type="text">DISABLED</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MODERATION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MODERATION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_MODERATION_DELAY</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Aantal dagen waarna nieuwe reacties in aanmerking komen voor moderaten</title>
+  <content type="text">14</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MODERATION_DELAY" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MODERATION_DELAY" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_MODERATION_EMAIL</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">E-mailadres waar meldingen binnenkomen over welke nieuwe reacties bewerkt of verwijderd moeten worden</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MODERATION_EMAIL" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_MODERATION_EMAIL" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENT_PROFILE_IMAGES</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of profielafbeeldingen in reacties moeten worden getoond</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_PROFILE_IMAGES" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENT_PROFILE_IMAGES" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENTS_ALLOWED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of er reacties moeten worden weergegeven</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENTS_ALLOWED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENTS_ALLOWED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_COMMENTS_TIME_STAMP_FORMAT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Getal van de tijdstempelnotatie voor reacties</title>
+  <content type="text">29</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENTS_TIME_STAMP_FORMAT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_COMMENTS_TIME_STAMP_FORMAT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_CONVERT_LINE_BREAKS</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of de regelscheidingen moeten worden omgezet in &lt;br /&gt;-tags in de posteditor</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CONVERT_LINE_BREAKS" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CONVERT_LINE_BREAKS" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_CUSTOM_ADS_TXT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De aangepaste ads.txt-content van de blog die aan advertentiezoekmachines wordt getoond.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ADS_TXT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ADS_TXT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_CUSTOM_ADS_TXT_ENABLED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Bepaalt of deze blog aangepaste ads.txt-content aan advertentiezoekmachines toont.</title>
+  <content type="text">false</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ADS_TXT_ENABLED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ADS_TXT_ENABLED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_CUSTOM_PAGE_NOT_FOUND</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De content die wordt weergegeven wanneer een post of pagina niet is gevonden.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_PAGE_NOT_FOUND" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_PAGE_NOT_FOUND" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_CUSTOM_ROBOTS_TXT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De aangepaste robots.txt-content van de blog wordt aan zoekmachines getoond.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ROBOTS_TXT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ROBOTS_TXT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_CUSTOM_ROBOTS_TXT_ENABLED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Bepaalt of deze blog aangepaste robots.txt-content aan zoekmachines toont.</title>
+  <content type="text">false</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ROBOTS_TXT_ENABLED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_CUSTOM_ROBOTS_TXT_ENABLED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_DATE_FORMAT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het getal van de datumnotatie voor koppen</title>
+  <content type="text">26</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DATE_FORMAT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DATE_FORMAT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_DEFAULT_BACKLINKS_MODE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Standaardbacklinks voor posts</title>
+  <content type="text">DEFAULT_HAVE_BACKLINKS</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DEFAULT_BACKLINKS_MODE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DEFAULT_BACKLINKS_MODE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_DEFAULT_COMMENTS_MODE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Standaardreactie voor posts</title>
+  <content type="text">DEFAULT_HAVE_COMMENTS</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DEFAULT_COMMENTS_MODE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DEFAULT_COMMENTS_MODE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_DESCRIPTION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Een beschrijving van de blog</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DESCRIPTION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_DESCRIPTION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_EMAIL_POST_LINKS</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of er een link moet worden weergegeven waarmee gebruikers posts kunnen e-mailen</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_EMAIL_POST_LINKS" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_EMAIL_POST_LINKS" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_FEED_REDIRECT_URL</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">URL waar verzoeken om postfeed naartoe worden geleid</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_FEED_REDIRECT_URL" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_FEED_REDIRECT_URL" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_FLOAT_ALIGNMENT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of zwevende uitlijning is ingeschakeld voor de blog</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_FLOAT_ALIGNMENT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_FLOAT_ALIGNMENT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_LOCALE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Taal voor deze blog</title>
+  <content type="text">nl</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_LOCALE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_LOCALE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_M2B_WHITELIST_EMAIL</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Lijst met e-mailadressen die via e-mail posts op de blog kunnen plaatsen.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_M2B_WHITELIST_EMAIL" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_M2B_WHITELIST_EMAIL" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_MAX_NUM</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Maximaal aantal items voor weergave op de hoofdpagina"</title>
+  <content type="text">100</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_MAX_NUM" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_MAX_NUM" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_MAX_UNIT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Eenheid van items voor weergave op de hoofdpagina</title>
+  <content type="text">POSTS</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_MAX_UNIT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_MAX_UNIT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_META_DESCRIPTION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De metabeschrijving van de blog die wordt gebruikt door zoekmachines.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_META_DESCRIPTION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_META_DESCRIPTION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_META_DESCRIPTION_ENABLED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Of deze blog wordt weergegeven met metabeschrijvingen.</title>
+  <content type="text">false</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_META_DESCRIPTION_ENABLED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_META_DESCRIPTION_ENABLED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_NAME</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De naam van de blog</title>
+  <content type="text">Notes of a Young Doctor</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_NAME" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_NAME" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_PER_POST_FEED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het type feed dat voor reacties op afzonderlijke posts moet worden gegeven</title>
+  <content type="text">FULL</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_PER_POST_FEED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_PER_POST_FEED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_POST_FEED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het type feed dat voor blogposts moet worden gegeven</title>
+  <content type="text">FULL</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_POST_FEED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_POST_FEED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_POST_FEED_FOOTER</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Voettekst om aan het einde van iedere vermelding in de postfeed toe te voegen</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_POST_FEED_FOOTER" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_POST_FEED_FOOTER" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_POST_TEMPLATE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De template voor blogposts</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_POST_TEMPLATE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_POST_TEMPLATE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_PROMOTED</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of deze blog op Blogger kan worden aangeprezen</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_PROMOTED" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_PROMOTED" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_QUICK_EDITING</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of Snel bewerken is ingeschakeld</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_QUICK_EDITING" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_QUICK_EDITING" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_READ_ACCESS_MODE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het type toegang voor de lezers van de blog.</title>
+  <content type="text">PUBLIC</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_READ_ACCESS_MODE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_READ_ACCESS_MODE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_READER_PERMISSION</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De e-maillijst voor gebruikers die toestemming hebben om de blog te lezen.</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_READER_PERMISSION" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_READER_PERMISSION" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_SEARCHABLE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of deze blog door zoekmachines moet worden geïndexeerd</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SEARCHABLE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SEARCHABLE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_SEND_EMAIL</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Door komma's gescheiden lijst met e-mailadressen om nieuwe blogposts naar te sturen</title>
+  <content type="text"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SEND_EMAIL" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SEND_EMAIL" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_SHOW_TITLE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of het titelveld moet worden weergegeven</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SHOW_TITLE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SHOW_TITLE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_SHOW_URL</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Hier wordt aangegeven of er een verwante link in de postopsteller moet worden weergegeven</title>
+  <content type="text">false</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SHOW_URL" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SHOW_URL" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_SUBDOMAIN</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het subdomein van BlogSpot om je blog op te publiceren</title>
+  <content type="text">youngdoctornotes</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SUBDOMAIN" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_SUBDOMAIN" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_TIME_STAMP_FORMAT</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Het getal van de tijdstempelnotatie</title>
+  <content type="text">27</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_TIME_STAMP_FORMAT" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_TIME_STAMP_FORMAT" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_TIME_ZONE</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">De tijdzone voor deze blog</title>
+  <content type="text">America/Los_Angeles</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_TIME_ZONE" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_TIME_ZONE" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.settings.BLOG_USE_LIGHTBOX</id>
+  <published>2010-11-27T07:08:20.877-08:00</published>
+  <updated>2018-08-02T12:38:27.320-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#settings"/>
+  <title type="text">Of afbeeldingen worden weergegeven in de lightbox wanneer erop wordt geklikt</title>
+  <content type="text">true</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_USE_LIGHTBOX" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/settings/BLOG_USE_LIGHTBOX" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.post-1276418104709695660</id>
+  <published>2010-11-27T08:21:00.000-08:00</published>
+  <updated>2018-08-02T12:22:48.286-07:00</updated>
+  <app:control>
+   <app:draft>yes</app:draft>
+  </app:control>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#post"/>
+  <category scheme="http://www.blogger.com/atom/ns#" term="Interesting cases"/>
+  <category scheme="http://www.blogger.com/atom/ns#" term="amputations"/>
+  <title type="text">Black as Egypt's Night</title>
+  <content type="html">Write next story here</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/posts/default/1276418104709695660" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/posts/default/1276418104709695660" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+  <thr:total>0</thr:total>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.post-1858599377741856733</id>
+  <published>2010-11-27T07:12:00.000-08:00</published>
+  <updated>2010-11-27T07:56:43.964-08:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#post"/>
+  <title type="text">The Steel Windpipe</title>
+  <content type="html">It was a cold Winter's night.&lt;br /&gt;&lt;br /&gt;&lt;ul&gt;&lt;li&gt;Very cold indeed.&lt;/li&gt;&lt;br /&gt;&lt;li&gt;Note to self: pad out ending&lt;/li&gt;&lt;/ul&gt;</content>
+  <link href="https://youngdoctornotes.blogspot.com/feeds/1858599377741856733/comments/default" rel="replies" title="Reacties posten" type="application/atom+xml"/>
+  <link href="http://youngdoctornotes.blogspot.com/2010/11/the-steel-windpipe.html#comment-form" rel="replies" title="1 reacties" type="text/html"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/posts/default/1858599377741856733" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/posts/default/1858599377741856733" rel="self" type="application/atom+xml"/>
+  <link href="http://youngdoctornotes.blogspot.com/2010/11/the-steel-windpipe.html" rel="alternate" title="The Steel Windpipe" type="text/html"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+  <thr:total>1</thr:total>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.page-4386962582497458967</id>
+  <published>2018-08-02T12:38:00.001-07:00</published>
+  <updated>2018-08-02T12:38:27.171-07:00</updated>
+  <app:control>
+   <app:draft>yes</app:draft>
+  </app:control>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#page"/>
+  <title type="text">Test page 2</title>
+  <content type="html">&lt;div dir="ltr" style="text-align: left;" trbidi="on"&gt;This is a second test&lt;/div&gt;</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/pages/default/4386962582497458967" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/pages/default/4386962582497458967" rel="self" type="application/atom+xml"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.page-1406163839769953231</id>
+  <published>2018-08-02T12:37:00.004-07:00</published>
+  <updated>2018-08-02T12:37:47.424-07:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#page"/>
+  <title type="text">Test page</title>
+  <content type="html">&lt;div dir="ltr" style="text-align: left;" trbidi="on"&gt;This is a test.&lt;/div&gt;</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/pages/default/1406163839769953231" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/pages/default/1406163839769953231" rel="self" type="application/atom+xml"/>
+  <link href="http://youngdoctornotes.blogspot.com/p/test-page.html" rel="alternate" title="Test page" type="text/html"/>
+  <author>
+   <name>Mikhail Afanasyevich Bulgakov</name>
+   <uri>https://www.blogger.com/profile/000082957</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+ </entry>
+ <entry>
+  <id>tag:blogger.com,1999:blog-6303278419262689239.post-5590533389087749201</id>
+  <published>2010-11-29T12:35:44.027-08:00</published>
+  <updated>2010-11-29T12:35:44.027-08:00</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/blogger/2008/kind#comment"/>
+  <title type="text">Mishka, always a pleasure to read your adventures!...</title>
+  <content type="html">Mishka, always a pleasure to read your adventures!&lt;br /&gt;&lt;br /&gt;It's a shame you don't get more time for writing.</content>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/1858599377741856733/comments/default/5590533389087749201" rel="edit" type="application/atom+xml"/>
+  <link href="https://www.blogger.com/feeds/6303278419262689239/1858599377741856733/comments/default/5590533389087749201" rel="self" type="application/atom+xml"/>
+  <link href="http://youngdoctornotes.blogspot.com/2010/11/the-steel-windpipe.html?showComment=1291062944027#c5590533389087749201" rel="alternate" title="" type="text/html"/>
+  <author>
+   <name>Thomas Isidore Noël Sankara</name>
+   <uri>https://www.blogger.com/profile/0617349827</uri>
+   <email>noreply@blogger.com</email>
+   <gd:image height="35" rel="http://schemas.google.com/g/2005#thumbnail" src="//lh3.googleusercontent.com/zFdxGE77vvD2w5xHy6jkVuElKv-U9_9qLkRYK8OnbDeJPtjSZ82UPq5w6hJ-SA=s35" width="35"/>
+  </author>
+  <thr:in-reply-to href="http://youngdoctornotes.blogspot.com/2010/11/the-steel-windpipe.html" ref="tag:blogger.com,1999:blog-6303278419262689239.post-1858599377741856733" source="https://www.blogger.com/feeds/6303278419262689239/posts/default/1858599377741856733" type="text/html"/>
+  <gd:extendedProperty name="blogger.itemClass" value="pid-944253050"/>
+  <gd:extendedProperty name="blogger.displayTime" value="29 november 2010 om 12:35"/>
+ </entry>
+</feed>

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -8,7 +8,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 from codecs import open
 from collections import defaultdict
 
@@ -117,19 +116,18 @@ def decode_wp_content(content, br=True):
     return content
 
 
-def get_items(xml):
-    """Opens a WordPress xml file and returns a list of items"""
+def xml_to_soup(xml):
+    """Opens an xml file"""
     try:
         from bs4 import BeautifulSoup
     except ImportError:
         error = ('Missing dependency "BeautifulSoup4" and "lxml" required to '
-                 'import WordPress XML files.')
+                 'import XML files.')
         sys.exit(error)
     with open(xml, encoding='utf-8') as infile:
         xmlfile = infile.read()
     soup = BeautifulSoup(xmlfile, "xml")
-    items = soup.rss.channel.findAll('item')
-    return items
+    return soup
 
 
 def get_filename(filename, post_id):
@@ -142,7 +140,8 @@ def get_filename(filename, post_id):
 def wp2fields(xml, wp_custpost=False):
     """Opens a wordpress XML file, and yield Pelican fields"""
 
-    items = get_items(xml)
+    soup = xml_to_soup(xml)
+    items = soup.rss.channel.findAll('item')
     for item in items:
 
         if item.find('status').string in ["publish", "draft"]:
@@ -163,8 +162,9 @@ def wp2fields(xml, wp_custpost=False):
             if raw_date == u'0000-00-00 00:00:00':
                 date = None
             else:
-                date_object = time.strptime(raw_date, '%Y-%m-%d %H:%M:%S')
-                date = time.strftime('%Y-%m-%d %H:%M', date_object)
+                date_object = SafeDatetime.strptime(
+                    raw_date, '%Y-%m-%d %H:%M:%S')
+                date = date_object.strftime('%Y-%m-%d %H:%M')
             author = item.find('creator').string
 
             categories = [cat.string for cat
@@ -193,6 +193,59 @@ def wp2fields(xml, wp_custpost=False):
                     kind = post_type
             yield (title, content, filename, date, author, categories,
                    tags, status, kind, 'wp-html')
+
+
+def blogger2fields(xml):
+    """Opens a blogger XML file, and yield Pelican fields"""
+
+    soup = xml_to_soup(xml)
+    entries = soup.feed.findAll('entry')
+    for entry in entries:
+        raw_kind = entry.find(
+            'category', {'scheme': 'http://schemas.google.com/g/2005#kind'}
+        ).get('term')
+        if raw_kind == 'http://schemas.google.com/blogger/2008/kind#post':
+            kind = 'article'
+        elif raw_kind == 'http://schemas.google.com/blogger/2008/kind#comment':
+            kind = 'comment'
+        elif raw_kind == 'http://schemas.google.com/blogger/2008/kind#page':
+            kind = 'page'
+        else:
+            continue
+
+        try:
+            assert kind != 'comment'
+            filename = entry.find('link', {'rel': 'alternate'})['href']
+            filename = os.path.splitext(os.path.basename(filename))[0]
+        except (AssertionError, TypeError, KeyError):
+            filename = entry.find('id').string.split('.')[-1]
+
+        title = entry.find('title').string or ''
+
+        content = entry.find('content').string
+        raw_date = entry.find('published').string
+        if hasattr(SafeDatetime, 'fromisoformat'):
+            date_object = SafeDatetime.fromisoformat(raw_date)
+        else:
+            date_object = SafeDatetime.strptime(
+                raw_date[:23], '%Y-%m-%dT%H:%M:%S.%f')
+        date = date_object.strftime('%Y-%m-%d %H:%M')
+        author = entry.find('author').find('name').string
+
+        # blogger posts only have tags, no category
+        tags = [tag.get('term') for tag in entry.findAll(
+            'category', {'scheme': 'http://www.blogger.com/atom/ns#'})]
+
+        # Drafts have <app:control><app:draft>yes</app:draft></app:control>
+        status = 'published'
+        try:
+            if entry.find('control').find('draft').string == 'yes':
+                status = 'draft'
+        except AttributeError:
+            pass
+
+        yield (title, content, filename, date, author, None, tags, status,
+               kind, 'html')
 
 
 def dc2fields(file):
@@ -391,7 +444,6 @@ def posterous2fields(api_token, email, password):
 
 def tumblr2fields(api_key, blogname):
     """ Imports Tumblr posts (API v2)"""
-    from time import strftime, localtime
     try:
         # py3k import
         import json
@@ -426,8 +478,10 @@ def tumblr2fields(api_key, blogname):
             slug = post.get('slug') or slugify(title)
             tags = post.get('tags')
             timestamp = post.get('timestamp')
-            date = strftime("%Y-%m-%d %H:%M:%S", localtime(int(timestamp)))
-            slug = strftime("%Y-%m-%d-", localtime(int(timestamp))) + slug
+            date = SafeDatetime.fromtimestamp(int(timestamp)).strftime(
+                "%Y-%m-%d %H:%M:%S")
+            slug = SafeDatetime.fromtimestamp(int(timestamp)).strftime(
+                "%Y-%m-%d-") + slug
             format = post.get('format')
             content = post.get('body')
             type = post.get('type')
@@ -499,7 +553,7 @@ def feed2fields(file):
     import feedparser
     d = feedparser.parse(file)
     for entry in d.entries:
-        date = (time.strftime('%Y-%m-%d %H:%M', entry.updated_parsed)
+        date = (entry.updated_parsed.strftime('%Y-%m-%d %H:%M')
                 if hasattr(entry, 'updated_parsed') else None)
         author = entry.author if hasattr(entry, 'author') else None
         tags = ([e['term'] for e in entry.tags]
@@ -619,7 +673,8 @@ def get_attachments(xml):
     """returns a dictionary of posts that have attachments with a list
     of the attachment_urls
     """
-    items = get_items(xml)
+    soup = xml_to_soup(xml)
+    items = soup.rss.channel.findAll('item')
     names = {}
     attachments = []
 
@@ -807,16 +862,16 @@ def fields2pelican(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Transform feed, WordPress, Tumblr, Dotclear, or "
-                    "Posterous files into reST (rst) or Markdown (md) files. "
+        description="Transform feed, Blogger, Dotclear, Posterous, Tumblr, or"
+                    "WordPress files into reST (rst) or Markdown (md) files. "
                     "Be sure to have pandoc installed.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument(
         dest='input', help='The input file to read')
     parser.add_argument(
-        '--wpfile', action='store_true', dest='wpfile',
-        help='Wordpress XML export')
+        '--blogger', action='store_true', dest='blogger',
+        help='Blogger XML export')
     parser.add_argument(
         '--dotclear', action='store_true', dest='dotclear',
         help='Dotclear export')
@@ -826,6 +881,9 @@ def main():
     parser.add_argument(
         '--tumblr', action='store_true', dest='tumblr',
         help='Tumblr export')
+    parser.add_argument(
+        '--wpfile', action='store_true', dest='wpfile',
+        help='Wordpress XML export')
     parser.add_argument(
         '--feed', action='store_true', dest='feed',
         help='Feed to parse')
@@ -841,7 +899,7 @@ def main():
     parser.add_argument(
         '--dir-page', action='store_true', dest='dirpage',
         help=('Put files recognised as pages in "pages/" sub-directory'
-              ' (wordpress import only)'))
+              ' (blogger and wordpress import only)'))
     parser.add_argument(
         '--filter-author', dest='author',
         help='Import only post from the specified author')
@@ -883,19 +941,21 @@ def main():
     args = parser.parse_args()
 
     input_type = None
-    if args.wpfile:
-        input_type = 'wordpress'
+    if args.blogger:
+        input_type = 'blogger'
     elif args.dotclear:
         input_type = 'dotclear'
     elif args.posterous:
         input_type = 'posterous'
     elif args.tumblr:
         input_type = 'tumblr'
+    elif args.wpfile:
+        input_type = 'wordpress'
     elif args.feed:
         input_type = 'feed'
     else:
-        error = ('You must provide either --wpfile, --dotclear, '
-                 '--posterous, --tumblr or --feed options')
+        error = ('You must provide either --blogger, --dotclear, '
+                 '--posterous, --tumblr, --wpfile or --feed options')
         exit(error)
 
     if not os.path.exists(args.output):
@@ -910,14 +970,16 @@ def main():
                  'to use the --wp-attach option')
         exit(error)
 
-    if input_type == 'wordpress':
-        fields = wp2fields(args.input, args.wp_custpost or False)
+    if input_type == 'blogger':
+        fields = blogger2fields(args.input)
     elif input_type == 'dotclear':
         fields = dc2fields(args.input)
     elif input_type == 'posterous':
         fields = posterous2fields(args.input, args.email, args.password)
     elif input_type == 'tumblr':
         fields = tumblr2fields(args.input, args.blogname)
+    elif input_type == 'wordpress':
+        fields = wp2fields(args.input, args.wp_custpost or False)
     elif input_type == 'feed':
         fields = feed2fields(args.input)
 


### PR DESCRIPTION
Adds importer for Blogger XML backups. This isn't meant to be comprehensive (covering all eventualities), but as a first version it should suffice (it works for my own export).