### PR TITLE
Add support for Unicode slugs

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -628,6 +628,12 @@ corresponding ``*_URL`` setting as string, while others hard-code them:
    in auto-generated slugs. Otherwise, unicode characters will be replaced
    with ASCII equivalents.
 
+
+.. data:: SLUGIFY_PRESERVE_CASE = False
+
+   Preserve uppercase characters in the slugs. Set ``True`` to keep the
+   uppercase characters in the ``SLUGIFY_SOURCE`` as is.
+
 .. data:: SLUG_REGEX_SUBSTITUTIONS = [
         (r'[^\\w\\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars
         (r'(?u)\\A\\s*', ''),  # strip leading whitespace

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -320,12 +320,6 @@ Basic settings
    A list of default Pygments settings for your reStructuredText code blocks.
    See :ref:`internal_pygments_options` for a list of supported options.
 
-.. data:: SLUGIFY_SOURCE = 'title'
-
-   Specifies where you want the slug to be automatically generated from. Can be
-   set to ``title`` to use the 'Title:' metadata tag or ``basename`` to use the
-   article's file name when creating the slug.
-
 .. data:: CACHE_CONTENT = False
 
    If ``True``, saves content in caches.  See
@@ -620,6 +614,19 @@ URLs for direct template pages are theme-dependent. Some themes use
 corresponding ``*_URL`` setting as string, while others hard-code them:
 ``'archives.html'``, ``'authors.html'``, ``'categories.html'``,
 ``'tags.html'``.
+
+
+.. data:: SLUGIFY_SOURCE = 'title'
+
+   Specifies where you want the slug to be automatically generated from. Can be
+   set to ``title`` to use the 'Title:' metadata tag or ``basename`` to use the
+   article's file name when creating the slug.
+
+.. data:: SLUGIFY_USE_UNICODE = False
+
+   Allow unicode characters in slugs. Set ``True`` to keep unicode characters
+   in auto-generated slugs. Otherwise, unicode characters will be replaced
+   with ASCII equivalents.
 
 .. data:: SLUG_REGEX_SUBSTITUTIONS = [
         (r'[^\\w\\s-]', ''),  # remove non-alphabetical/whitespace/'-' chars

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -92,16 +92,17 @@ class Content(object):
         if not hasattr(self, 'slug'):
             if (settings['SLUGIFY_SOURCE'] == 'title' and
                     hasattr(self, 'title')):
-                self.slug = slugify(
-                    self.title,
-                    regex_subs=settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
+                value = self.title
             elif (settings['SLUGIFY_SOURCE'] == 'basename' and
                     source_path is not None):
-                basename = os.path.basename(
-                    os.path.splitext(source_path)[0])
+                value = os.path.basename(os.path.splitext(source_path)[0])
+            else:
+                value = None
+            if value is not None:
                 self.slug = slugify(
-                    basename,
-                    regex_subs=settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
+                    value,
+                    regex_subs=settings.get('SLUG_REGEX_SUBSTITUTIONS', []),
+                    use_unicode=settings['SLUGIFY_USE_UNICODE'])
 
         self.source_path = source_path
         self.relative_source_path = self.get_relative_source_path()

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -102,7 +102,8 @@ class Content(object):
                 self.slug = slugify(
                     value,
                     regex_subs=settings.get('SLUG_REGEX_SUBSTITUTIONS', []),
-                    use_unicode=settings['SLUGIFY_USE_UNICODE'])
+                    preserve_case=settings.get('SLUGIFY_PRESERVE_CASE', False),
+                    use_unicode=settings.get('SLUGIFY_USE_UNICODE', False))
 
         self.source_path = source_path
         self.relative_source_path = self.get_relative_source_path()

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -156,6 +156,7 @@ DEFAULT_CONFIG = {
     'INTRASITE_LINK_REGEX': '[{|](?P<what>.*?)[|}]',
     'SLUGIFY_SOURCE': 'title',
     'SLUGIFY_USE_UNICODE': False,
+    'SLUGIFY_PRESERVE_CASE': False,
     'CACHE_CONTENT': False,
     'CONTENT_CACHING_LAYER': 'reader',
     'CACHE_PATH': 'cache',

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -155,6 +155,7 @@ DEFAULT_CONFIG = {
     ],
     'INTRASITE_LINK_REGEX': '[{|](?P<what>.*?)[|}]',
     'SLUGIFY_SOURCE': 'title',
+    'SLUGIFY_USE_UNICODE': False,
     'CACHE_CONTENT': False,
     'CONTENT_CACHING_LAYER': 'reader',
     'CACHE_PATH': 'cache',

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -135,6 +135,17 @@ class TestPage(LoggedTestCase):
         page = Page(**page_kwargs)
         self.assertEqual(page.slug, 'foo')
 
+        # test slug from unicode title
+        # slug doesn't use unicode
+        settings['SLUGIFY_SOURCE'] = "title"
+        page_kwargs['metadata']['title'] = '指導書'
+        page = Page(**page_kwargs)
+        self.assertEqual(page.slug, 'zhi-dao-shu')
+        # slug uses unicode
+        settings['SLUGIFY_USE_UNICODE'] = True
+        page = Page(**page_kwargs)
+        self.assertEqual(page.slug, '指導書')
+
     def test_defaultlang(self):
         # If no lang is given, default to the default one.
         page = Page(**self.page_kwargs)

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -128,6 +128,45 @@ class TestUtils(LoggedTestCase):
         self.assertEqual(
             utils.slugify('Cat', regex_subs=subs, preserve_case=True), 'Cat')
 
+    def test_slugify_use_unicode(self):
+
+        samples = (
+            ('this is a test', 'this-is-a-test'),
+            ('this        is a test', 'this-is-a-test'),
+            ('this → is ← a ↑ test', 'this-is-a-test'),
+            ('this--is---a test', 'this-is-a-test'),
+            ('unicode測試許功蓋，你看到了嗎？', 'unicode測試許功蓋你看到了嗎'),
+            ('Çığ', 'çığ')
+        )
+
+        settings = read_settings()
+        subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+
+        for value, expected in samples:
+            self.assertEqual(
+                utils.slugify(value, regex_subs=subs, use_unicode=True),
+                expected)
+
+        # check with preserve case
+        for value, expected in samples:
+            self.assertEqual(
+                utils.slugify('Çığ', regex_subs=subs,
+                              preserve_case=True, use_unicode=True),
+                'Çığ')
+
+        # check normalization
+        samples = (
+            ('大飯原発４号機、１８日夜起動へ', '大飯原発4号機18日夜起動へ'),
+            (
+                '\N{LATIN SMALL LETTER C}\N{COMBINING CEDILLA}',
+                '\N{LATIN SMALL LETTER C WITH CEDILLA}'
+            )
+        )
+        for value, expected in samples:
+            self.assertEqual(
+                utils.slugify(value, regex_subs=subs, use_unicode=True),
+                expected)
+
     def test_slugify_substitute(self):
 
         samples = (('C++ is based on C', 'cpp-is-based-on-c'),

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -34,15 +34,14 @@ class URLWrapper(object):
         if self._slug is None:
             class_key = '{}_REGEX_SUBSTITUTIONS'.format(
                 self.__class__.__name__.upper())
-            if class_key in self.settings:
-                self._slug = slugify(
-                    self.name,
-                    regex_subs=self.settings[class_key])
-            else:
-                self._slug = slugify(
-                    self.name,
-                    regex_subs=self.settings.get(
-                        'SLUG_REGEX_SUBSTITUTIONS', []))
+            regex_subs = self.settings.get(
+                class_key,
+                self.settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
+            self._slug = slugify(
+                self.name,
+                regex_subs=regex_subs,
+                use_unicode=self.settings.get('SLUGIFY_USE_UNICODE', False)
+            )
         return self._slug
 
     @slug.setter
@@ -61,8 +60,13 @@ class URLWrapper(object):
         return hash(self.slug)
 
     def _normalize_key(self, key):
-        subs = self.settings.get('SLUG_REGEX_SUBSTITUTIONS', [])
-        return slugify(key, regex_subs=subs)
+        class_key = '{}_REGEX_SUBSTITUTIONS'.format(
+            self.__class__.__name__.upper())
+        regex_subs = self.settings.get(
+            class_key,
+            self.settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
+        use_unicode = self.settings.get('SLUGIFY_USE_UNICODE', False)
+        return slugify(key, regex_subs=regex_subs, use_unicode=use_unicode)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -37,9 +37,11 @@ class URLWrapper(object):
             regex_subs = self.settings.get(
                 class_key,
                 self.settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
+            preserve_case = self.settings.get('SLUGIFY_PRESERVE_CASE', False)
             self._slug = slugify(
                 self.name,
                 regex_subs=regex_subs,
+                preserve_case=preserve_case,
                 use_unicode=self.settings.get('SLUGIFY_USE_UNICODE', False)
             )
         return self._slug
@@ -66,7 +68,12 @@ class URLWrapper(object):
             class_key,
             self.settings.get('SLUG_REGEX_SUBSTITUTIONS', []))
         use_unicode = self.settings.get('SLUGIFY_USE_UNICODE', False)
-        return slugify(key, regex_subs=regex_subs, use_unicode=use_unicode)
+        preserve_case = self.settings.get('SLUGIFY_PRESERVE_CASE', False)
+        return slugify(
+            key,
+            regex_subs=regex_subs,
+            preserve_case=preserve_case,
+            use_unicode=use_unicode)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):


### PR DESCRIPTION
This has two commits for adding the option to use unicode in auto-generated slugs
* Reworks `slugify` and adds the `use_unicode` argument. See commit message for details about what changed and why. Also adds direct tests for `use_unicode`
* Exposes the option in `settings` as `SLUGIFY_USE_UNICODE` (default: `False`), uses it internally, updates docs and adds an indirect test for it. While updating the docs, I also moved the `SLUGIFY_SOURCE` documentation to where the other related settings are.

Fixes #1207