### PR TITLE
Gracefully handle reST parse errors

### DIFF
--- a/pelican/log.py
+++ b/pelican/log.py
@@ -24,6 +24,9 @@ class BaseFormatter(logging.Formatter):
         record.__dict__['customlevelname'] = customlevel
         # format multiline messages 'nicely' to make it clear they are together
         record.msg = record.msg.replace('\n', '\n  | ')
+        record.args = tuple(arg.replace('\n', '\n  | ') if
+                            isinstance(arg, six.string_types) else
+                            arg for arg in record.args)
         return super(BaseFormatter, self).format(record)
 
     def formatException(self, ei):

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -12,6 +12,7 @@ import docutils.io
 from docutils.writers.html4css1 import HTMLTranslator, Writer
 
 import six
+from six import StringIO
 from six.moves.html_parser import HTMLParser
 
 from pelican import rstdirectives  # NOQA
@@ -256,7 +257,9 @@ class RstReader(BaseReader):
                         'syntax_highlight': 'short',
                         'input_encoding': 'utf-8',
                         'language_code': self.settings.get('DEFAULT_LANG'),
-                        'exit_status_level': 2,
+                        'halt_level': 2,
+                        'traceback': True,
+                        'warning_stream': StringIO(),
                         'embed_stylesheet': False}
         user_params = self.settings.get('DOCUTILS_SETTINGS')
         if user_params:
@@ -269,7 +272,7 @@ class RstReader(BaseReader):
         pub.set_components('standalone', 'restructuredtext', 'html')
         pub.process_programmatic_settings(None, extra_params, None)
         pub.set_source(source_path=source_path)
-        pub.publish(enable_exit_status=True)
+        pub.publish()
         return pub
 
     def read(self, source_path):

--- a/pelican/tests/parse_error/parse_error.rst
+++ b/pelican/tests/parse_error/parse_error.rst
@@ -1,0 +1,4 @@
+Page with a parse error
+#############
+
+The underline is too short.

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -225,3 +225,18 @@ class TestPelican(LoggedTestCase):
             count=1,
             msg="MD_EXTENSIONS is deprecated use MARKDOWN instead.",
             level=logging.WARNING)
+
+    def test_parse_errors(self):
+        # Verify that just an error is printed and the application doesn't
+        # abort, exit or something.
+        settings = read_settings(path=None, override={
+            'PATH': os.path.abspath(os.path.join(CURRENT_DIR, 'parse_error')),
+            'OUTPUT_PATH': self.temp_path,
+            'CACHE_PATH': self.temp_cache,
+        })
+        pelican = Pelican(settings=settings)
+        mute(True)(pelican.run)()
+        self.assertLogCountEqual(
+            count=1,
+            msg="Could not process .*parse_error.rst",
+            level=logging.ERROR)

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -410,6 +410,12 @@ class RstReaderTest(ReaderTest):
         self.assertEqual(tuple_date.metadata['date'],
                          string_date.metadata['date'])
 
+    def test_parse_error(self):
+        # Verify that it raises an Exception, not nothing and not SystemExit or
+        # some such
+        with six.assertRaisesRegex(self, Exception, "underline too short"):
+            self.read_file(path='../parse_error/parse_error.rst')
+
 
 @unittest.skipUnless(readers.Markdown, "markdown isn't installed")
 class MdReaderTest(ReaderTest):


### PR DESCRIPTION
Contains the solution suggested by @avaris in https://github.com/getpelican/pelican/pull/2047#issuecomment-430757553 together with a test, so we ensure neither the hard exit described in #1759 nor the false success described in #1224 ever happens again.

I was struggling a bit where to put the test because the actual conversion of an exception to an `ERROR` is done in `pelican.generators` and not in the reST reader class, hope that's okay.