### PR TITLE
Add missing striptags filter to simple theme

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block html_lang %}{{ article.lang }}{% endblock %}
 
-{% block title %}{{ SITENAME }} - {{ article.title }}{% endblock %}
+{% block title %}{{ SITENAME }} - {{ article.title|striptags  }}{% endblock %}
 
 {% block head %}
   {{ super() }}

--- a/pelican/themes/simple/templates/page.html
+++ b/pelican/themes/simple/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block html_lang %}{{ page.lang }}{% endblock %}
 
-{% block title %}{{ SITENAME }} - {{ page.title }}{%endblock%}
+{% block title %}{{ SITENAME }} - {{ page.title|striptags }}{%endblock%}
 
 {% block head %}
   {{ super() }}


### PR DESCRIPTION
``page.title`` are missing ``striptags`` in title block.

Page titles might get some extra html (from typogrify) then html tags end up in title block, ie within ``html head title`` element.