### PR TITLE
Docs: Remove redundant text and reorder settings for consistency

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -467,6 +467,14 @@ This would save your articles into something like
    The actual location a page draft which doesn't use the default language is
    saved at.
 
+.. data:: AUTHOR_URL = 'author/{slug}.html'
+
+   The URL to use for an author.
+
+.. data:: AUTHOR_SAVE_AS = 'author/{slug}.html'
+
+   The location to save an author.
+
 .. data:: CATEGORY_URL = 'category/{slug}.html'
 
    The URL to use for a category.
@@ -482,41 +490,6 @@ This would save your articles into something like
 .. data:: TAG_SAVE_AS = 'tag/{slug}.html'
 
    The location to save the tag page.
-
-.. data:: AUTHOR_URL = 'author/{slug}.html'
-
-   The URL to use for an author.
-
-.. data:: AUTHOR_SAVE_AS = 'author/{slug}.html'
-
-   The location to save an author.
-
-.. data:: YEAR_ARCHIVE_SAVE_AS = ''
-
-   The location to save per-year archives of your posts.
-
-.. data:: YEAR_ARCHIVE_URL = ''
-
-   The URL to use for per-year archives of your posts. Used only if you have
-   the ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
-
-.. data:: MONTH_ARCHIVE_SAVE_AS = ''
-
-   The location to save per-month archives of your posts.
-
-.. data:: MONTH_ARCHIVE_URL = ''
-
-   The URL to use for per-month archives of your posts. Used only if you have
-   the ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
-
-.. data:: DAY_ARCHIVE_SAVE_AS = ''
-
-   The location to save per-day archives of your posts.
-
-.. data:: DAY_ARCHIVE_URL = ''
-
-   The URL to use for per-day archives of your posts. Used only if you have the
-   ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
 
 .. note::
 
@@ -546,6 +519,33 @@ posts for the month at ``posts/2011/Aug/index.html``.
     This way a reader can remove a portion of your URL and automatically arrive
     at an appropriate archive of posts, without having to specify a page name.
 
+.. data:: YEAR_ARCHIVE_URL = ''
+
+   The URL to use for per-year archives of your posts. Used only if you have
+   the ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
+
+.. data:: YEAR_ARCHIVE_SAVE_AS = ''
+
+   The location to save per-year archives of your posts.
+
+.. data:: MONTH_ARCHIVE_URL = ''
+
+   The URL to use for per-month archives of your posts. Used only if you have
+   the ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
+
+.. data:: MONTH_ARCHIVE_SAVE_AS = ''
+
+   The location to save per-month archives of your posts.
+
+.. data:: DAY_ARCHIVE_URL = ''
+
+   The URL to use for per-day archives of your posts. Used only if you have the
+   ``{url}`` placeholder in ``PAGINATION_PATTERNS``.
+
+.. data:: DAY_ARCHIVE_SAVE_AS = ''
+
+   The location to save per-day archives of your posts.
+
 ``DIRECT_TEMPLATES`` work a bit differently than noted above. Only the
 ``_SAVE_AS`` settings are available, but it is available for any direct
 template.
@@ -553,18 +553,6 @@ template.
 .. data:: ARCHIVES_SAVE_AS = 'archives.html'
 
    The location to save the article archives page.
-
-.. data:: YEAR_ARCHIVE_SAVE_AS = ''
-
-   The location to save per-year archives of your posts.
-
-.. data:: MONTH_ARCHIVE_SAVE_AS = ''
-
-   The location to save per-month archives of your posts.
-
-.. data:: DAY_ARCHIVE_SAVE_AS = ''
-
-   The location to save per-day archives of your posts.
 
 .. data:: AUTHORS_SAVE_AS = 'authors.html'
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -728,12 +728,12 @@ Template pages
 
    The extensions to use when looking up template files from template names.
 
-.. data:: DIRECT_TEMPLATES = ['index', 'tags', 'categories', 'authors', 'archives']
+.. data:: DIRECT_TEMPLATES = ['index', 'authors', 'categories', 'tags', 'archives']
 
    List of templates that are used directly to render content. Typically direct
    templates are used to generate index pages for collections of content (e.g.,
-   tags and category index pages). If the tag and category collections are not
-   needed, set ``DIRECT_TEMPLATES = ['index', 'authors', 'archives']``
+   category and tag index pages). If the author, category and tag collections are not
+   needed, set ``DIRECT_TEMPLATES = ['index', 'archives']``
 
    ``DIRECT_TEMPLATES`` are searched for over paths maintained in
    ``THEME_TEMPLATES_OVERRIDES``.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -728,12 +728,12 @@ Template pages
 
    The extensions to use when looking up template files from template names.
 
-.. data:: DIRECT_TEMPLATES = ['index', 'categories', 'authors', 'archives']
+.. data:: DIRECT_TEMPLATES = ['index', 'tags', 'categories', 'authors', 'archives']
 
    List of templates that are used directly to render content. Typically direct
    templates are used to generate index pages for collections of content (e.g.,
    tags and category index pages). If the tag and category collections are not
-   needed, set ``DIRECT_TEMPLATES = ['index', 'archives']``
+   needed, set ``DIRECT_TEMPLATES = ['index', 'authors', 'archives']``
 
    ``DIRECT_TEMPLATES`` are searched for over paths maintained in
    ``THEME_TEMPLATES_OVERRIDES``.

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -82,11 +82,11 @@ dates           The same list of articles, but ordered by date,
                 ascending.
 drafts          The list of draft articles
 authors         A list of (author, articles) tuples, containing all
-                the authors.
+                the authors and corresponding articles (values)
 categories      A list of (category, articles) tuples, containing
                 all the categories and corresponding articles (values)
 tags            A list of (tag, articles) tuples, containing all
-                the tags.
+                the tags and corresponding articles (values)
 pages           The list of pages
 hidden_pages    The list of hidden pages
 draft_pages     The list of draft pages

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -81,10 +81,12 @@ articles        The list of articles, ordered descending by date.
 dates           The same list of articles, but ordered by date,
                 ascending.
 drafts          The list of draft articles
-tags            A list of (tag, articles) tuples, containing all
-                the tags.
+authors         A list of (author, articles) tuples, containing all
+                the authors.
 categories      A list of (category, articles) tuples, containing
                 all the categories and corresponding articles (values)
+tags            A list of (tag, articles) tuples, containing all
+                the tags.
 pages           The list of pages
 hidden_pages    The list of hidden pages
 draft_pages     The list of draft pages


### PR DESCRIPTION
- Remove redundant `YEAR`, `MONTH`, and `DAY` `_ARCHIVE_SAVE_AS` sections
- Move `AUTHOR_URL` and `AUTHOR_SAVE_AS` to match `AUTHOR`, `CATEGORY`, `TAG` order throughout the rest of the document
- Move `YEAR`, `MONTH`, and `DAY` `_ARCHIVE_URL` and `_ARCHIVE_SAVE_AS` sections below paragraph describing them; and match ( `_URL`, `_SAVE_AS` ) order throughout the rest of the document

Recommend viewing with `--diff-algorithm=patience`