### PR TITLE
Update CI config and fix failing CI envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
-  - "3.5"
+  - "3.6"
 env:
   - TOX_ENV=docs
   - TOX_ENV=flake8
   - TOX_ENV=py27
-  - TOX_ENV=py35
+  - TOX_ENV=py36
 matrix:
   include:
     - python: 3.6

--- a/pelican/server.py
+++ b/pelican/server.py
@@ -138,6 +138,6 @@ if __name__ == '__main__':
                 args.port, args.server)
     try:
         httpd.serve_forever()
-    except KeyboardInterrupt as e:
+    except KeyboardInterrupt:
         logger.info("Shutting down server.")
         httpd.socket.close()

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     - coveralls
 
 [testenv:docs]
-basepython = python2.7
+basepython = python3.6
 deps =
     -rrequirements/docs.pip
 changedir = docs
@@ -34,7 +34,7 @@ application-import-names = pelican
 import-order-style = cryptography
 
 [testenv:flake8]
-basepython = python2.7
+basepython = python3.6
 deps =
     -rrequirements/style.pip
 commands =


### PR DESCRIPTION
Updates base Python version for Travis and Tox to 3.6.

This fixes deprecation warnings related to Python 2.7 on Travis CI in some tasks:

>DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.

Fixes a linting error that caused the linting build to fail.