### PR TITLE
Don't process metadata links before all files are present

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -142,10 +142,6 @@ class Content(object):
         if not hasattr(self, 'status'):
             self.status = getattr(self, 'default_status', None)
 
-        if (len(self._context.get('generated_content', [])) > 0 or
-                len(self._context.get('static_content', [])) > 0):
-            self.refresh_metadata_intersite_links()
-
         signals.content_object_init.send(self)
 
     def __str__(self):

--- a/pelican/tests/cyclic_intersite_links/first-article.rst
+++ b/pelican/tests/cyclic_intersite_links/first-article.rst
@@ -1,0 +1,7 @@
+First article
+#############
+
+:date: 2018-11-10
+:summary: Here's the `second <{filename}/second-article.rst>`_,
+    `third <{filename}/third-article.rst>`_ and a
+    `nonexistent article <{filename}/nonexistent.rst>`_.

--- a/pelican/tests/cyclic_intersite_links/second-article.rst
+++ b/pelican/tests/cyclic_intersite_links/second-article.rst
@@ -1,0 +1,7 @@
+Second article
+##############
+
+:date: 2018-11-10
+:summary: Here's the `first <{filename}/first-article.rst>`_,
+    `third <{filename}/third-article.rst>`_ and a
+    `nonexistent article <{filename}/nonexistent.rst>`_.

--- a/pelican/tests/cyclic_intersite_links/third-article.rst
+++ b/pelican/tests/cyclic_intersite_links/third-article.rst
@@ -1,0 +1,7 @@
+Third article
+#############
+
+:date: 2018-11-10
+:summary: Here's the `first <{filename}/first-article.rst>`_,
+    `second <{filename}/second-article.rst>`_ and a
+    `nonexistent article <{filename}/nonexistent.rst>`_.

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -333,6 +333,10 @@ class TestPage(LoggedTestCase):
         args['metadata']['custom'] = parsed
         args['context']['localsiteurl'] = 'http://notmyidea.org'
         p = Page(**args)
+        # This is called implicitly from all generators and Pelican.run() once
+        # all files are processed. Here we process just one page so it needs
+        # to be called explicitly.
+        p.refresh_metadata_intersite_links()
         self.assertEqual(p.summary, linked)
         self.assertEqual(p.custom, linked)
 


### PR DESCRIPTION
@justinmayer @avaris I finally got back to this (sorry for the delay) and submitting a fix proposed in the discussion at https://github.com/getpelican/pelican/pull/2288/files#r204337359. Since #2288 caused regressions (and this is fixing them), I think it makes sense to have this included in the 3.8 release.

Description of the change is below, is just a summary of the discussion linked above.

- - - 

The `refresh_metadata_intersite_links()` is called again later, so this bit is only causing everything to be processed twice. Besides that, it makes the processing dependent on file order -- in particular, when metadata references a file that was not parsed yet, it reports an "Unable to find" warning. But everything is found in the second pass, so this only causes a superflous false warning and no change to the output.

This also brings back the `_summary` field, because some plugins might have depended on that, even though it's internal.