### PR TITLE
Fix _DEFAULT_LANGUAGE in pelican-quickstart

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -34,7 +34,7 @@ except ValueError:
     # Don't fail on macosx: "unknown locale: UTF-8"
     _DEFAULT_LANGUAGE = None
 if _DEFAULT_LANGUAGE is None:
-    _DEFAULT_LANGUAGE = 'English'
+    _DEFAULT_LANGUAGE = 'en'
 else:
     _DEFAULT_LANGUAGE = _DEFAULT_LANGUAGE.split('_')[0]
 


### PR DESCRIPTION
This closes #2517 (also see related #2481) by changing line 37 on pelican_quickstart.py from ` _DEFAULT_LANGUAGE = 'English'` to ` _DEFAULT_LANGUAGE = 'en'` -- this is necessary to escape the warning (for Windows users) from docutils upon executing `pelican content`

Note: this warning behavior only appears on Windows because `locale.getlocale()` returns `(None, None)`

It's a minor issue and simplistic fix, but seemingly important so that Quickstart on the docs performs without warnings.

Thanks for keeping Pelican up to date!
