### PR TITLE
Allow empty save_as in PAGINATION_PATTERNS for capping max page

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -262,8 +262,9 @@ class Writer(object):
 
                 localcontext = _get_localcontext(
                     context, page.save_as, paginated_kwargs, relative_urls)
-                _write_file(template, localcontext, self.output_path,
-                            page.save_as, override_output)
+                if page.save_as:
+                    _write_file(template, localcontext, self.output_path,
+                                page.save_as, override_output)
         else:
             # no pagination
             localcontext = _get_localcontext(


### PR DESCRIPTION
I want to limit the maximum number of older pages a viewer can visit, so here's a quick fix.

Just place settings like these in your `pelicanconf.py`:

    PAGINATION_PATTERNS = (
        (1, '{name}{extension}', '{name}{extension}'),
        (2, '{name}.{number:02d}{extension}', '{name}.{number:02d}{extension}'),
        (10, '#', ''),  # allow only up to 9 pages generated
    )


And it's done.

It's consistent with the rest of `*_SAVE_AS` settings convention.

