### PR TITLE
pelican_import: Fix post titles that are entirely made of spaces

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -131,11 +131,11 @@ def xml_to_soup(xml):
     return soup
 
 
-def get_filename(filename, post_id):
-    if filename is not None:
-        return filename
-    else:
+def get_filename(post_name, post_id):
+    if post_name is None or post_name.isspace():
         return post_id
+    else:
+        return post_name
 
 
 def wp2fields(xml, wp_custpost=False):
@@ -154,9 +154,9 @@ def wp2fields(xml, wp_custpost=False):
                 title = 'No title [%s]' % item.find('post_name').string
                 logger.warning('Post "%s" is lacking a proper title', title)
 
-            filename = item.find('post_name').string
+            post_name = item.find('post_name').string
             post_id = item.find('post_id').string
-            filename = get_filename(filename, post_id)
+            filename = get_filename(post_name, post_id)
 
             content = item.find('encoded').string
             raw_date = item.find('post_date').string
@@ -690,14 +690,14 @@ def get_attachments(xml):
 
     for item in items:
         kind = item.find('post_type').string
-        filename = item.find('post_name').string
+        post_name = item.find('post_name').string
         post_id = item.find('post_id').string
 
         if kind == 'attachment':
             attachments.append((item.find('post_parent').string,
                                 item.find('attachment_url').string))
         else:
-            filename = get_filename(filename, post_id)
+            filename = get_filename(post_name, post_id)
             names[post_id] = filename
     attachedposts = defaultdict(list)
     for parent, url in attachments:


### PR DESCRIPTION
get_filename: 
   fixup names that are entirely made up of spaces.
   use "post_name", where the parameter is the postname.
