### PR TITLE
Importer: Avoid downloading duplicate post attachments

### DIFF
--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -417,20 +417,22 @@ class TestWordpressXMLAttachements(unittest.TestCase):
         self.assertTrue(self.attachments)
         for post in self.attachments.keys():
             if post is None:
-                expected = ('https://upload.wikimedia.org/wikipedia/commons/'
-                            'thumb/2/2c/Pelican_lakes_entrance02.jpg/'
-                            '240px-Pelican_lakes_entrance02.jpg')
-                self.assertEqual(self.attachments[post][0], expected)
+                expected = {
+                    ('https://upload.wikimedia.org/wikipedia/commons/'
+                     'thumb/2/2c/Pelican_lakes_entrance02.jpg/'
+                     '240px-Pelican_lakes_entrance02.jpg')
+                }
+                self.assertEqual(self.attachments[post], expected)
             elif post == 'with-excerpt':
                 expected_invalid = ('http://thisurlisinvalid.notarealdomain/'
                                     'not_an_image.jpg')
                 expected_pelikan = ('http://en.wikipedia.org/wiki/'
                                     'File:Pelikan_Walvis_Bay.jpg')
-                self.assertEqual(self.attachments[post][0], expected_invalid)
-                self.assertEqual(self.attachments[post][1], expected_pelikan)
+                self.assertEqual(self.attachments[post],
+                                 {expected_invalid, expected_pelikan})
             elif post == 'with-tags':
                 expected_invalid = ('http://thisurlisinvalid.notarealdomain')
-                self.assertEqual(self.attachments[post][0], expected_invalid)
+                self.assertEqual(self.attachments[post], {expected_invalid})
             else:
                 self.fail('all attachments should match to a '
                           'filename or None, {}'

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -699,7 +699,7 @@ def get_attachments(xml):
         else:
             filename = get_filename(filename, post_id)
             names[post_id] = filename
-    attachedposts = defaultdict(list)
+    attachedposts = defaultdict(set)
     for parent, url in attachments:
         try:
             parent_name = names[parent]
@@ -707,7 +707,7 @@ def get_attachments(xml):
             # attachment's parent is not a valid post
             parent_name = None
 
-        attachedposts[parent_name].append(url)
+        attachedposts[parent_name].add(url)
     return attachedposts
 
 


### PR DESCRIPTION
When importing from wordpress it's possible to have posts with the same attachment multiple times, this creates a set per post of attachments avoiding this.