### PR TITLE
Fix legacy plugin loading

### DIFF
--- a/pelican/tests/dummy_plugins/normal_plugin/normal_plugin/__init__.py
+++ b/pelican/tests/dummy_plugins/normal_plugin/normal_plugin/__init__.py
@@ -1,3 +1,5 @@
+from .submodule import noop  # noqa: F401
+
 NAME = 'normal plugin'
 
 

--- a/pelican/tests/dummy_plugins/normal_plugin/normal_plugin/submodule.py
+++ b/pelican/tests/dummy_plugins/normal_plugin/normal_plugin/submodule.py
@@ -1,0 +1,2 @@
+def noop():
+    pass


### PR DESCRIPTION
Legacy plugin loading was semi-broken. It would fail if the module imported itself at some point (common for packages). This updates the tests to account for that and fixes the problem.