### PR TITLE
fix: tag like C++ and C# are treated as a same tag

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -144,7 +144,9 @@ DEFAULT_CONFIG = {
     'TEMPLATE_EXTENSIONS': ['.html'],
     'IGNORE_FILES': ['.#*'],
     'SLUG_REGEX_SUBSTITUTIONS': [
-        (r'[^\w\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars
+        # remove all characters except alphanumeric, whitespace,
+        # '_', '-', '+', '#' characters
+        (r'[^\w\s\-#\+]', ''),
         (r'(?u)\A\s*', ''),  # strip leading whitespace
         (r'(?u)\s*\Z', ''),  # strip trailing whitespace
         (r'[-\s]+', '-'),  # reduce multiple whitespace or '-' to single '-'
@@ -387,7 +389,7 @@ def handle_deprecated_settings(settings):
 
                 if replace:
                     regex_subs += [
-                        (r'[^\w\s-]', ''),
+                        (r'[^\w\s\-#\+]', ''),
                         (r'(?u)\A\s*', ''),
                         (r'(?u)\s*\Z', ''),
                         (r'[-\s]+', '-'),

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -125,7 +125,7 @@ class TestUtils(LoggedTestCase):
     def test_slugify_substitute(self):
 
         samples = (('C++ is based on C', 'cpp-is-based-on-c'),
-                   ('C+++ test C+ test', 'cpp-test-c-test'),
+                   ('C+++ test C+ test', 'cpp+-test-c+-test'),
                    ('c++, c#, C#, C++', 'cpp-c-sharp-c-sharp-cpp'),
                    ('c++-streams', 'cpp-streams'),)
 


### PR DESCRIPTION
## Problem

Create an article. Use tags `C++` and `C#`.

A single article has used the tags `C++` and `C#`. Therefore count of articles in these tags should be one. Instead you get 2 articles for each of these tags. The same article is added twice.

## Why it happens?

The problem starts from [this line](https://github.com/getpelican/pelican/blob/master/pelican/generators.py#L654).

```python
                    self.tags[tag].append(article)
```

Keys tag `C++` and tag `C#` overwrite each other.

Why do they overwrite? Url_wrapper class uses [this regex](https://github.com/getpelican/pelican/blob/master/pelican/settings.py#L147) to create hash of the object.

```python
        (r'[^\w\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars
```

This regex removes `+` and `#` from a tag. Hence `C++` and `C#` both become `C`.

## Solution

This patch changes the regex to allow `+` and `#` characters.
slug method is also used to get the filename and url. Both of these characters are allowed in filenames and in URLs.

---
<sup>Related to https://github.com/Pelican-Elegant/elegant/issues/516</sup>