### PR TITLE
Fix output directory deletion logic

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -99,10 +99,11 @@ class Pelican(object):
             ) for cls in self.get_generator_classes()
         ]
 
-        # erase the directory if it is not the source and if that's
-        # explicitly asked
-        if (self.delete_outputdir and not
-                os.path.realpath(self.path).startswith(self.output_path)):
+        # Delete the output directory if (1) the appropriate setting is True
+        # and (2) that directory is not the parent of the source directory
+        if (self.delete_outputdir
+                and os.path.commonpath([self.output_path]) !=
+                os.path.commonpath([self.output_path, self.path])):
             clean_output_dir(self.output_path, self.output_retention)
 
         for p in generators:


### PR DESCRIPTION
The intention of the pre-existing code was to prevent accidental source content data loss by skipping output directory deletion if the output directory is a parent of the source content directory. But the previous implementation did so by checking path *strings*, resulting in scenarios where the following settings would erroneously skip deletion of the output directory:
```
PATH = "/repo/docs-src/content"
OUTPUT_PATH = "/repo/docs"
```
The output directory should have been deleted but wasn't because the PATH string contains "/repo/docs". This change eschews string comparison and instead compares actual paths to ensure that the output path is not a parent of the source content directory.

Closes #2137