### PR TITLE
Use relative paths only in StaticGenerator

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -800,8 +800,7 @@ class StaticGenerator(Generator):
 
     def generate_context(self):
         self.staticfiles = []
-        linked_files = {os.path.join(self.path, path)
-                        for path in self.context['static_links']}
+        linked_files = set(self.context['static_links'])
         found_files = self.get_files(self.settings['STATIC_PATHS'],
                                      exclude=self.settings['STATIC_EXCLUDES'],
                                      extensions=False)


### PR DESCRIPTION
While trying to write a plugin for post-processing static files, I saw that `context['staticfiles']` had duplicate entries for the same file. I checked `StaticGenerator.generate_context` and I found that we're using absolute paths for linked static files and relative paths for static files from `STATIC_PATHS`.

I fixed it by using relative paths for linked files.