### PR TITLE
when markdown is selected, 'wheel' pip seem to be required

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,8 @@ Install Pelican (and optionally Markdown if you intend to use it) on Python
 2.7.x or Python 3.3+ by running the following command in your preferred
 terminal, prefixing with ``sudo`` if permissions warrant::
 
-    pip install pelican markdown
+    pip install pelican markdown wheel
+
 
 Create a project
 ----------------


### PR DESCRIPTION
following errors are there if wheel is not installed:

Building wheels for collected packages: feedgenerator, blinker, MarkupSafe
  Running setup.py bdist_wheel for feedgenerator ... error
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-dLBjLv/feedgenerator/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpy7Uxf9pip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for feedgenerator
  Running setup.py clean for feedgenerator
  Running setup.py bdist_wheel for blinker ... error
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-dLBjLv/blinker/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpCwjK2dpip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for blinker
  Running setup.py clean for blinker
  Running setup.py bdist_wheel for MarkupSafe ... error
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-dLBjLv/MarkupSafe/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpohyVw1pip-wheel- --python-tag cp27:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for MarkupSafe
  Running setup.py clean for MarkupSafe
Failed to build feedgenerator blinker MarkupSafe