### PR TITLE
Try importing from collections.abc for compatibility with Python 3.8

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -2,7 +2,10 @@
 from __future__ import print_function, unicode_literals
 
 import argparse
-import collections
+try:
+    import collections.abc as collections
+except ImportError:
+    import collections
 import locale
 import logging
 import multiprocessing

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -5,7 +5,11 @@ import locale
 import logging
 import os
 import sys
-from collections import Mapping, defaultdict
+from collections import defaultdict
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 import six
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -12,7 +12,10 @@ import re
 import shutil
 import sys
 import traceback
-from collections import Hashable
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 from contextlib import contextmanager
 from functools import partial
 from itertools import groupby


### PR DESCRIPTION
This changes the remaining imports not covered by https://github.com/getpelican/pelican/pull/2389. The try/catch is necessary as long as we support Python 2.7.