### PR TITLE
Fix bug in process_translations warning message generation that caused error with empty slugs

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -677,9 +677,12 @@ def process_translations(content_list, translation_id=None):
                              'attributes'.format(translation_id))
 
     for id_vals, items in groupby(content_list, attrgetter(*translation_id)):
-        items = list(items)
+        # prepare warning string
+        id_vals = (id_vals,) if len(translation_id) == 1 else id_vals
         with_str = 'with' + ', '.join([' {} "{{}}"'] * len(translation_id))\
             .format(*translation_id).format(*id_vals)
+
+        items = list(items)
         original_items = get_original_items(items, with_str)
         index.extend(original_items)
         for a in items:


### PR DESCRIPTION
Fixes https://github.com/getpelican/pelican/issues/2534

Instances of `operator.attrgetter` return a tuple if initialised with multiple arguments, but not if initialised with just one argument. Nevertheless, we would unpack that return value into a `format` call on our warning message. With most strings, this would just cause malformed warning messages as the first character was inserted and the rest ignored. But with empty strings, it caused a tuple index out of range error.