### PR TITLE
Add AutoPub to auto-publish releases on PR merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,31 @@ before_install:
 install:
   - pip install tox==2.5.0
 script: tox -e $TOX_ENV
+before_deploy:
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+  - pip install githubrelease
+  - pip install --pre autopub
+  - autopub check || travis_terminate 0
+  - pip install poetry
+  - pip install twine
+  - git checkout ${TRAVIS_BRANCH}
+  - git remote set-url origin https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG
+deploy:
+  provider: script
+  script: autopub deploy
+  skip_cleanup: true
+  on:
+    branch: master
+    python: "3.7"
 notifications:
   irc:
     channels:
       - "irc.freenode.org#pelican"
     on_success: change
+env:
+  global:
+    - PYPI_USERNAME=autopub
+    - secure: "h5V/+YL+CrqvfAesNkSb824Ngk5x+f0eFzj/LBbmnzjvArKAmc6R6WGyx8SDD7WF/PlaTf0M1fH3a7pjIS8Ee+TS1Rb0Lt1HPqUs1yntg1+Js2ZQp3p20wfsDc+bZ4/2g8xLsSMv1EJ4np7/GJ5fXqpSxjr/Xs5LYA7ZLwNNwDw="
+    - secure: "GiDFfmjH7uzYNnkjQMV/mIkbRdmgkGmtbFPeaj9taBNA5tPp3IBt3GOOS6UL/zm9xiwu9Xo6sxZWkGzY19Hsdv28YPH34N3abo0QSnz4IGiHs152Hi7Qi6Tb0QkT5D3OxuSIm8LmFL7+su89Q7vBFowrT6HL1Mn8CDDWSj3eqbo="
+    - TWINE_USERNAME=$PYPI_USERNAME
+    - TWINE_PASSWORD=$PYPI_PASSWORD

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,6 +97,14 @@ Using Git and GitHub
   For example, if you're hacking on a new feature and find a bugfix that
   doesn't *require* your new feature, **make a new distinct branch and pull
   request** for the bugfix.
+* Add a ``RELEASE.md`` file in the root of the project that contains the
+  release type (major, minor, patch) and a summary of the changes that will be
+  used as the release changelog entry. For example::
+
+       Release type: minor
+
+       Reload browser window upon changes to content, settings, or theme
+
 * Check for unnecessary whitespace via ``git diff --check`` before committing.
 * First line of your commit message should start with present-tense verb, be 50
   characters or less, and include the relevant issue number(s) if applicable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,12 @@ markdown = ["markdown"]
 [tool.poetry.scripts]
 pelican = "pelican.__main__:main"
 
+[tool.autopub]
+project-name = "Pelican"
+git-username = "botpub"
+git-email = "botpub@autopub.rocks"
+version-strings = ["setup.py"]
+build-system = "setuptools"
+
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,5 +60,4 @@ markdown = ["markdown"]
 pelican = "pelican.__main__:main"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["setuptools >= 40.6.0", "wheel"]


### PR DESCRIPTION
Contributors will henceforth be asked to include a `RELEASE.md` file containing the release type (major, minor, patch) and a summary of the changes in the pull request. This information will be used by the continuous integration (CI) system to automatically publish a new release to PyPI when the pull request is merged.

For more details, see: https://github.com/autopub/autopub