### PR TITLE
Remove/unregister metadata extension in MarkdownReader._parse_metadata()

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -318,6 +318,9 @@ class MarkdownReader(BaseReader):
         """Return the dict containing document metadata"""
         formatted_fields = self.settings['FORMATTED_FIELDS']
 
+        # unload meta extension to avoid parsing field values again
+        del self._md.preprocessors['meta']
+
         output = {}
         for name, value in meta.items():
             name = name.lower()


### PR DESCRIPTION
Fixes #1904.

When metadata is returned from the Markdown parser, it is further processed with that same object, resulting in the metadata fields being parsed again. This prevents using `FORMATTED_FIELDS` that are written like metadata fields (e.g. `title: Holidays: 2018`).

This commit removes/unregisters the metadata extension from self._md.preprocessors (`del`/`__delitem__` is used for backwards compatibility in python-markdown) before processing the metadata further. I have tested the commit with Tox and it works O.K., as well as on my own site. I'm unsure if this deserves an extra test case, especially considering this is more of a bug fix than a new feature. Your call.

Thanks for everything.