### PR TITLE
Resolving mtime truncation (issue #2412)

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -820,7 +820,7 @@ class StaticGenerator(Generator):
         save_as = os.path.join(self.output_path, staticfile.save_as)
         s_mtime = os.path.getmtime(source_path)
         d_mtime = os.path.getmtime(save_as)
-        return s_mtime > d_mtime
+        return s_mtime - d_mtime > 0.000001
 
     def _link_or_copy_staticfile(self, sc):
         if self.settings['STATIC_CREATE_LINKS']:


### PR DESCRIPTION
Issue #2412 : python copy instruction doesn't preserve mtime under Debian/stretch (up to date).
This results in lot of files are copied to output even if not changed (and a lot of wasted time).

Proposed solution in pelican/pelican/generators.py, line 823:
#return s_mtime > d_mtime
return s_mtime - d_mtime > 0.000001