### PR TITLE
Support --exclude-from for rsync publishing using excludes.txt

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -347,6 +347,14 @@ needed by Pelican.
                 fd.close()
         except OSError as e:
             print('Error: {0}'.format(e))
+        try:
+            with open(os.path.join(CONF['basedir'], 'excludes.txt'),
+                      'w', 'utf-8') as fd:
+                _template = _jinja_env.get_template('excludes.txt.jinja2')
+                fd.write(_template.render(**CONF))
+                fd.close()
+        except OSError as e:
+            print('Error: {0}'.format(e))
 
     print('Done. Your new project is available at %s' % CONF['basedir'])
 

--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -125,7 +125,7 @@ ssh_upload: publish
 
 {% set upload = upload + ["rsync_upload"] %}
 rsync_upload: publish
-	rsync -e "ssh -p $(SSH_PORT)" -P -rvzc --cvs-exclude --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
+	rsync -e "ssh -p $(SSH_PORT)" -P -rvzc --cvs-exclude --exclude-from=excludes.txt --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 
 {% endif %}
 {% if dropbox %}

--- a/pelican/tools/templates/excludes.txt.jinja2
+++ b/pelican/tools/templates/excludes.txt.jinja2
@@ -1,0 +1,4 @@
+# Files to exclude with rsync(1) during publishing.
+# See the INCLUDE/EXCLUDE PATTERN RULES section of the rsync man page.
+
+.DS_Store

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -131,7 +131,7 @@ def publish(c):
     """Publish to production via rsync"""
     c.run('pelican -s {settings_publish}'.format(**CONFIG))
     c.run(
-        'rsync --delete --exclude ".DS_Store" -pthrvz -c '
+        'rsync --delete --exclude-from=excludes.txt -pthrvz -c '
         '-e "ssh -p {ssh_port}" '
         '{} {ssh_user}@{ssh_host}:{ssh_path}'.format(
             CONFIG['deploy_path'].rstrip('/') + '/',


### PR DESCRIPTION
Add an excludes.txt example file where users can list rsync exclude
specifications.  If the site you are publishing has any paths on the
remote site that Pelican should ignore and not remove, list them in
excludes.txt so they are not removed each time you do:

    make rsync_upload

The example file has a comment pointing users to the rsync man page
for information on the format used in exclude files.  The only entry
in it by default is the .DS_Store entry which was from the rsync
command in tasks.py.