### PR TITLE
 New feature: support for {include} syntax. Fixes #1902.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*.swp
 .*.swo
 *.pyc
+.cache/
 .DS_Store
 docs/_build
 docs/fr/_build
@@ -16,3 +17,4 @@ six-*.egg/
 venv
 samples/output
 *.pem
+pip-wheel-metadata/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add support for the ``{include}`` syntax

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -369,6 +369,45 @@ Linking to authors, categories, index and tags
 You can link to authors, categories, index and tags using the ``{author}name``,
 ``{category}foobar``, ``{index}`` and ``{tag}tagname`` syntax.
 
+Including common text into your content
+---------------------------------------
+
+From Pelican 4.2 onward, you can include common text snippets into your content using
+the ``{include}file.ext`` syntax. You can specify semi-absolute paths starting
+from the ``PATH`` directory, e.g. ``{include}/pages/disclaimer.html`` or use
+relative paths, e.g. ``{include}notice.html``. Relativity is
+calculated based on the location of the file containing the ``{include}``.
+For example when you have the following content layout::
+
+    content
+    └── notice2.html
+    └── pages
+        ├── page1.html
+        └── notice1.html
+
+Then the includes may look like::
+
+    <html>
+        <head>
+            <title>PAGE 1</title>
+        </head>
+        <body>
+            This is the content of page 1
+
+            {include}../notice2.html
+        </body>
+    </html>
+
+
+``notice2.html`` looks like::
+
+    {include}pages/notice1.html
+    This is the second warning about relative paths
+
+When using ``{include}`` it is best to blacklist the included files using the
+``IGNORE_FILES`` setting. Otherwise Pelican will try to render them as regular
+content and will most likely fail!
+
 Deprecated internal link syntax
 -------------------------------
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -155,16 +155,15 @@ class Generator(object):
 
             if os.path.isdir(root):
                 for dirpath, dirs, temp_files in os.walk(
-                        root, followlinks=True):
-                    drop = []
+                        root, topdown=True, followlinks=True):
                     excl = exclusions_by_dirpath.get(dirpath, ())
-                    for d in dirs:
+                    # We copy the `dirs` list as we will modify it in the loop:
+                    for d in list(dirs):
                         if (d in excl or
                             any(fnmatch.fnmatch(d, ignore)
                                 for ignore in ignores)):
-                            drop.append(d)
-                    for d in drop:
-                        dirs.remove(d)
+                            if d in dirs:
+                                dirs.remove(d)
 
                     reldir = os.path.relpath(dirpath, self.path)
                     for f in temp_files:

--- a/pelican/tests/content/include/html_from_subdir_includer.md
+++ b/pelican/tests/content/include/html_from_subdir_includer.md
@@ -1,0 +1,5 @@
+_includes HTML_:
+
+{include}subdir/include_other.html
+
+^Included content above^

--- a/pelican/tests/content/include/html_includer.md
+++ b/pelican/tests/content/include/html_includer.md
@@ -1,0 +1,5 @@
+_includes HTML_:
+
+{include}included.html
+
+^Included content above^

--- a/pelican/tests/content/include/html_includer.rst
+++ b/pelican/tests/content/include/html_includer.rst
@@ -1,0 +1,6 @@
+Article including some HTML file
+################################
+
+{include}included.html
+
+^Included content above^

--- a/pelican/tests/content/include/html_includer_with_full_path.md
+++ b/pelican/tests/content/include/html_includer_with_full_path.md
@@ -1,0 +1,5 @@
+_includes HTML_:
+
+{include}/pelican/tests/content/include/included.html
+
+^Included content above^

--- a/pelican/tests/content/include/include_other.html
+++ b/pelican/tests/content/include/include_other.html
@@ -1,0 +1,1 @@
+{include}include_sibling.html

--- a/pelican/tests/content/include/include_sibling.html
+++ b/pelican/tests/content/include/include_sibling.html
@@ -1,0 +1,1 @@
+{include}include_other.html

--- a/pelican/tests/content/include/included.html
+++ b/pelican/tests/content/include/included.html
@@ -1,0 +1,1 @@
+<span>this content has been included</span>

--- a/pelican/tests/content/include/included.md
+++ b/pelican/tests/content/include/included.md
@@ -1,0 +1,2 @@
+**this is Markdown**
+Here is a [link](https://docs.getpelican.com).

--- a/pelican/tests/content/include/included.py
+++ b/pelican/tests/content/include/included.py
@@ -1,0 +1,5 @@
+import antigravity
+
+import this
+
+_ = antigravity + this

--- a/pelican/tests/content/include/included.rst
+++ b/pelican/tests/content/include/included.rst
@@ -1,0 +1,2 @@
+**this is reStructuredText**
+Here is a `link <https://docs.getpelican.com>`_.

--- a/pelican/tests/content/include/includer_of_md_includer.md
+++ b/pelican/tests/content/include/includer_of_md_includer.md
@@ -1,0 +1,5 @@
+START
+
+{include}md_includer.md
+
+END

--- a/pelican/tests/content/include/inexisting_file_includer.md
+++ b/pelican/tests/content/include/inexisting_file_includer.md
@@ -1,0 +1,5 @@
+_includes HTML_:
+
+{include}inexisting_file.html
+
+^Included content above^

--- a/pelican/tests/content/include/md_includer.html
+++ b/pelican/tests/content/include/md_includer.html
@@ -1,0 +1,2 @@
+<em>includes Markdown</em>: {include}included.md
+^Included content above^

--- a/pelican/tests/content/include/md_includer.md
+++ b/pelican/tests/content/include/md_includer.md
@@ -1,0 +1,2 @@
+_inline includes Markdown_: {include}included.md
+^Included content above^

--- a/pelican/tests/content/include/py_includer.md
+++ b/pelican/tests/content/include/py_includer.md
@@ -1,0 +1,3 @@
+```
+{include}included.py
+```

--- a/pelican/tests/content/include/py_includer.rst
+++ b/pelican/tests/content/include/py_includer.rst
@@ -1,0 +1,6 @@
+Article with an indented code block
+###################################
+
+.. code-block:: python
+
+    {include}included.py

--- a/pelican/tests/content/include/rst_includer.rst
+++ b/pelican/tests/content/include/rst_includer.rst
@@ -1,0 +1,5 @@
+Article with an inline included reStructuredText file
+#####################################################
+
+Inline includes *reStructuredText*: {include}included.rst
+^Included content above^

--- a/pelican/tests/content/include/subdir/include_other.html
+++ b/pelican/tests/content/include/subdir/include_other.html
@@ -1,0 +1,2 @@
+this file includes another via absolute path
+{include}/pelican/tests/content/include/subdir/include_parent.html

--- a/pelican/tests/content/include/subdir/include_parent.html
+++ b/pelican/tests/content/include/subdir/include_parent.html
@@ -1,0 +1,2 @@
+this file includes another in a parent directory
+{include}../included.html

--- a/pelican/tests/test_cache.py
+++ b/pelican/tests/test_cache.py
@@ -33,6 +33,7 @@ class TestCache(unittest.TestCase):
         settings['CACHE_CONTENT'] = True
         settings['LOAD_CONTENT_CACHE'] = True
         settings['CACHE_PATH'] = self.temp_cache
+        settings['IGNORE_FILES'] = ['include']
         return settings
 
     def test_generator_caching(self):

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -183,6 +183,7 @@ class TestArticlesGenerator(unittest.TestCase):
         settings['DEFAULT_DATE'] = (1970, 1, 1)
         settings['READERS'] = {'asc': None}
         settings['CACHE_CONTENT'] = False
+        settings['IGNORE_FILES'] = ['include']
         context = get_context(settings)
 
         cls.generator = ArticlesGenerator(
@@ -307,6 +308,7 @@ class TestArticlesGenerator(unittest.TestCase):
         settings['USE_FOLDER_AS_CATEGORY'] = False
         settings['CACHE_PATH'] = self.temp_cache
         settings['READERS'] = {'asc': None}
+        settings['IGNORE_FILES'] = ['include']
         context = get_context(settings)
         generator = ArticlesGenerator(
             context=context, settings=settings,
@@ -404,6 +406,7 @@ class TestArticlesGenerator(unittest.TestCase):
         settings['YEAR_ARCHIVE_SAVE_AS'] = 'posts/{date:%Y}/index.html'
         settings['YEAR_ARCHIVE_URL'] = 'posts/{date:%Y}/'
         settings['CACHE_PATH'] = self.temp_cache
+        settings['IGNORE_FILES'] = ['include']
         context = get_context(settings)
         generator = ArticlesGenerator(
             context=context, settings=settings,
@@ -514,6 +517,7 @@ class TestArticlesGenerator(unittest.TestCase):
                                         # DEFAULT_CATEGORY
                                         ('category', 'Random'),
                                         ('tags', 'general, untagged'))
+        settings['IGNORE_FILES'] = ['include']
         context = get_context(settings)
         generator = ArticlesGenerator(
             context=context, settings=settings,
@@ -543,6 +547,7 @@ class TestArticlesGenerator(unittest.TestCase):
         settings['DEFAULT_CATEGORY'] = 'Default'
         settings['DEFAULT_DATE'] = (1970, 1, 1)
         settings['ARTICLE_ORDER_BY'] = 'title'
+        settings['IGNORE_FILES'] = ['include']
         context = get_context(settings)
 
         generator = ArticlesGenerator(
@@ -590,6 +595,7 @@ class TestArticlesGenerator(unittest.TestCase):
         settings['DEFAULT_CATEGORY'] = 'Default'
         settings['DEFAULT_DATE'] = (1970, 1, 1)
         settings['ARTICLE_ORDER_BY'] = 'reversed-title'
+        settings['IGNORE_FILES'] = ['include']
         context = get_context(settings)
 
         generator = ArticlesGenerator(

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -207,8 +207,12 @@ class TestPelican(LoggedTestCase):
         mute(True)(pelican.run)()
         logger.setLevel(orig_level)
         self.assertLogCountEqual(
-            count=2,
-            msg="Writing .*",
+            count=1,
+            msg='Writing .+/oh-yeah.html',
+            level=logging.INFO)
+        self.assertLogCountEqual(
+            count=1,
+            msg='Writing .+/categories.html',
             level=logging.INFO)
 
     def test_cyclic_intersite_links_no_warnings(self):


### PR DESCRIPTION
I took over @atodorov work started in https://github.com/getpelican/pelican/pull/1909 in order to complete this feature. I changed the code accordingly to the recommandations in the original PR.

The new {include} syntax makes it possible to include
frequently used text snippets into your content.
