### PR TITLE
Fix LOG_FILTER to act on exact messages

### DIFF
--- a/pelican/log.py
+++ b/pelican/log.py
@@ -110,11 +110,13 @@ class LimitFilter(logging.Filter):
         else:
             self._raised_messages.add(message_key)
 
-        # ignore LOG_FILTER records by templates when "debug" isn't enabled
+        # ignore LOG_FILTER records by templates or messages
+        # when "debug" isn't enabled
         logger_level = logging.getLogger().getEffectiveLevel()
         if logger_level > logging.DEBUG:
-            ignore_key = (record.levelno, record.msg)
-            if ignore_key in self._ignore:
+            template_key = (record.levelno, record.msg)
+            message_key = (record.levelno, record.getMessage())
+            if (template_key in self._ignore or message_key in self._ignore):
                 return False
 
         # check if we went over threshold

--- a/pelican/tests/test_log.py
+++ b/pelican/tests/test_log.py
@@ -1,0 +1,78 @@
+import logging
+import unittest
+from collections import defaultdict
+
+from pelican import log
+from pelican.tests.support import LogCountHandler
+
+
+class TestLog(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.logger = logging.getLogger(__name__)
+        self.handler = LogCountHandler()
+        self.logger.addHandler(self.handler)
+
+    def tearDown(self):
+        self._reset_limit_filter()
+        self.logger.removeHandler(self.handler)
+        super().tearDown()
+
+    def _reset_limit_filter(self):
+        log.LimitFilter._ignore = set()
+        log.LimitFilter._raised_messages = set()
+        log.LimitFilter._threshold = 5
+        log.LimitFilter._group_count = defaultdict(int)
+
+    def test_log_filter(self):
+        def do_logging():
+            for i in range(5):
+                self.logger.warning('Log %s', i)
+                self.logger.warning('Another log %s', i)
+        # no filter
+        do_logging()
+        self.assertEqual(
+            self.handler.count_logs('Log \\d', logging.WARNING),
+            5)
+        self.assertEqual(
+            self.handler.count_logs('Another log \\d', logging.WARNING),
+            5)
+        self.handler.flush()
+        self._reset_limit_filter()
+
+        # filter by template
+        log.LimitFilter._ignore.add((logging.WARNING, 'Log %s'))
+        do_logging()
+        self.assertEqual(
+            self.handler.count_logs('Log \\d', logging.WARNING),
+            0)
+        self.assertEqual(
+            self.handler.count_logs('Another log \\d', logging.WARNING),
+            5)
+        self.handler.flush()
+        self._reset_limit_filter()
+
+        # filter by exact message
+        log.LimitFilter._ignore.add((logging.WARNING, 'Log 3'))
+        do_logging()
+        self.assertEqual(
+            self.handler.count_logs('Log \\d', logging.WARNING),
+            4)
+        self.assertEqual(
+            self.handler.count_logs('Another log \\d', logging.WARNING),
+            5)
+        self.handler.flush()
+        self._reset_limit_filter()
+
+        # filter by both
+        log.LimitFilter._ignore.add((logging.WARNING, 'Log 3'))
+        log.LimitFilter._ignore.add((logging.WARNING, 'Another log %s'))
+        do_logging()
+        self.assertEqual(
+            self.handler.count_logs('Log \\d', logging.WARNING),
+            4)
+        self.assertEqual(
+            self.handler.count_logs('Another log \\d', logging.WARNING),
+            0)
+        self.handler.flush()
+        self._reset_limit_filter()


### PR DESCRIPTION
* Adds the ability to filter templated messages by exact message,
as well as templates.
* Adds a test for LimitFilter.

Fixes #2552,  #2682