### PR TITLE
Add extra/optional Markdown dependency to setup.py

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,6 +9,10 @@ You can install Pelican via several different methods. The simplest is via
 
     pip install pelican
 
+Or, if you plan on using Markdown::
+
+    pip install pelican[Markdown]
+
 (Keep in mind that operating systems will often require you to prefix the above
 command with ``sudo`` in order to install Pelican system-wide.)
 
@@ -40,7 +44,11 @@ Optional packages
 -----------------
 
 If you plan on using `Markdown <http://pypi.python.org/pypi/Markdown>`_ as a
-markup format, you'll need to install the Markdown library::
+markup format, you can install Pelican with Markdown support::
+
+   pip install pelican[Markdown]
+
+Or you might need to install it a posteriori::
 
     pip install Markdown
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ Install Pelican (and optionally Markdown if you intend to use it) on Python
 2.7.x or Python 3.5+ by running the following command in your preferred
 terminal, prefixing with ``sudo`` if permissions warrant::
 
-    pip install pelican markdown
+    pip install pelican[Markdown]
 
 Create a project
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(
                           for name in names],
     },
     install_requires=requires,
+    extras_require={
+        'Markdown': ['markdown~=3.1.1']
+    },
     entry_points=entry_points,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
## PR contents
- Fixes #2585
- Adds `extras_require` for Markdown optional feature.
- Modifies documentation to use the extra dependency in order to install the recommended markdown package version.
- There is no `RELEASE.md` because I wasn't sure it was appropriate. Just let me know and I'll add it.

## Testing
1. Create new Python 3 venv and activate it.
2. Install wheel: `$ pip install wheel`.
3. Setup Pelican for development: `$ python setup.py develop`.
4. Install Pelican with optional markdown: `$ pip install pelican[markdown]`.
5. Verify that the `markdown` package is installed.

Tested again without optional markdown and verify that it's not installed.