### PR TITLE
Make relative source path available for themes

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -595,6 +595,7 @@ class ArticlesGenerator(CachingGenerator):
                 all_articles.append(article)
             elif article.status == "draft":
                 all_drafts.append(article)
+            article.orig_relpath  = f;
             self.add_source_path(article)
 
         self.articles, self.translations = process_translations(all_articles)


### PR DESCRIPTION
| Item | Explanation |
| --- | --- |
| Need | Figure out in themes the **relative path name** from the file (md or rst) which is generated |
| Typical use case  | Users may **directly modify their article** from a link opening GitHub in edition mode |
| Proposal | Make a **article.orig_relpath** available for themes article.html template |

# Example

In *YOURTHEME*/template/article.html:
``` html
...
<button onclick="window.location.href='https://github.com/getpelican/pelican/edit/master/{{ article.orig_relpath }}'">
  Modify this article under GitHub
</button>
...
```