### PR TITLE
Remove Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - TOX_ENV=docs
   - TOX_ENV=flake8
   - TOX_ENV=py27
-  - TOX_ENV=py34
   - TOX_ENV=py35
 matrix:
   include:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,7 +1,7 @@
 Installing Pelican
 ##################
 
-Pelican currently runs best on Python 2.7.x and 3.4+; earlier versions of
+Pelican currently runs best on Python 2.7.x and 3.5+; earlier versions of
 Python are not supported.
 
 You can install Pelican via several different methods. The simplest is via

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -444,8 +444,8 @@ def get_instance(args):
 
     config_file = args.settings
     if config_file is None and os.path.isfile(DEFAULT_CONFIG_NAME):
-            config_file = DEFAULT_CONFIG_NAME
-            args.settings = DEFAULT_CONFIG_NAME
+        config_file = DEFAULT_CONFIG_NAME
+        args.settings = DEFAULT_CONFIG_NAME
 
     settings = read_settings(config_file, override=get_config(args))
 

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -367,7 +367,7 @@ class HTMLReader(BaseReader):
     class _HTMLParser(HTMLParser):
         def __init__(self, settings, filename):
             try:
-                # Python 3.4+
+                # Python 3.5+
                 HTMLParser.__init__(self, convert_charrefs=False)
             except TypeError:
                 HTMLParser.__init__(self)

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -524,11 +524,11 @@ def configure_settings(settings):
 
     # check content caching layer and warn of incompatibilities
     if settings.get('CACHE_CONTENT', False) and \
-       settings.get('CONTENT_CACHING_LAYER', '') == 'generator' and \
-       settings.get('WITH_FUTURE_DATES', False):
-            logger.warning(
-                "WITH_FUTURE_DATES conflicts with CONTENT_CACHING_LAYER "
-                "set to 'generator', use 'reader' layer instead")
+            settings.get('CONTENT_CACHING_LAYER', '') == 'generator' and \
+            settings.get('WITH_FUTURE_DATES', False):
+        logger.warning(
+            "WITH_FUTURE_DATES conflicts with CONTENT_CACHING_LAYER "
+            "set to 'generator', use 'reader' layer instead")
 
     # Warn if feeds are generated with both SITEURL & FEED_DOMAIN undefined
     feed_keys = [

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -102,8 +102,8 @@ class TestWordpressXmlImporter(unittest.TestCase):
     def test_ignore_empty_posts(self):
         self.assertTrue(self.posts)
         for (title, content, fname, date, author,
-             categ, tags, status, kind, format) in self.posts:
-                self.assertTrue(title.strip())
+                categ, tags, status, kind, format) in self.posts:
+            self.assertTrue(title.strip())
 
     def test_recognise_page_kind(self):
         """ Check that we recognise pages in wordpress, as opposed to posts """
@@ -111,9 +111,9 @@ class TestWordpressXmlImporter(unittest.TestCase):
         # Collect (title, filename, kind) of non-empty posts recognised as page
         pages_data = []
         for (title, content, fname, date, author,
-             categ, tags, status, kind, format) in self.posts:
-                if kind == 'page':
-                    pages_data.append((title, fname))
+                categ, tags, status, kind, format) in self.posts:
+            if kind == 'page':
+                pages_data.append((title, fname))
         self.assertEqual(2, len(pages_data))
         self.assertEqual(('Page', 'contact'), pages_data[0])
         self.assertEqual(('Empty Page', 'empty'), pages_data[1])
@@ -151,22 +151,22 @@ class TestWordpressXmlImporter(unittest.TestCase):
         self.assertTrue(self.posts)
         pages_data = []
         for (title, content, fname, date, author, categ,
-             tags, status, kind, format) in self.posts:
-                if kind == 'page' or kind == 'article':
-                    pass
-                else:
-                    pages_data.append((title, fname))
+                tags, status, kind, format) in self.posts:
+            if kind == 'page' or kind == 'article':
+                pass
+            else:
+                pages_data.append((title, fname))
         self.assertEqual(0, len(pages_data))
 
     def test_recognise_custom_post_type(self):
         self.assertTrue(self.custposts)
         cust_data = []
         for (title, content, fname, date, author, categ,
-             tags, status, kind, format) in self.custposts:
-                if kind == 'article' or kind == 'page':
-                    pass
-                else:
-                    cust_data.append((title, kind))
+                tags, status, kind, format) in self.custposts:
+            if kind == 'article' or kind == 'page':
+                pass
+            else:
+                cust_data.append((title, kind))
         self.assertEqual(3, len(cust_data))
         self.assertEqual(
             ('A custom post in category 4', 'custom1'),

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -22,7 +22,7 @@ from pelican.settings import read_settings
 from pelican.utils import SafeDatetime, slugify
 
 try:
-    from html import unescape  # py3.4+
+    from html import unescape  # py3.5+
 except ImportError:
     from six.moves.html_parser import HTMLParser
     unescape = HTMLParser().unescape

--- a/pelican/tools/pelican_themes.py
+++ b/pelican/tools/pelican_themes.py
@@ -81,9 +81,9 @@ def main():
     to_sym = args.to_symlink or args.clean
 
     if args.action:
-        if args.action is 'list':
+        if args.action == 'list':
             list_themes(args.verbose)
-        elif args.action is 'path':
+        elif args.action == 'path':
             print(_THEMES_PATH)
     elif to_install or args.to_remove or to_sym:
         if args.to_remove:

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -787,12 +787,15 @@ def folder_watcher(path, extensions, ignores=[]):
             dirs[:] = [x for x in dirs if not x.startswith(os.curdir)]
 
             for f in files:
-                if f.endswith(tuple(extensions)) and \
-                   not any(fnmatch.fnmatch(f, ignore) for ignore in ignores):
-                        try:
-                            yield os.stat(os.path.join(root, f)).st_mtime
-                        except OSError as e:
-                            logger.warning('Caught Exception: %s', e)
+                valid_extension = f.endswith(tuple(extensions))
+                file_ignored = any(
+                    fnmatch.fnmatch(f, ignore) for ignore in ignores
+                )
+                if valid_extension and not file_ignored:
+                    try:
+                        yield os.stat(os.path.join(root, f)).st_mtime
+                    except OSError as e:
+                        logger.warning('Caught Exception: %s', e)
 
     LAST_MTIME = 0
     while True:

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{27,34,35,36,37},docs,flake8
+envlist = py{27,35,36,37},docs,flake8
 
 [testenv]
 basepython =
     py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7


### PR DESCRIPTION
This PR removes the Python 3.4 tox task and updates references in the
code to Python 3.5+.

tox complains about Python 3.4, which is EOL after next month:

>py34 installed: DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).

This PR also fixes linting issues that caused the `flake8` CI stage to fail.