### PR TITLE
Fix pelican.settings.load_source to avoid caching issues

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix pelican.settings.load_source to avoid caching issues - PR #2621

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -14,12 +14,16 @@ import six
 
 from pelican.log import LimitFilter
 
+
 try:
-    # SourceFileLoader is the recommended way in Python 3.3+
-    from importlib.machinery import SourceFileLoader
+    # spec_from_file_location is the recommended way in Python 3.5+
+    import importlib.util
 
     def load_source(name, path):
-        return SourceFileLoader(name, path).load_module()
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
 except ImportError:
     # but it does not exist in Python 2.7, so fall back to imp
     import imp


### PR DESCRIPTION
I met this caching issue while working on `pelican-plugins` CI : https://github.com/getpelican/pelican-plugins/issues/1170

In this context, `pelican.settings.load_source` is repeatedly called in the same `nostests` process, and when `name='pelicanconf'` the same settings are returned on subsequent calls to `read_settings`.

Here is a minimal code example reproducing the issue : https://chezsoi.org/shaarli/?hBpGew
