### PR TITLE
WIP: wp_import: resolve links to posts of the form ?attachment_id={post_id}

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -677,9 +677,10 @@ def get_out_filename(output_path, filename, ext, kind,
     return out_filename
 
 
-def get_attachments(xml):
+def get_attachments(xml, resolve_by_id=False):
     """
 
+    :param resolve_by_id:  Lookup posts by id
     :param xml:
     :return:  attachment_urls
     """
@@ -708,8 +709,9 @@ def get_attachments(xml):
         if kind == 'attachment':
             attachments.append((item.find('post_parent').string,
                                 item.find('attachment_url').string))
-            attachment_ids[post_id] = item.find('attachment_url').string
-        elif kind == 'post':
+            if resolve_by_id:
+                attachment_ids[post_id] = item.find('attachment_url').string
+        elif resolve_by_id and kind == 'post':
             content = item.find('encoded').string
             find_attachment = re.compile(r'({}/\?attachment_id=(\d+))'.format(server))
             for url, attachment_id in find_attachment.findall(content):
@@ -722,7 +724,7 @@ def get_attachments(xml):
             attachedposts[parent_name].add(url)
 
     attachment_links = defaultdict(set)
-    if attachments_by_id:
+    if resolve_by_id and attachments_by_id:
         for filename, links in attachments_by_id.items():
             for url, attachment_id in links:
                 destination = attachment_ids[attachment_id]
@@ -1052,7 +1054,7 @@ def main():
         fields = feed2fields(args.input)
 
     if args.wp_attach:
-        attachments, attachment_links = get_attachments(args.input)
+        attachments, attachment_links = get_attachments(args.input, args.wp_resolve)
     else:
         attachments, attachment_links = None, None
 

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -720,9 +720,12 @@ def get_attachments(xml, resolve_by_id=False):
 
     attachedposts = defaultdict(set)
     for parent, url in attachments:
-        if parent in post_names:  # check parent post is valid
+        try:
             parent_name = post_names[parent]
-            attachedposts[parent_name].add(url)
+        except KeyError:
+            # attachment's parent is not a valid post
+            parent_name = None
+        attachedposts[parent_name].add(url)
 
     attachment_links = defaultdict(set)
     if resolve_by_id and attachments_by_id:


### PR DESCRIPTION
Links within wordpress can take the form of ```?attachment_id={post_id}``` linking to another post.

Resolve these links if they point to existing ~~posts~~ attachments.

This works for the one link I have in my own wordpress dump ~~, possibly this should be amalgamated with the existing attachment handling somehow.~~

The link I have is to attachment potentially they could potentially be to anything (my link was created 10 years ago, so not sure what I did in the blog, but maybe I created a link to an unpublished/unsaved post/attachment?)