### PR TITLE
Add a devserver-global Make task for non-local dev testing

### DIFF
--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -114,6 +114,13 @@ else
 	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
 endif
 
+devserver-global:
+ifdef PORT
+	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT) -b 0.0.0.0
+else
+	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -b 0.0.0.0
+endif
+
 publish:
 	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
 


### PR DESCRIPTION
The devserver target recently acquired a sane default of restricting
access only to localhost. This is good for security. However, it can
frustrate some usages like testing on phones on a local network or
hosting the dev server within VMs (e.g. Docker for Mac) which see host
OS browsers as not being 127.0.0.1.

Add a new target called `devserver-global` for this case. As it's longer
to type, the more svelte `devserver` will retain the more secure
defaults that will suffice for most users; they can use the
longer-to-type `devserver-global` target to relax the localhost-only
restriction.