### PR TITLE
Fix bug of open function parameter in pelican_quickstart

### DIFF
--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -309,7 +309,7 @@ needed by Pelican.
 
     try:
         with open(os.path.join(CONF['basedir'], 'pelicanconf.py'),
-                  'w', 'utf-8') as fd:
+                  'w', encoding='utf-8') as fd:
             conf_python = dict()
             for key, value in CONF.items():
                 conf_python[key] = repr(value)
@@ -322,7 +322,7 @@ needed by Pelican.
 
     try:
         with open(os.path.join(CONF['basedir'], 'publishconf.py'),
-                  'w', 'utf-8') as fd:
+                  'w', encoding='utf-8') as fd:
             _template = _jinja_env.get_template('publishconf.py.jinja2')
             fd.write(_template.render(**CONF))
             fd.close()
@@ -332,7 +332,7 @@ needed by Pelican.
     if automation:
         try:
             with open(os.path.join(CONF['basedir'], 'tasks.py'),
-                      'w', 'utf-8') as fd:
+                  'w', encoding='utf-8') as fd:
                 _template = _jinja_env.get_template('tasks.py.jinja2')
                 fd.write(_template.render(**CONF))
                 fd.close()
@@ -340,7 +340,7 @@ needed by Pelican.
             print('Error: {0}'.format(e))
         try:
             with open(os.path.join(CONF['basedir'], 'Makefile'),
-                      'w', 'utf-8') as fd:
+                      'w', encoding='utf-8') as fd:
                 py_v = 'python3'
                 _template = _jinja_env.get_template('Makefile.jinja2')
                 fd.write(_template.render(py_v=py_v, **CONF))


### PR DESCRIPTION
Fix a small bug about the encoding parameter of the open function


Signed-off-by: xiaojieluo <xiaojieluoff@gmail.com>