### PR TITLE
Update Tox config and fix failing CI envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
-  - "3.5"
+  - "3.6"
 env:
   - TOX_ENV=docs
   - TOX_ENV=flake8
   - TOX_ENV=py27
-  - TOX_ENV=py35
+  - TOX_ENV=py37
 matrix:
   include:
     - python: 3.6

--- a/pelican/server.py
+++ b/pelican/server.py
@@ -138,6 +138,6 @@ if __name__ == '__main__':
                 args.port, args.server)
     try:
         httpd.serve_forever()
-    except KeyboardInterrupt as e:
+    except KeyboardInterrupt:
         logger.info("Shutting down server.")
         httpd.socket.close()

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -485,20 +485,20 @@ class MdReaderTest(ReaderTest):
             _path('article_with_markdown_and_footnote.md'))
         expected_content = (
             '<p>This is some content'
-            '<sup id="fnref-1"><a class="footnote-ref" href="#fn-1"'
+            '<sup id="fnref:1"><a class="footnote-ref" href="#fn:1"'
             '>1</a></sup>'
             ' with some footnotes'
-            '<sup id="fnref-footnote"><a class="footnote-ref" '
-            'href="#fn-footnote">2</a></sup></p>\n'
+            '<sup id="fnref:footnote"><a class="footnote-ref" '
+            'href="#fn:footnote">2</a></sup></p>\n'
 
             '<div class="footnote">\n'
-            '<hr>\n<ol>\n<li id="fn-1">\n'
+            '<hr>\n<ol>\n<li id="fn:1">\n'
             '<p>Numbered footnote&#160;'
-            '<a class="footnote-backref" href="#fnref-1" '
+            '<a class="footnote-backref" href="#fnref:1" '
             'title="Jump back to footnote 1 in the text">&#8617;</a></p>\n'
-            '</li>\n<li id="fn-footnote">\n'
+            '</li>\n<li id="fn:footnote">\n'
             '<p>Named footnote&#160;'
-            '<a class="footnote-backref" href="#fnref-footnote"'
+            '<a class="footnote-backref" href="#fnref:footnote"'
             ' title="Jump back to footnote 2 in the text">&#8617;</a></p>\n'
             '</li>\n</ol>\n</div>')
         expected_metadata = {

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     - coveralls
 
 [testenv:docs]
-basepython = python2.7
+basepython = python3.7
 deps =
     -rrequirements/docs.pip
 changedir = docs
@@ -34,7 +34,7 @@ application-import-names = pelican
 import-order-style = cryptography
 
 [testenv:flake8]
-basepython = python2.7
+basepython = python3.7
 deps =
     -rrequirements/style.pip
 commands =


### PR DESCRIPTION
Updates Python version for flake8 and docs Tox envs from 2.7 to 3.7.

This fixes deprecation warnings related to Python 2.7 on Travis CI in these tasks:

>DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.

This PR also fixes a failing test and a linting error that caused other CI envs to fail.