### PR TITLE
Add feed url attributes to content objects

### DIFF
--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -379,6 +379,8 @@ title                   Title of the article.
 translations            List of translations
                         :ref:`Article <object-article>` objects.
 url                     URL to the article page.
+lang_atom_feed_url      URL to the language's ATOM feed
+land_rss_feed_url       URL to the language's RSS feed
 ======================  ===================================================
 
 .. _PATH: settings.html#PATH
@@ -399,6 +401,8 @@ page_name               Author page name.
 save_as                 Location to save the author page.
 slug                    Page slug.
 url                     URL to the author page.
+atom_feed_url           URL to the ATOM feed for the author.
+rss_feed_url            URL to the RSS feed for the author.
 ===================     ===================================================
 
 .. [1] for Author object, coming from `:authors:` or `AUTHOR`.
@@ -438,6 +442,8 @@ title                  Title of the page.
 translations           List of translations
                        :ref:`Article <object-article>` objects.
 url                    URL to the page.
+lang_atom_feed_url     URL to the language's ATOM feed.
+land_rss_feed_url      URL to the language's RSS feed.
 =====================  ===================================================
 
 .. _PATH: settings.html#PATH

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -93,6 +93,10 @@ class Content(object):
 
             self.in_default_lang = (self.lang == default_lang)
 
+        # build feed urls
+        self._build_rss_feed_url()
+        self._build_atom_feed_url()
+
         # create the slug if not existing, generate slug according to
         # setting of SLUG_ATTRIBUTE
         if not hasattr(self, 'slug'):
@@ -148,6 +152,24 @@ class Content(object):
             self._summary = metadata['summary']
 
         signals.content_object_init.send(self)
+
+    def _build_atom_feed_url(self):
+        atom_url = self.settings.get('TRANSLATION_FEED_ATOM', None)
+        if atom_url is None or getattr(self, 'lang', None) is None:
+            self.lang_atom_feed_url = None
+        else:
+            self.lang_atom_feed_url = atom_url.format(
+                lang=self.lang
+            )
+
+    def _build_rss_feed_url(self):
+        rss_url = self.settings.get('TRANSLATION_FEED_RSS', None)
+        if rss_url is None or getattr(self, 'lang', None) is None:
+            self.lang_rss_feed_url = None
+        else:
+            self.lang_rss_feed_url = rss_url.format(
+                lang=self.lang
+            )
 
     def __str__(self):
         return self.source_path or repr(self)

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -133,6 +133,52 @@ class TestPage(LoggedTestCase):
         page = Page(**self.page_kwargs)
         self.assertEqual(page.lang, 'fr')
 
+    def test_lang_feed_urls(self):
+        page_kwargs = self._copy_page_kwargs()
+        settings = get_settings()
+
+        if 'TRANSLATION_FEED_RSS' in settings:
+            del settings['TRANSLATION_FEED_RSS']
+        if 'TRANSLATION_FEED_ATOM' in settings:
+            del settings['TRANSLATION_FEED_ATOM']
+        page_kwargs['settings'] = settings
+
+        # if atom and rss translations settings are not set
+        # 'lang_rss_feed_url' and 'lang_atom_feed_url' should
+        # return None
+        page = Page(**page_kwargs)
+        self.assertIsNone(page.lang_atom_feed_url)
+        self.assertIsNone(page.lang_rss_feed_url)
+
+        settings['TRANSLATION_FEED_RSS'] = None
+        settings['TRANSLATION_FEED_ATOM'] = None
+        page_kwargs['settings'] = settings
+
+        # if atom and rss translations settings are None
+        # 'lang_rss_feed_url' and 'lang_atom_feed_url' should
+        # return None
+        page = Page(**page_kwargs)
+        self.assertIsNone(page.lang_atom_feed_url)
+        self.assertIsNone(page.lang_rss_feed_url)
+
+        rss_path = '/we/speak/{lang}.rss.xml'
+        atom_path = '/we/speak/{lang}.atom.xml'
+        settings['TRANSLATION_FEED_RSS'] = rss_path
+        settings['TRANSLATION_FEED_ATOM'] = atom_path
+        page_kwargs['settings'] = settings
+
+        # if the language for the page is set 'lang_rss_feed_url'
+        # and 'lang_atom_feed_url' should return the formated path
+        page = Page(**page_kwargs)
+        self.assertEqual(
+            page.lang_atom_feed_url,
+            atom_path.format(lang=DEFAULT_CONFIG['DEFAULT_LANG'])
+        )
+        self.assertEqual(
+            page.lang_rss_feed_url,
+            rss_path.format(lang=DEFAULT_CONFIG['DEFAULT_LANG'])
+        )
+
     def test_save_as(self):
         # If a lang is not the default lang, save_as should be set
         # accordingly.

--- a/pelican/tests/test_urlwrappers.py
+++ b/pelican/tests/test_urlwrappers.py
@@ -86,3 +86,61 @@ class TestURLWrapper(unittest.TestCase):
         self.assertEqual(author1.slug, 'mr-senko')
         self.assertEqual(author2.slug, 'atodorov')
         self.assertEqual(author3.slug, 'krasimir')
+
+    def test_atom_feed_url(self):
+        settings = {
+            'URLWRAPPER_FEED_ATOM': None
+        }
+        wrapper = URLWrapper("A Smart Person", settings=settings)
+
+        # if '{}_FEED_ATOM' is None, then 'atom_feed_url' should
+        # also be None
+        self.assertIsNone(wrapper.atom_feed_url)
+
+        url = '/feed/{slug}.atom.xml'
+        settings['URLWRAPPER_FEED_ATOM'] = url
+        wrapper = URLWrapper("A Smart Person", settings=settings)
+
+        # if '{}_FEED_ATOM is set, then 'atom_feed_url' should
+        # return the url of the atom feed.
+        self.assertEqual(
+            wrapper.atom_feed_url,
+            url.format(slug='a smart person')
+        )
+
+        # if we update 'URLWrapper.slug', 'atom_feed_url'
+        # should also update.
+        wrapper.slug = 'not-a-smart-person'
+        self.assertEqual(
+            wrapper.atom_feed_url,
+            url.format(slug='not-a-smart-person')
+        )
+
+    def test_rss_feed_url(self):
+        settings = {
+            'URLWRAPPER_FEED_RSS': None
+        }
+        wrapper = URLWrapper("A Smart Person", settings=settings)
+
+        # if '{}_FEED_ATOM' is None, then 'atom_feed_url' should
+        # also be None
+        self.assertIsNone(wrapper.atom_feed_url)
+
+        url = '/feed/{slug}.rss.xml'
+        settings['URLWRAPPER_FEED_RSS'] = url
+        wrapper = URLWrapper("A Smart Person", settings=settings)
+
+        # if '{}_FEED_ATOM is set, then 'atom_feed_url' should
+        # return the url of the atom feed.
+        self.assertEqual(
+            wrapper.rss_feed_url,
+            url.format(slug='a smart person')
+        )
+
+        # if we update 'URLWrapper.slug', 'atom_feed_url'
+        # should also update.
+        wrapper.slug = 'not-a-smart-person'
+        self.assertEqual(
+            wrapper.rss_feed_url,
+            url.format(slug='not-a-smart-person')
+        )

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -17,17 +17,23 @@
         <link href="{{ FEED_DOMAIN }}/{% if FEED_RSS_URL %}{{ FEED_RSS_URL }}{% else %}{{ FEED_RSS }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
         {% endif %}
         {% if CATEGORY_FEED_ATOM and category %}
-        <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_ATOM_URL %}{{ CATEGORY_FEED_ATOM_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_ATOM|format(category.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Categories Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{{ category.atom_feed_url }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ category.name }} Category Atom Feed" />
         {% endif %}
         {% if CATEGORY_FEED_RSS and category %}
-        <link href="{{ FEED_DOMAIN }}/{% if CATEGORY_FEED_RSS_URL %}{{ CATEGORY_FEED_RSS_URL|format(category.slug) }}{% else %}{{ CATEGORY_FEED_RSS|format(category.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Categories RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{{ category.rss_feed_url }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} {{ category.name }} Category RSS Feed" />
         {% endif %}
         {% if TAG_FEED_ATOM and tag %}
-        <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_ATOM_URL %}{{ TAG_FEED_ATOM_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_ATOM|format(tag.slug) }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Tags Atom Feed" />
+        <link href="{{ FEED_DOMAIN }}/{{ tag.atom_feed_url }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ tag.name }} Tag Atom Feed" />
         {% endif %}
         {% if TAG_FEED_RSS and tag %}
-        <link href="{{ FEED_DOMAIN }}/{% if TAG_FEED_RSS_URL %}{{ TAG_FEED_RSS_URL|format(tag.slug) }}{% else %}{{ TAG_FEED_RSS|format(tag.slug) }}{% endif %}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} Tags RSS Feed" />
+        <link href="{{ FEED_DOMAIN }}/{{ tag.rss_feed_url }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} {{ tag.name }} Tags RSS Feed" />
         {% endif %}
+	{% if TRANSLATION_FEED_ATOM and article %}
+	<link href="{{ FEED_DOMAIN }}/{{ article.lang_atom_feed_url }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} {{ article.lang }} Translation Atom Feed" />
+	{% endif %}
+	{% if TRANSLATION_FEED_RSS and article %}
+	<link href="{{ FEED_DOMAIN }}/{{ article.lang_rss_feed_url }}" type="application/rss+xml" rel="alternate" title="{{ SITENAME }} {{ article.lang }} Translation RSS Feed" />
+	{% endif %}
         {% endblock head %}
 </head>
 

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -55,6 +55,22 @@ class URLWrapper(object):
         self._slug_from_name = False
         self._slug = slug
 
+    @property
+    def atom_feed_url(self):
+        feed_key = '{}_FEED_ATOM'.format(
+            self.__class__.__name__.upper())
+        feed_url = self.settings.get(feed_key, None)
+        if feed_url is not None:
+            return feed_url.format(slug=self.slug)
+
+    @property
+    def rss_feed_url(self):
+        feed_key = '{}_FEED_RSS'.format(
+            self.__class__.__name__.upper())
+        feed_url = self.settings.get(feed_key, None)
+        if feed_url is not None:
+            return feed_url.format(slug=self.slug)
+
     def as_dict(self):
         d = self.__dict__
         d['name'] = self.name


### PR DESCRIPTION
Hi everyone!

After my first try (#2510) I found @avaris [comment](https://github.com/getpelican/pelican/issues/2442#issuecomment-438660830) that I thought was a much better approach to this, but had a few questions I wanted to run past everyone.

The main idea from that thread was that we should try to avoid theme creators generating their own urls manually. Mainly to prevent things from breaking when changes are made in the future. Like Atom and RSS Feed settings :)

This fix will add ```atom_feed_url``` and ```rss_feed_url``` attributes to the ```Tag```, ```Category```, and ```Author``` objects, as well as add ```lang_rss_feed_url``` and ```lang_atom_feed_url``` to the ```Content``` object.

I've also included updates to the 'simple' theme to use these attributes, that my first attempt fixed, but didn't address the real issue of building urls in the themes directly.

This does not update the documentation, or setup any tests to make sure this works properly mainly because I wasn't sure what to do about the ```FEED_ATOM, FEED_RSS, FEED_ALL_ATOM, FEED_ALL_RSS``` settings. To me it would be wierd to have:

``` jinja2
<link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" />
```
for all content, and

``` jinja2
<link href="{{ FEED_DOMAIN }}/{{ tag.atom_feed_url }}" />
<link href="{{ FEED_DOMAIN }}/{{ article.lang_atom_feed_url }}" />
...
```
for each category and translation.

My plan was to get an idea of what everyone though before I finish the documentation and tests.

So here are my questions for some of the more veteran developers.

* Why don't we treat translations like we do with Categories and Tags by having a Translation object? Would that make sense if we did?

* What should we do about the ```FEED_ATOM, FEED_URL``` settings? Should they stay as they are and let theme developers use them directly? or should we have a Feeds object passed as another Common Variable to all the templates? (eg: ```feed.atom_all_url```)

Going the common variable route would give us the ability to prevent using the settings that don't need formatting in the theme directly. So that's a plus

Sorry for the wall of text. 
Hope everyone is having a great 2019!



