### PR TITLE
Remove unnecessary whitespace stripping in Makefile template

### DIFF
--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -123,7 +123,7 @@ publish:
 ssh_upload: publish
 	scp -P $(SSH_PORT) -r $(OUTPUTDIR)/* $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 
-{%- set upload = upload + ["rsync_upload"] -%}
+{% set upload = upload + ["rsync_upload"] %}
 rsync_upload: publish
 	rsync -e "ssh -p $(SSH_PORT)" -P -rvzc --cvs-exclude --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 


### PR DESCRIPTION
This fixes: #2482 for me. It was just some extra white-space controls that didn't need to be in the makefile template.