### PR TITLE
Extend stale bot issue closure window

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+daysUntilClose: 30
+
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
 
@@ -10,7 +16,7 @@ exemptMilestones: true
 exemptAssignees: true
 
 # Label to use when marking as stale
-staleLabel: retired
+staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >


### PR DESCRIPTION
I saw that this issue I just been closed by the bot : https://github.com/getpelican/pelican/issues/2536
and I think that's a good example of case where I am a bit sad it did so.
I think the discussion did not really found a satisfying conclusion there.