### PR TITLE
Disinherit Page from Static so default draft status does not affect save_as

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -527,7 +527,11 @@ class Article(Content):
 
 
 @python_2_unicode_compatible
-class Static(Page):
+class Static(Content):
+    mandatory_properties = ('title',)
+    default_status = 'published'
+    default_template = None
+
     def __init__(self, *args, **kwargs):
         super(Static, self).__init__(*args, **kwargs)
         self._output_location_referenced = False

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -917,3 +917,18 @@ class TestStatic(LoggedTestCase):
                                    self.settings['INDEX_SAVE_AS'])) +
                          '">link</a>')
         self.assertEqual(content, expected_html)
+
+    def test_not_save_as_draft(self):
+        """Static.save_as is not affected by draft status."""
+
+        static = Static(
+            content=None,
+            metadata=dict(status='draft',),
+            settings=self.settings,
+            source_path=os.path.join('dir', 'foo.jpg'),
+            context=self.settings.copy())
+
+        expected_save_as = os.path.join('dir', 'foo.jpg')
+        self.assertEqual(static.status, 'draft')
+        self.assertEqual(static.save_as, expected_save_as)
+        self.assertEqual(static.url, path_to_url(expected_save_as))


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican/issues/2444 (hopefully)

Hitherto, the `Static` class inherited from the `Page` class. In particular it inherited its `_expand_settings` method, meaning its `save_as` (and friends) metadata values would be determined by the `DRAFT_PAGE_SAVE_AS` setting (and friends) if `DEFAULT_METADATA` included `'status': 'draft'`. I've changed that by letting `Static` inherit from `Content` directly.

Is there anything that relied on `Static` inheriting from `Page` that the tests don't pick up on?

(I'm assuming we don't want draft static content. Still, I've not set `allowed_statuses = ('published',)` because at the moment, default metadata does still affect static content. Then again, `is_valid` isn't actually called when static content is generated, so `allowed_statuses` wouldn't have been tested for anyway.)