### PR TITLE
Remove stopserver from .PHONY prereqs in Makefile template

### DIFF
--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -160,4 +160,4 @@ github: publish
 
 {% endif %}
 
-.PHONY: html help clean regenerate serve serve-global devserver stopserver publish {{ upload|join(" ") }}
+.PHONY: html help clean regenerate serve serve-global devserver publish {{ upload|join(" ") }}


### PR DESCRIPTION
Just a minor oversight from when the devserver functionality was integrated into the pelican command and the stopserver target was removed. This shouldn't really affect much -- I just noticed in shell completion output while upgrading to 4.x :)