### PR TITLE
Set default content status to a blank string rather than `None`.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+Release type: patch
+
+Set default content status to a blank string rather than `None`. Fixes
+[#2558](https://github.com/getpelican/pelican/issues/2558). Fixes issues
+encountered by comment plugins among others
+([1](https://github.com/bstpierre/pelican-comments/pull/4),
+[2](https://github.com/Scheirle/pelican_comment_system/issues/8)).

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -141,7 +141,9 @@ class Content(object):
 
         # manage status
         if not hasattr(self, 'status'):
-            self.status = getattr(self, 'default_status', None)
+            # using None as the default here breaks comment plugins (and
+            # probably others)
+            self.status = getattr(self, 'default_status', '')
 
         # store the summary metadata if it is set
         if 'summary' in metadata:


### PR DESCRIPTION
Fixes #2558. Fixes issues encountered by comment plugins among others.

c.f. [1](https://github.com/bstpierre/pelican-comments/pull/4), [2](https://github.com/Scheirle/pelican_comment_system/issues/8), [3](https://github.com/Scheirle/pelican_comment_system/pull/7)