### PR TITLE
Fix a typo in the pagination settings docs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -997,7 +997,7 @@ subsequent pages at ``.../page/2/`` etc, you could set ``PAGINATION_PATTERNS``
 as follows::
 
   PAGINATION_PATTERNS = (
-      (1, '{url}', '{save_as}',
+      (1, '{url}', '{save_as}'),
       (2, '{base_name}/page/{number}/', '{base_name}/page/{number}/index.html'),
   )
 


### PR DESCRIPTION
The pagination settings docs have a typo:

```python
PAGINATION_PATTERNS = (
    (1, '{url}', '{save_as}',  # <-- This is missing a closing parenthesis
    (2, '{base_name}/page/{number}/', '{base_name}/page/{number}/index.html'),
)
```

It seems so minor that I didn't add a RELEASE.md file, but if this is necessary I'll add that, too.