### PR TITLE
Add image tag for cover image of articles.

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -286,6 +286,7 @@ class ArticlesGenerator(CachingGenerator):
         self.categories = defaultdict(list)
         self.related_posts = []
         self.authors = defaultdict(list)
+        self.images = defaultdict(list)
         self.drafts = []                   # only drafts in default language
         self.drafts_translations = []
         super().__init__(*args, **kwargs)

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -42,7 +42,8 @@ DUPLICATES_DEFINITIONS_ALLOWED = {
     'save_as': False,
     'url': False,
     'authors': False,
-    'slug': False
+    'slug': False,
+    'image': False
 }
 
 METADATA_PROCESSORS = {
@@ -60,6 +61,7 @@ METADATA_PROCESSORS = {
         for author in ensure_metadata_list(x)
     ] or _DISCARD),
     'slug': lambda x, y: x.strip() or _DISCARD,
+    'image': lambda x, y: x.strip() or _DISCARD
 }
 
 logger = logging.getLogger(__name__)

--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -30,6 +30,9 @@
  {% import 'translations.html' as translations with context %}
  {{ translations.translations_for(article) }}
   </header>
+  {% if article.image %}
+    <img src="{{ article.image }}"/>
+  {% endif %}
   <footer class="post-info">
     <time class="published" datetime="{{ article.date.isoformat() }}">
       {{ article.locale_date }}

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -81,6 +81,7 @@ class Writer(object):
         feed.add_item(
             title=title,
             link=link,
+            image=item.image,
             unique_id=get_tag_uri(link, item.date),
             description=description,
             content=content,


### PR DESCRIPTION
So many blogs may need cover image in their articles. In this commit we add a
way to insert image in the article metadata. Also an example of how to use it
in a theme is added to the simple theme.