### PR TITLE
fix log formatting of iterable objects

### DIFF
--- a/pelican/log.py
+++ b/pelican/log.py
@@ -28,9 +28,10 @@ class BaseFormatter(logging.Formatter):
         record.__dict__['customlevelname'] = customlevel
         # format multiline messages 'nicely' to make it clear they are together
         record.msg = record.msg.replace('\n', '\n  | ')
-        record.args = tuple(arg.replace('\n', '\n  | ') if
-                            isinstance(arg, six.string_types) else
-                            arg for arg in record.args)
+        if isinstance(args, tuple):
+            record.args = tuple(arg.replace('\n', '\n  | ') if
+                                isinstance(arg, six.string_types) else
+                                arg for arg in record.args)
         return super(BaseFormatter, self).format(record)
 
     def formatException(self, ei):


### PR DESCRIPTION
If logged object is a dictionary (or any other iterable object), 1 argument is extected to a number of items in the object by `BaseFormatter`  in attempt to prettify a message. This would result in a invalid message format with unexpected numbers of arguments.

```
import logging
logger = logging.getLogger(__name__)
logger.debug('my dict: %s', {'here': 'is', 'my': 'dict'})
```

Which results in the following error:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 868, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 741, in format
    return fmt.format(record)
  File "/usr/local/lib/python2.7/dist-packages/pelican/log.py", line 34, in format
    return super(BaseFormatter, self).format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```

introduce by https://github.com/getpelican/pelican/commit/dd76c7158f7e05b0d203818d3fe18bea26e48c3f in #2438

"Solution": try to prettify arguments only if it's a tuple: `logger.debug('my message: %s and %s', 'foo', 'bar')`

This requires review and thourugh testing.