### PR TITLE
Add support for themes to define their own defaults

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -529,16 +529,17 @@ def configure_settings(settings):
         preserved = {}
         logger.debug('Theme provides a config `%s`', theme_config)
         # preserve variables that are dynamically calculated in read_settings()
-        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'CACHE_PATH', 'PLUGIN_PATHS']:
+        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'CACHE_PATH',
+                  'PLUGIN_PATHS']:
             if settings.get(p) is not None:
                 preserved[p] = settings.get(p)
-        settings.pop('THEME') # avoid recursion
+        settings.pop('THEME')  # avoid recursion
         settings = read_settings(theme_config, settings)
         # restore them back to look like we did not calculate them again
-        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'CACHE_PATH', 'PLUGIN_PATHS']:
+        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'CACHE_PATH',
+                  'PLUGIN_PATHS']:
             if preserved.get(p) is not None:
                 settings[p] = preserved.pop(p)
-
 
     # make paths selected for writing absolute if necessary
     settings['WRITE_SELECTED'] = [

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -524,6 +524,22 @@ def configure_settings(settings):
             raise Exception("Could not find the theme %s"
                             % settings['THEME'])
 
+    theme_config = os.path.join(settings['THEME'], 'pelicanconf.py')
+    if os.path.isfile(theme_config):
+        preserved = {}
+        logger.debug('Theme provides a config `%s`', theme_config)
+        # preserve variables that are dynamically calculated in read_settings()
+        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'CACHE_PATH', 'PLUGIN_PATHS']:
+            if settings.get(p) is not None:
+                preserved[p] = settings.get(p)
+        settings.pop('THEME') # avoid recursion
+        settings = read_settings(theme_config, settings)
+        # restore them back to look like we did not calculate them again
+        for p in ['PATH', 'OUTPUT_PATH', 'THEME', 'CACHE_PATH', 'PLUGIN_PATHS']:
+            if preserved.get(p) is not None:
+                settings[p] = preserved.pop(p)
+
+
     # make paths selected for writing absolute if necessary
     settings['WRITE_SELECTED'] = [
         os.path.abspath(path) for path in

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -6,11 +6,13 @@ import os
 from os.path import abspath, dirname, join
 from sys import platform
 
+
 from pelican.settings import (DEFAULT_CONFIG, DEFAULT_THEME,
                               _printf_s_to_format_field,
                               configure_settings, handle_deprecated_settings,
                               read_settings)
 from pelican.tests.support import unittest
+
 
 class TestSettingsConfiguration(unittest.TestCase):
     """Provided a file, it should read it, replace the default values,
@@ -72,7 +74,7 @@ class TestSettingsConfiguration(unittest.TestCase):
         expected = copy.deepcopy(self.settings)
         expected['THEME'] = os.path.join(self.PATH, 'themes/custom')
         expected['CUSTOM_THEME_SETTING'] = 'test'
-        settings = read_settings(default_conf, { 'THEME': 'themes/custom' } )
+        settings = read_settings(default_conf, {'THEME': 'themes/custom'})
         self.maxDiff = None
         self.assertDictEqual(settings, expected)
 

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -6,13 +6,11 @@ import os
 from os.path import abspath, dirname, join
 from sys import platform
 
-
 from pelican.settings import (DEFAULT_CONFIG, DEFAULT_THEME,
                               _printf_s_to_format_field,
                               configure_settings, handle_deprecated_settings,
                               read_settings)
 from pelican.tests.support import unittest
-
 
 class TestSettingsConfiguration(unittest.TestCase):
     """Provided a file, it should read it, replace the default values,
@@ -65,6 +63,18 @@ class TestSettingsConfiguration(unittest.TestCase):
         settings['SITEURL'] = 'new-value'
         new_settings = read_settings(default_conf)
         self.assertNotEqual(new_settings['SITEURL'], settings['SITEURL'])
+
+    def test_theme_settings_applied(self):
+        # Make sure that the results from loading theme's config do not
+        # affect the previously defined system configuration
+        self.PATH = abspath(dirname(__file__))
+        default_conf = join(self.PATH, 'default_conf.py')
+        expected = copy.deepcopy(self.settings)
+        expected['THEME'] = os.path.join(self.PATH, 'themes/custom')
+        expected['CUSTOM_THEME_SETTING'] = 'test'
+        settings = read_settings(default_conf, { 'THEME': 'themes/custom' } )
+        self.maxDiff = None
+        self.assertDictEqual(settings, expected)
 
     def test_defaults_not_overwritten(self):
         # This assumes 'SITENAME': 'A Pelican Blog'

--- a/pelican/tests/themes/custom/pelicanconf.py
+++ b/pelican/tests/themes/custom/pelicanconf.py
@@ -1,0 +1,3 @@
+CUSTOM_THEME_SETTING = 'test'
+PATH = 'a path'
+AUTHOR = 'Test Suite'


### PR DESCRIPTION
Until #1564 is implemented (and it is a lot of work both on the technical side as well as public relations), I am proposing quite a simple enhancement to allow theme authors to define defaults for things they are using in their themes, e.g. I have configurable layout in the theme and the user could choose to display the navigation menu on the left or the right side, then I could provide the default using `pelicanconf.py` inside my theme folder.

The way this PR is implemented, the theme cannot override any of the system provided setting.  This means that the primary configuration file + command line arguments take precedence in all cases.  This choice was made consciously to avoid any unexpected outfalls from the change.

If the community decides that we actually want to give theme authors the power to mangle system settings, well, then we should discuss how to do it in a correct way (it gets a bit complicated, since , in my opinion, the theme config in this case should be able to override the `DEFAULT_CONFIG` settings, this way user's config and command-line arguments will override it if needed).