### PR TITLE
Replace os.mknod with open for macos and windows compatibility

### DIFF
--- a/pelican/tests/test_server.py
+++ b/pelican/tests/test_server.py
@@ -35,12 +35,12 @@ class TestServer(unittest.TestCase):
                                             self.server)
         handler.base_path = self.temp_output
 
-        os.mknod(os.path.join(self.temp_output, 'foo.html'))
+        open(os.path.join(self.temp_output, 'foo.html'), 'a').close()
         os.mkdir(os.path.join(self.temp_output, 'foo'))
-        os.mknod(os.path.join(self.temp_output, 'foo', 'index.html'))
+        open(os.path.join(self.temp_output, 'foo', 'index.html'), 'a').close()
 
         os.mkdir(os.path.join(self.temp_output, 'bar'))
-        os.mknod(os.path.join(self.temp_output, 'bar', 'index.html'))
+        open(os.path.join(self.temp_output, 'bar', 'index.html'), 'a').close()
 
         os.mkdir(os.path.join(self.temp_output, 'baz'))
 


### PR DESCRIPTION
Fix issue raised in https://github.com/getpelican/pelican/pull/2588

As far as I can tell, this is also supposed to work on MacOS and Windows, but I haven't tested it..