### PR TITLE
Fix PAGINATION_PATTERNS documentation example

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -997,7 +997,7 @@ subsequent pages at ``.../page/2/`` etc, you could set ``PAGINATION_PATTERNS``
 as follows::
 
   PAGINATION_PATTERNS = (
-      (1, '{url}', '{save_as}`,
+      (1, '{url}', '{save_as}'),
       (2, '{base_name}/page/{number}/', '{base_name}/page/{number}/index.html'),
   )
 


### PR DESCRIPTION
The example for PAGINATION_PATTERNS is invalid and fails if someone would  just copy and paste into their own `pelicanconf.py`.

This should fix it.