### PR TITLE
Skip TestServer test on non-Linux platforms

### DIFF
--- a/pelican/tests/test_server.py
+++ b/pelican/tests/test_server.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from shutil import rmtree
 from tempfile import mkdtemp
 
@@ -17,6 +18,7 @@ class MockServer(object):
     pass
 
 
+@unittest.skipUnless(sys.platform.startswith("linux"), "requires Linux")
 class TestServer(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
The `os.mknod()` call in `test_get_path_that_exists` causes an error on non-Linux platforms. For example, on macOS 10.13.6 it seems `mknod()` requires super-user privileges:
```
======================================================================
ERROR: test_get_path_that_exists (pelican.tests.test_server.TestServer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Virtualenvs/pelican-dev/pelican/pelican/tests/test_server.py", line 38, in test_get_path_that_exists
    os.mknod(os.path.join(self.temp_output, 'foo.html'))
PermissionError: [Errno 1] Operation not permitted
```
I don't believe Windows supports `mknod()` either, so to work around this for the moment, I added a decorator to skip this test on non-Linux platforms.

@oulenz: Can you think of a cross-platform alternative method of handling this? Methinks that would be preferable to my workaround.