### PR TITLE
Skip some non-Windows tests on Windows

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,9 @@
 Release type: patch
 
-Skip some tests (on Windows) that are un-able to pass on Windows due to the
-difference in Windows vs Linux filesystems.
+* Fix quick-start docs regarding `pelican --listen`
+* Set default listen address to 127.0.0.1
+* Add extra/optional Markdown dependency to setup.py
+* Use correct SSH port syntax for rsync in tasks.py
+* Place all deprecated settings handling together
+* Add related project URLs for display on PyPI
+* Skip some tests on Windows that can't pass due to filesystem differences

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+Skip some tests (on Windows) that are un-able to pass on Windows due to the
+difference in Windows vs Linux filesystems.

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -14,9 +14,10 @@ import six
 from pelican.contents import Article, Author, Category, Page, Static
 from pelican.settings import DEFAULT_CONFIG
 from pelican.signals import content_object_init
-from pelican.tests.support import LoggedTestCase, get_context, get_settings,\
-    unittest
-from pelican.utils import SafeDatetime, path_to_url, truncate_html_words
+from pelican.tests.support import (LoggedTestCase, get_context, get_settings,
+                                   unittest)
+from pelican.utils import (SafeDatetime, path_to_url, posixize_path,
+                           truncate_html_words)
 
 
 # generate one paragraph, enclosed with <p>
@@ -943,7 +944,7 @@ class TestStatic(LoggedTestCase):
             source_path=os.path.join('dir', 'foo.jpg'),
             context=self.settings.copy())
 
-        expected_save_as = os.path.join('dir', 'foo.jpg')
+        expected_save_as = posixize_path(os.path.join('dir', 'foo.jpg'))
         self.assertEqual(static.status, 'draft')
         self.assertEqual(static.save_as, expected_save_as)
         self.assertEqual(static.url, path_to_url(expected_save_as))

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -1089,7 +1089,12 @@ class TestStaticGenerator(unittest.TestCase):
         os.mkdir(os.path.join(self.temp_output, "static"))
         self.generator.fallback_to_symlinks = True
         self.generator.generate_context()
-        self.generator.generate_output(None)
+        try:
+            self.generator.generate_output(None)
+        except OSError as e:
+            # On Windows, possibly others, due to not holding symbolic link
+            # privilege
+            self.skipTest(e)
         self.assertTrue(os.path.islink(self.endfile))
 
     def test_existing_symlink_is_considered_up_to_date(self):
@@ -1097,7 +1102,11 @@ class TestStaticGenerator(unittest.TestCase):
         with open(self.startfile, "w") as f:
             f.write("staticcontent")
         os.mkdir(os.path.join(self.temp_output, "static"))
-        os.symlink(self.startfile, self.endfile)
+        try:
+            os.symlink(self.startfile, self.endfile)
+        except OSError as e:
+            # On Windows, possibly others
+            self.skipTest(e)
         staticfile = MagicMock()
         staticfile.source_path = self.startfile
         staticfile.save_as = self.endfile
@@ -1109,7 +1118,11 @@ class TestStaticGenerator(unittest.TestCase):
         with open(self.startfile, "w") as f:
             f.write("staticcontent")
         os.mkdir(os.path.join(self.temp_output, "static"))
-        os.symlink("invalid", self.endfile)
+        try:
+            os.symlink("invalid", self.endfile)
+        except OSError as e:
+            # On Windows, possibly others
+            self.skipTest(e)
         staticfile = MagicMock()
         staticfile.source_path = self.startfile
         staticfile.save_as = self.endfile

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -717,6 +717,8 @@ class TestDateFormatter(unittest.TestCase):
 
 
 class TestSanitisedJoin(unittest.TestCase):
+    @unittest.skipIf(platform == 'win32',
+                     "Different filesystem root on Windows")
     def test_detect_parent_breakout(self):
         with six.assertRaisesRegex(
                 self,
@@ -727,6 +729,8 @@ class TestSanitisedJoin(unittest.TestCase):
                 "../test"
             )
 
+    @unittest.skipIf(platform == 'win32',
+                     "Different filesystem root on Windows")
     def test_detect_root_breakout(self):
         with six.assertRaisesRegex(
                 self,
@@ -737,6 +741,8 @@ class TestSanitisedJoin(unittest.TestCase):
                 "/test"
             )
 
+    @unittest.skipIf(platform == 'win32',
+                     "Different filesystem root on Windows")
     def test_pass_deep_subpaths(self):
         self.assertEqual(
             utils.sanitised_join(


### PR DESCRIPTION
Some tests will never pass on Windows due to differences in filesystems between
Windows and Linux.