### PR TITLE
Enhance Invoke livereload task

### DIFF
--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -102,6 +102,13 @@ def livereload(c):
     for extension in content_file_extensions:
         content_blob = '{0}/**/*{1}'.format(SETTINGS['PATH'], extension)
         server.watch(content_blob, lambda: build(c))
+    # Watch the theme's templates and static assets
+    theme_path = SETTINGS['THEME']
+    server.watch('{}/templates/*.html'.format(theme_path), lambda: build(c))
+    static_file_extensions = ['.css', '.js']
+    for extension in static_file_extensions:
+        static_file = '{0}/static/**/*{1}'.format(theme_path, extension)
+        server.watch(static_file, lambda: build(c))
     # Serve output path on configured port
     server.serve(port=CONFIG['port'], root=CONFIG['deploy_path'])
 

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -95,13 +95,12 @@ def livereload(c):
     from livereload import Server
     build(c)
     server = Server()
-    deploy_path = CONFIG['deploy_path']
-    content_path = SETTINGS['PATH']
+    # Watch content source files
     content_file_extensions = ['.md', '.rst']
-    for file_extension in content_file_extensions:
-        content_blob = '{0}/**/*{1}'.format(content_path, file_extension)
+    for extension in content_file_extensions:
+        content_blob = '{0}/**/*{1}'.format(SETTINGS['PATH'], extension)
         server.watch(content_blob, lambda: build(c))
-    server.serve(root=deploy_path)
+    server.serve(root=CONFIG['deploy_path'])
 
 {% if cloudfiles %}
 @task

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -95,6 +95,8 @@ def livereload(c):
     from livereload import Server
     build(c)
     server = Server()
+    # Watch the base settings file
+    server.watch(CONFIG['settings_base'], lambda: build(c))
     # Watch content source files
     content_file_extensions = ['.md', '.rst']
     for extension in content_file_extensions:

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -100,7 +100,8 @@ def livereload(c):
     for extension in content_file_extensions:
         content_blob = '{0}/**/*{1}'.format(SETTINGS['PATH'], extension)
         server.watch(content_blob, lambda: build(c))
-    server.serve(root=CONFIG['deploy_path'])
+    # Serve output path on configured port
+    server.serve(port=CONFIG['port'], root=CONFIG['deploy_path'])
 
 {% if cloudfiles %}
 @task


### PR DESCRIPTION
Main changes are:

* Instead of using LiveReload's default port (5500), use the existing `port` value from the task's CONFIG dictionary, which defaults to 8000.
* Add Pelican's settings file to the list of watched files
* Add theme's templates and static assets (CSS + JS) to the list of watched files

Related to #1326 and #2526. cc: @bhrutledge, @johnfraney