### PR TITLE
Consolidate version strings in pyproject.toml

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2010 – present, Alexis Metaireau and contributors'
 exclude_patterns = ['_build']
 release = __version__
 version = '.'.join(release.split('.')[:1])
-last_stable = '4.0.1'
+last_stable = __version__
 rst_prolog = '''
 .. |last_stable| replace:: :pelican-doc:`{0}`
 '''.format(last_stable)

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -32,7 +32,12 @@ from pelican.utils import (clean_output_dir, file_watcher,
                            folder_watcher, maybe_pluralize)
 from pelican.writers import Writer
 
-__version__ = "4.0.2.dev0"
+try:
+    __version__ = __import__('pkg_resources') \
+        .get_distribution('pelican').version
+except Exception:
+    __version__ = "unknown"
+
 DEFAULT_CONFIG_NAME = 'pelicanconf.py'
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,28 @@
 #!/usr/bin/env python
+import re
 import sys
 from io import open
 from os import walk
 from os.path import join, relpath
 
 from setuptools import setup
+
+
+def get_version():
+    VERSION_REGEX = re.compile(
+        r"^version\s*=\s*\"(?P<version>.*)\"$"
+    )
+    with open("pyproject.toml") as f:
+        for line in f:
+            match = VERSION_REGEX.match(line)
+
+            if match:
+                return match.group("version")
+
+    return None
+
+
+version = get_version()
 
 requires = ['feedgenerator >= 1.9', 'jinja2 >= 2.7', 'pygments', 'docutils',
             'pytz >= 0a', 'blinker', 'unidecode', 'six >= 1.4',
@@ -28,7 +46,7 @@ if sys.version_info.major < 3:
 
 setup(
     name='pelican',
-    version='4.0.2.dev0',
+    version=version,
     url='https://getpelican.com/',
     author='Alexis Metaireau',
     maintainer='Justin Mayer',


### PR DESCRIPTION
Storing the current version in a single place greatly simplifies issuing new package releases. I'm working on some new automation tooling, and having the version string exist solely in `pyproject.toml` will help that endeavor significantly.