### PR TITLE
Enable both pages & categories on Simple theme menu. Fixes #2404

### DIFF
--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -43,12 +43,11 @@
           {% for p in pages %}
             <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
           {% endfor %}
-        {% else %}
-          {% if DISPLAY_CATEGORIES_ON_MENU %}
-            {% for cat, null in categories %}
-              <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
-            {% endfor %}
-          {% endif %}
+        {% endif %}
+        {% if DISPLAY_CATEGORIES_ON_MENU %}
+          {% for cat, null in categories %}
+            <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
+          {% endfor %}
         {% endif %}
         </ul></nav><!-- /#menu -->
         {% block content %}


### PR DESCRIPTION
I changed the logic of the nav bar creation by removing the else statement that prevented categories from being added to the nav bar if pages are present. And, of course, I cleaned up the indent levels and end tags.
