### PR TITLE
Docs: properly show escaped chars in SLUG_REGEX_SUBSTITUTIONS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -588,10 +588,10 @@ corresponding ``*_URL`` setting as string, while others hard-code them:
 ``'tags.html'``.
 
 .. data:: SLUG_REGEX_SUBSTITUTIONS = [
-        (r'[^\w\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars
-        (r'(?u)\A\s*', ''),  # strip leading whitespace
-        (r'(?u)\s*\Z', ''),  # strip trailing whitespace
-        (r'[-\s]+', '-'),  # reduce multiple whitespace or '-' to single '-'
+        (r'[^\\w\\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars
+        (r'(?u)\\A\\s*', ''),  # strip leading whitespace
+        (r'(?u)\\s*\\Z', ''),  # strip trailing whitespace
+        (r'[-\\s]+', '-'),  # reduce multiple whitespace or '-' to single '-'
     ]
 
    Regex substitutions to make when generating slugs of articles and pages.


### PR DESCRIPTION
Fixes documentation for #2326 by @oulenz (sorry, it's just a total coincidence that all my recent PRs are redoing your stuff :sweat_smile:).

**For reviewers:** please check before merging that the generated docs actually show it correctly this time. I verified on an unrelated reST snippet, but I might have missed some.

- - -

The backstory (and a counter-proposal): I [upgraded to Pelican 4.0](https://github.com/mosra/magnum-website/commit/fd758e88d68c95ff7b6953603324f8b573286d72) by replacing this line:

```py
SLUG_SUBSTITUTIONS = [('C++', 'cpp')]
```

with this line:

```py
SLUG_REGEX_SUBSTITUTIONS = [('C\+\+', 'cpp')]
```

... because that was what the warning told me. Everything seemingly worked correctly (and I didn't bother checking the docs). Much later I realized that some tags and categories had slugs containg spaces instead of the `-` character, which made me realize that the substitutions now have to contain *also* what was previously the default. So I went to the documentation to copy the defaults and use these... but they were broken, missing the backslashes, so I had to dig in and copy from the sources instead. 

That made me realize -- is it *really* desired to force users to [specify these]()? It's admittedly a non-trivial set of regexps and while a lot can go wrong when the users upgrade (like I did), I don't think there are many use cases where it would be desired to *remove* the defaults -- and in that case one could specify a "pass-through" regex to avoid such replacement. For example:

```py
SLUG_REGEX_SUBSTITUTIONS = [
    (r'[-\\s]+', r'\g<0>'), # instead of '-'
    ...
]
```

and then, when merging the default `SLUG_REGEX_SUBSTITUTIONS` dict with the new one, the (duplicate) key `r'[-\\s]+'` would get its value replaced by the user-provided `r'\g<0>'`.

What do you think?