### PR TITLE
Add FEED_START_DATE to shortcut initial feed entries

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -931,6 +931,14 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    Maximum number of items allowed in a feed. Feed item quantity is
    unrestricted by default.
 
+.. data:: FEED_START_DATE
+
+   Date from the first entry expected in the new generated feed. Date format
+   is defined as "%Y-%m-%d" i.e. "2019-07-31".
+   This setting is specially useful to migrated blogs that used to have an
+   original feed and do not want every single post been parsed again, or
+   set a cut date for feed start to be generated.
+
 .. data:: RSS_FEED_SUMMARY_ONLY = True
 
    Only include item summaries in the ``description`` tag of RSS feeds. If set
@@ -1238,7 +1246,7 @@ ignored. Simply populate the list with the log messages you want to hide, and
 they will be filtered out.
 
 For example::
-    
+
    import logging
    LOG_FILTER = [(logging.WARN, 'TAG_SAVE_AS is set to False')]
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -50,6 +50,7 @@ DEFAULT_CONFIG = {
     'AUTHOR_FEED_RSS': posix_join('feeds', '{slug}.rss.xml'),
     'TRANSLATION_FEED_ATOM': posix_join('feeds', 'all-{lang}.atom.xml'),
     'FEED_MAX_ITEMS': '',
+    'FEED_START_DATE': '',
     'RSS_FEED_SUMMARY_ONLY': True,
     'SITEURL': '',
     'SITENAME': 'A Pelican Blog',

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -3,10 +3,13 @@ from __future__ import print_function, unicode_literals, with_statement
 
 import logging
 import os
+from datetime import datetime
 
 from feedgenerator import Atom1Feed, Rss201rev2Feed, get_tag_uri
 
 from jinja2 import Markup
+
+import pytz
 
 import six
 from six.moves.urllib.parse import urljoin
@@ -147,7 +150,15 @@ class Writer(object):
         max_items = len(elements)
         if self.settings['FEED_MAX_ITEMS']:
             max_items = min(self.settings['FEED_MAX_ITEMS'], max_items)
+
+        feed_start_date = None
+        if self.settings['FEED_START_DATE']:
+            feed_start_date = \
+                datetime.strptime(self.settings['FEED_START_DATE'], "%Y-%m-%d")
+            feed_start_date = pytz.utc.localize(feed_start_date)
         for i in range(max_items):
+            if feed_start_date and elements[i].date < feed_start_date:
+                continue
             self._add_item_to_the_feed(feed, elements[i])
 
         signals.feed_generated.send(context, feed=feed)


### PR DESCRIPTION
Usually feed parsers from different systems ignores past entries from
the original migraated blog when catch a new feed,
then simply repost all entries of the newly migrated
blog/site again, making an unwanted side effect.

This option enables to decide when the newly created site should
create the feeds and provide the proper atom/rss outputs