### PR TITLE
Remove Python 2.7 support from settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   matrix:
     - TOX_ENV=docs
     - TOX_ENV=flake8
-    - TOX_ENV=py27
     - TOX_ENV=py35
     - TOX_ENV=py36
 matrix:

--- a/THANKS
+++ b/THANKS
@@ -117,6 +117,7 @@ Nico Di Rocco
 Nicolas Duhamel
 Nicolas Perriault
 Nicolas Steinmetz
+Paolo Melchiorre
 Paul Asselin
 Pavel Puchkin
 Perry Roper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ classifiers = [
     "Framework :: Pelican",
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
@@ -29,7 +27,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.5"
+python = "^3.5"
 feedgenerator = "^1.9"
 jinja2 = "~2.10.1"
 pygments = "^2.4"

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ setup(
         'Framework :: Pelican',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{27,35,36,37},docs,flake8
+envlist = py{35,36,37},docs,flake8
 
 [testenv]
 basepython =
-    py27: python2.7
     py35: python3.5
     py36: python3.6
     py37: python3.7


### PR DESCRIPTION
As requested by @justinmayer  in #2645 I've just opened a PR to remove Python 2.7 support from some settings.

I'm not familiar with poetry, so I left `poetry.lock` as is.