### PR TITLE
Docs: Add info about pelican-quickstart command path flag.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,9 +102,12 @@ your site::
 
     pelican-quickstart
 
-If it is running inside a virtual environment it will try to detect the path
-associated to it and save the project there. A custom path can be configured
-using the ``--path`` flag.
+If run inside an activated virtual environment, ``pelican-quickstart`` will
+look for an associated project path inside ``$VIRTUAL_ENV/.project``. If that
+file exists and contains a valid directory path, the new Pelican project will
+be saved at that location. Otherwise, the default is the current working
+directory. To set the new project path on initial invocation, use:
+``pelican-quickstart --path /your/desired/directory``
 
 Once you finish answering all the questions, your project will consist of the
 following hierarchy (except for *pages* — shown in parentheses below — which

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,6 +102,10 @@ your site::
 
     pelican-quickstart
 
+If it is running inside a virtual environment it will try to detect the path
+associated to it and save the project there. A custom path can be configured
+using the ``--path`` flag.
+
 Once you finish answering all the questions, your project will consist of the
 following hierarchy (except for *pages* — shown in parentheses below — which
 you can optionally add yourself if you plan to create non-chronological

--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -200,7 +200,7 @@ needed by Pelican.
     no_path_was_specified = hasattr(args.path, 'is_default_path')
     if os.path.isfile(project) and no_path_was_specified:
         CONF['basedir'] = open(project, 'r').read().rstrip("\n")
-        print('Using project associated with current virtual environment.'
+        print('Using project associated with current virtual environment. '
               'Will save to:\n%s\n' % CONF['basedir'])
     else:
         CONF['basedir'] = os.path.abspath(os.path.expanduser(


### PR DESCRIPTION
Resolves https://github.com/getpelican/pelican/issues/2608.

Adds a short paragraph about the `path` flag for the `pelican-quickstart` command to save the new project into a different directory than the venv one.