### PR TITLE
Docs should lead to existing pelican themes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,8 +64,8 @@ Documentation
    publish
    settings
    themes
-   plugins
    pelican-themes
+   plugins
    importer
    faq
    tips

--- a/docs/pelican-themes.rst
+++ b/docs/pelican-themes.rst
@@ -1,7 +1,17 @@
-pelican-themes
+Themes for Pelican
 ##############
 
 
+Where to find themes
+===========
+
+We maintain a separate repository of themes for people to share and use. Please visit the [pelican-themes repository](https://github.com/getpelican/pelican-themes) for a list of available themes.
+
+Please note that while we do our best to review and maintain these themes, they are submitted by the Pelican community and thus may have varying levels of support and interoperability.
+
+
+pelican-themes
+##############
 
 Description
 ===========


### PR DESCRIPTION
It took me a google search to find out that others already have created a large amount of themes and I was confused that there even is a collection maintained by the Pelican community. Shouldn't that be mentioned in the docs for Pelican?

Also: The difference between "Themes" and "pelican-themes" in the sidebar nav are only obvious *after* reading through their content, but this inconsistency is *not adressed* in this PR. I just put them closer together so that a reader will miss them less likely.