### PR TITLE
Reset global state set by tests in test_pelican

### DIFF
--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -50,6 +50,7 @@ class TestPelican(LoggedTestCase):
         locale.setlocale(locale.LC_ALL, str('C'))
 
     def tearDown(self):
+        read_settings()  # cleanup PYGMENTS_RST_OPTIONS
         rmtree(self.temp_path)
         rmtree(self.temp_cache)
         locale.setlocale(locale.LC_ALL, self.old_locale)


### PR DESCRIPTION
Calling `read_settings` to clear the options put into
`pelican.settings.PYGMENTS_RST_OPTIONS` in `tearDown` so
that tests that are run after are not affected