### PR TITLE
Remove CSS references to the non-existent digg.png icon

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Remove the reference to the non-existent digg.png icon in main.css.

--- a/pelican/tests/output/basic/theme/css/main.css
+++ b/pelican/tests/output/basic/theme/css/main.css
@@ -326,7 +326,6 @@ div.figure p.caption, figure p.caption { /* margin provided by figure */
 		.social a[href*='about.me'] {background-image: url('../images/icons/aboutme.png');}
 		.social a[href*='bitbucket.org'] {background-image: url('../images/icons/bitbucket.png');}
 		.social a[href*='delicious.com'] {background-image: url('../images/icons/delicious.png');}
-		.social a[href*='digg.com'] {background-image: url('../images/icons/digg.png');}
 		.social a[href*='facebook.com'] {background-image: url('../images/icons/facebook.png');}
 		.social a[href*='gitorious.org'] {background-image: url('../images/icons/gitorious.png');}
 		.social a[href*='github.com'],

--- a/pelican/tests/output/custom/theme/css/main.css
+++ b/pelican/tests/output/custom/theme/css/main.css
@@ -326,7 +326,6 @@ div.figure p.caption, figure p.caption { /* margin provided by figure */
 		.social a[href*='about.me'] {background-image: url('../images/icons/aboutme.png');}
 		.social a[href*='bitbucket.org'] {background-image: url('../images/icons/bitbucket.png');}
 		.social a[href*='delicious.com'] {background-image: url('../images/icons/delicious.png');}
-		.social a[href*='digg.com'] {background-image: url('../images/icons/digg.png');}
 		.social a[href*='facebook.com'] {background-image: url('../images/icons/facebook.png');}
 		.social a[href*='gitorious.org'] {background-image: url('../images/icons/gitorious.png');}
 		.social a[href*='github.com'],

--- a/pelican/tests/output/custom_locale/theme/css/main.css
+++ b/pelican/tests/output/custom_locale/theme/css/main.css
@@ -326,7 +326,6 @@ div.figure p.caption, figure p.caption { /* margin provided by figure */
 		.social a[href*='about.me'] {background-image: url('../images/icons/aboutme.png');}
 		.social a[href*='bitbucket.org'] {background-image: url('../images/icons/bitbucket.png');}
 		.social a[href*='delicious.com'] {background-image: url('../images/icons/delicious.png');}
-		.social a[href*='digg.com'] {background-image: url('../images/icons/digg.png');}
 		.social a[href*='facebook.com'] {background-image: url('../images/icons/facebook.png');}
 		.social a[href*='gitorious.org'] {background-image: url('../images/icons/gitorious.png');}
 		.social a[href*='github.com'],

--- a/pelican/themes/notmyidea/static/css/main.css
+++ b/pelican/themes/notmyidea/static/css/main.css
@@ -326,7 +326,6 @@ div.figure p.caption, figure p.caption { /* margin provided by figure */
 		.social a[href*='about.me'] {background-image: url('../images/icons/aboutme.png');}
 		.social a[href*='bitbucket.org'] {background-image: url('../images/icons/bitbucket.png');}
 		.social a[href*='delicious.com'] {background-image: url('../images/icons/delicious.png');}
-		.social a[href*='digg.com'] {background-image: url('../images/icons/digg.png');}
 		.social a[href*='facebook.com'] {background-image: url('../images/icons/facebook.png');}
 		.social a[href*='gitorious.org'] {background-image: url('../images/icons/gitorious.png');}
 		.social a[href*='github.com'],


### PR DESCRIPTION
`main.css` in the notmyidea theme contains a reference to a non-existant digg.png icon. I searched the git history and couldn't find a reference to it so I wasn't able to restore it (assuming it ever existed).

I've removed the line in the CSS that references the file and updated the unit test output files. Please let me know if there's anything else required. Thanks!