### PR TITLE
Add livereload invoke task. Fixes #1326

### DIFF
--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -146,6 +146,12 @@ http://localhost:8000/::
 
     invoke serve
 
+To serve the generated site with automatic browser reloading every time a
+change is detected, first ``pip install livereload``, then use the
+following command::
+
+    invoke livereload
+
 If during the ``pelican-quickstart`` process you answered "yes" when asked
 whether you want to upload your site via SSH, you can use the following command
 to publish your site via rsync over SSH::

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -7,7 +7,14 @@ import datetime
 
 from invoke import task
 from invoke.util import cd
+from livereload import Server
 from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
+from pelican.settings import DEFAULT_CONFIG, get_settings_from_file
+
+SETTINGS = {}
+SETTINGS.update(DEFAULT_CONFIG)
+LOCAL_SETTINGS = get_settings_from_file('pelicanconf.py')
+SETTINGS.update(LOCAL_SETTINGS)
 
 CONFIG = {
     # Local path configuration (can be absolute or relative to tasks.py)
@@ -79,6 +86,19 @@ def reserve(c):
 def preview(c):
     """Build production version of site"""
     c.run('pelican -s publishconf.py')
+
+@task
+def livereload(c):
+    """Automatically reload browser tab upon file modification."""
+    build(c)
+    server = Server()
+    deploy_path = CONFIG['deploy_path']
+    content_path = SETTINGS['PATH']
+    content_file_extensions = ['.md', '.rst']
+    for file_extension in content_file_extensions:
+        content_blob = '{0}/**/*{1}'.format(content_path, file_extension)
+        server.watch(content_blob, lambda: build(c))
+    server.serve(root=deploy_path)
 
 {% if cloudfiles %}
 @task

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -7,7 +7,6 @@ import datetime
 
 from invoke import task
 from invoke.util import cd
-from livereload import Server
 from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
 from pelican.settings import DEFAULT_CONFIG, get_settings_from_file
 
@@ -90,6 +89,7 @@ def preview(c):
 @task
 def livereload(c):
     """Automatically reload browser tab upon file modification."""
+    from livereload import Server
     build(c)
     server = Server()
     deploy_path = CONFIG['deploy_path']

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 requires = ['feedgenerator >= 1.9', 'jinja2 >= 2.7', 'pygments', 'docutils',
             'pytz >= 0a', 'blinker', 'unidecode', 'six >= 1.4',
-            'python-dateutil']
+            'python-dateutil', 'livereload']
 
 entry_points = {
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 requires = ['feedgenerator >= 1.9', 'jinja2 >= 2.7', 'pygments', 'docutils',
             'pytz >= 0a', 'blinker', 'unidecode', 'six >= 1.4',
-            'python-dateutil', 'livereload']
+            'python-dateutil']
 
 entry_points = {
     'console_scripts': [


### PR DESCRIPTION
Adds a `livereload` invoke task that reloads the browser window when
content files are updated.

Usage:

```console
$ invoke livereload
[I 190202 16:28:30 server:298] Serving on http://127.0.0.1:5500
[I 190202 16:28:30 handlers:59] Start watching changes
[I 190202 16:28:30 handlers:61] Start detecting changes
[I 190202 16:28:32 handlers:132] Browser Connected: http://127.0.0.1:5500/
```

See: https://livereload.readthedocs.io/en/latest/