### PR TITLE
Fix PAGINATED_DIRECT_TEMPLATES backward compatibility handling to not crash

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -323,6 +323,11 @@ def handle_deprecated_settings(settings):
             'PAGINATED_DIRECT_TEMPLATES', 'PAGINATED_TEMPLATES')
         logger.warning(message)
 
+        # set PAGINATED_TEMPLATES
+        if 'PAGINATED_TEMPLATES' not in settings:
+            settings['PAGINATED_TEMPLATES'] = {
+                'tag': None, 'category': None, 'author': None}
+
         for t in settings['PAGINATED_DIRECT_TEMPLATES']:
             if t not in settings['PAGINATED_TEMPLATES']:
                 settings['PAGINATED_TEMPLATES'][t] = None

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -187,6 +187,20 @@ class TestSettingsConfiguration(unittest.TestCase):
                          {'index': 10, 'category': None, 'archives': None})
         self.assertNotIn('PAGINATED_DIRECT_TEMPLATES', settings)
 
+    def test_deprecated_paginated_direct_templates_from_file(self):
+        # This is equivalent to reading a settings file that has
+        # PAGINATED_DIRECT_TEMPLATES defined but no PAGINATED_TEMPLATES.
+        settings = read_settings(None, override={
+            'PAGINATED_DIRECT_TEMPLATES': ['index', 'archives']
+        })
+        self.assertEqual(settings['PAGINATED_TEMPLATES'], {
+            'archives': None,
+            'author': None,
+            'index': None,
+            'category': None,
+            'tag': None})
+        self.assertNotIn('PAGINATED_DIRECT_TEMPLATES', settings)
+
     def test_theme_and_extra_templates_exception(self):
         settings = self.settings
         settings['EXTRA_TEMPLATES_PATHS'] = ['/ha']

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -285,3 +285,14 @@ class TestSettingsConfiguration(unittest.TestCase):
         self.assertEqual(settings['AUTHOR_REGEX_SUBSTITUTIONS'],
                          [(r'Alexander\ Todorov', 'atodorov')] +
                          default_slug_regex_subs)
+
+    def test_deprecated_slug_substitutions_from_file(self):
+        # This is equivalent to reading a settings file that has
+        # SLUG_SUBSTITUTIONS defined but no SLUG_REGEX_SUBSTITUTIONS.
+        settings = read_settings(None, override={
+            'SLUG_SUBSTITUTIONS': [('C++', 'cpp')]
+        })
+        self.assertEqual(settings['SLUG_REGEX_SUBSTITUTIONS'],
+                         [(r'C\+\+', 'cpp')] +
+                         self.settings['SLUG_REGEX_SUBSTITUTIONS'])
+        self.assertNotIn('SLUG_SUBSTITUTIONS', settings)


### PR DESCRIPTION
**Note::** this PR currently fails the CI, because I'm not sure what the proper fix is. Read on ...

I just tried to regenerate my site using current Pelican master and was greeted with the following:

```
$ pelican -Dlr
DEBUG: Pelican version: 3.7.2.dev0
DEBUG: Python version: 3.7.1
WARNING: The PAGINATED_DIRECT_TEMPLATES setting has been removed in favor of PAGINATED_TEMPLATES
CRITICAL: KeyError: 'PAGINATED_TEMPLATES'
Traceback (most recent call last):
  File "/usr/bin/pelican", line 11, in <module>
    load_entry_point('pelican==3.7.2.dev0', 'console_scripts', 'pelican')()
  File "/usr/lib/python3.7/site-packages/pelican/__init__.py", line 565, in main
    pelican, settings = get_instance(args)
  File "/usr/lib/python3.7/site-packages/pelican/__init__.py", line 450, in get_instance
    settings = read_settings(config_file, override=get_config(args))
  File "/usr/lib/python3.7/site-packages/pelican/settings.py", line 182, in read_settings
    settings = handle_deprecated_settings(settings)
  File "/usr/lib/python3.7/site-packages/pelican/settings.py", line 327, in handle_deprecated_settings
    if t not in settings['PAGINATED_TEMPLATES']:
KeyError: 'PAGINATED_TEMPLATES'
```

Seems to be due to an unfortunate combination of #2326 and #2384 (sorry, @oulenz :)).

My `pelicanconf.py` contains the `PAGINATED_DIRECT_TEMPLATES` setting and the exception is coming from the deprecation handling code -- basically, the code in https://github.com/getpelican/pelican/blob/b6b3724ed262e9d623ebef88e9037fa841093645/pelican/settings.py#L181-L204 is first handling deprecated values *and then* merging the loaded settings with the default ones, which then results in the above exception because `PAGINATED_DIRECT_TEMPLATES` is set but `PAGINATED_TEMPLATES` not.

This PR moves the deprecation handling after merge of the default values, which fixes the above abort (related to #2384) -- but it causes a critical error due to #2326, as my `pelicanconf.py` contains *also* `SLUG_SUBSTITUTIONS` and then, because the settings get merged before deprecation is handled, it complains:

```
CRITICAL: Exception: Setting both SLUG_REGEX_SUBSTITUTIONS and SLUG_SUBSTITUTIONS (or variants
  thereof) is not permitted. Please move to only setting SLUG_REGEX_SUBSTITUTIONS.
```

I added a repro case for this as well. Basically either the first test case fails or, when that is fixed, the second test case blows up. So, um, I'm kinda lost on what the fix should be :( Nevertheless I think this is sufficiently critical to have fixed for 3.8 (sorry, @justinmayer, for piling up more work...).
