### PR TITLE
listen: handle KeyboardInterrupt

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -474,6 +474,9 @@ def listen(server, port, output, excqueue=None):
             excqueue.put(traceback.format_exception_only(type(e), e)[-1])
         return
 
+    except KeyboardInterrupt:
+        logger.info("Shutting down server.")
+        httpd.socket.close()
 
 def main(argv=None):
     args = parse_arguments(argv)


### PR DESCRIPTION
Current response to Ctrl+C with `pelican --listen` is to bail with an
exception.

Instead, exit proper and show a message.

Fixes #2676