### PR TITLE
Make the markdown package requirement explicit.

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -21,10 +21,7 @@ from pelican.contents import Author, Category, Page, Tag
 from pelican.utils import SafeDatetime, escape_html, get_date, pelican_open, \
     posixize_path
 
-try:
-    from markdown import Markdown
-except ImportError:
-    Markdown = False  # NOQA
+from markdown import Markdown # NOQA
 
 # Metadata processors have no way to discard an unwanted value, so we have
 # them return this value instead to signal that it should be discarded later.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os.path import join, relpath
 from setuptools import setup
 
 requires = ['feedgenerator >= 1.9', 'jinja2 >= 2.7', 'pygments', 'docutils',
-            'pytz >= 0a', 'blinker', 'unidecode', 'six >= 1.4',
+            'pytz >= 0a', 'blinker', 'unidecode', 'six >= 1.4', 'markdown',
             'python-dateutil']
 
 entry_points = {


### PR DESCRIPTION
Similar changes had been done on this fix #1234.
When using markdown documents currently the error messages doesn't say
the actual error, which forces the developer to debug the pelican code
to spot the bug. This fix will explicitly enforce the required dependency.