### PR TITLE
Fix warning message

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -281,7 +281,7 @@ class Content(object):
                             if linked_content:
                                 logger.warning(
                                     '{filename} used for linking to static'
-                                    'content %s in %s. Use {static} instead',
+                                    ' content %s in %s. Use {static} instead',
                                     path,
                                     self.get_relative_source_path())
                                 return linked_content


### PR DESCRIPTION
Add space between words 'static' and 'content'.