### PR TITLE
Settings via pathlib

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -454,80 +454,80 @@ This would save your articles into something like
    The place where we will save an article which doesn't use the default
    language.
 
-.. data:: DRAFT_URL = 'drafts/{slug}.html'
+.. data:: DRAFT_URL = pathlib.Path('drafts') / '{slug}.html'
 
    The URL to refer to an article draft.
 
-.. data:: DRAFT_SAVE_AS = 'drafts/{slug}.html'
+.. data:: DRAFT_SAVE_AS = pathlib.Path('drafts') / '{slug}.html'
 
    The place where we will save an article draft.
 
-.. data:: DRAFT_LANG_URL = 'drafts/{slug}-{lang}.html'
+.. data:: DRAFT_LANG_URL = pathlib.Path('drafts') / '{slug}-{lang}.html'
 
    The URL to refer to an article draft which doesn't use the default language.
 
-.. data:: DRAFT_LANG_SAVE_AS = 'drafts/{slug}-{lang}.html'
+.. data:: DRAFT_LANG_SAVE_AS = pathlib.Path('drafts') / '{slug}-{lang}.html'
 
    The place where we will save an article draft which doesn't use the default
    language.
 
-.. data:: PAGE_URL = 'pages/{slug}.html'
+.. data:: PAGE_URL = pathlib.Path('pages') / '{slug}.html'
 
    The URL we will use to link to a page.
 
-.. data:: PAGE_SAVE_AS = 'pages/{slug}.html'
+.. data:: PAGE_SAVE_AS = pathlib.Path('pages') / '{slug}.html'
 
    The location we will save the page. This value has to be the same as
    PAGE_URL or you need to use a rewrite in your server config.
 
-.. data:: PAGE_LANG_URL = 'pages/{slug}-{lang}.html'
+.. data:: PAGE_LANG_URL = pathlib.Path('pages') / '{slug}-{lang}.html'
 
    The URL we will use to link to a page which doesn't use the default
    language.
 
-.. data:: PAGE_LANG_SAVE_AS = 'pages/{slug}-{lang}.html'
+.. data:: PAGE_LANG_SAVE_AS = pathlib.Path('pages') / '{slug}-{lang}.html'
 
    The location we will save the page which doesn't use the default language.
 
-.. data:: DRAFT_PAGE_URL = 'drafts/pages/{slug}.html'
+.. data:: DRAFT_PAGE_URL = pathlib.Path('drafts') / 'pages' / '{slug}.html'
 
    The URL used to link to a page draft.
 
-.. data:: DRAFT_PAGE_SAVE_AS = 'drafts/pages/{slug}.html'
+.. data:: DRAFT_PAGE_SAVE_AS = pathlib.Path('drafts') / 'pages' / '{slug}.html'
 
    The actual location a page draft is saved at.
 
-.. data:: DRAFT_PAGE_LANG_URL = 'drafts/pages/{slug}-{lang}.html'
+.. data:: DRAFT_PAGE_LANG_URL = pathlib.Path('drafts') / 'pages' / '{slug}-{lang}.html'
 
    The URL used to link to a page draft which doesn't use the default
    language.
 
-.. data:: DRAFT_PAGE_LANG_SAVE_AS = 'drafts/pages/{slug}-{lang}.html'
+.. data:: DRAFT_PAGE_LANG_SAVE_AS = pathlib.Path('drafts') / 'pages' / '{slug}-{lang}.html'
 
    The actual location a page draft which doesn't use the default language is
    saved at.
 
-.. data:: AUTHOR_URL = 'author/{slug}.html'
+.. data:: AUTHOR_URL = pathlib.Path('author') / '{slug}.html'
 
    The URL to use for an author.
 
-.. data:: AUTHOR_SAVE_AS = 'author/{slug}.html'
+.. data:: AUTHOR_SAVE_AS = pathlib.Path('author') / '{slug}.html'
 
    The location to save an author.
 
-.. data:: CATEGORY_URL = 'category/{slug}.html'
+.. data:: CATEGORY_URL = pathlib.Path('category') / '{slug}.html'
 
    The URL to use for a category.
 
-.. data:: CATEGORY_SAVE_AS = 'category/{slug}.html'
+.. data:: CATEGORY_SAVE_AS = pathlib.Path('category') / '{slug}.html'
 
    The location to save a category.
 
-.. data:: TAG_URL = 'tag/{slug}.html'
+.. data:: TAG_URL = pathlib.Path('tag') / '{slug}.html'
 
    The URL to use for a tag.
 
-.. data:: TAG_SAVE_AS = 'tag/{slug}.html'
+.. data:: TAG_SAVE_AS = pathlib.Path('tag') / '{slug}.html'
 
    The location to save the tag page.
 
@@ -909,7 +909,7 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    Relative URL of the RSS feed. If not set, ``FEED_RSS`` is used both for save
    location and URL.
 
-.. data:: FEED_ALL_ATOM = 'feeds/all.atom.xml'
+.. data:: FEED_ALL_ATOM = pathlib.Path('feeds') / 'all.atom.xml'
 
    The location to save the all-posts Atom feed: this feed will contain all
    posts regardless of their language.
@@ -929,7 +929,7 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    Relative URL of the all-posts RSS feed. If not set, ``FEED_ALL_RSS`` is used
    both for save location and URL.
 
-.. data:: CATEGORY_FEED_ATOM = 'feeds/{slug}.atom.xml'
+.. data:: CATEGORY_FEED_ATOM = pathlib.Path('feeds') / '{slug}.atom.xml'
 
    The location to save the category Atom feeds. [2]_
 
@@ -950,7 +950,7 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    placeholder. [2]_ If not set, ``CATEGORY_FEED_RSS`` is used both for save
    location and URL.
 
-.. data:: AUTHOR_FEED_ATOM = 'feeds/{slug}.atom.xml'
+.. data:: AUTHOR_FEED_ATOM = pathlib.Path('feeds') / '{slug}.atom.xml'
 
    The location to save the author Atom feeds. [2]_
 
@@ -960,7 +960,7 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    [2]_ If not set, ``AUTHOR_FEED_ATOM`` is used both for save location and
    URL.
 
-.. data:: AUTHOR_FEED_RSS = 'feeds/{slug}.rss.xml'
+.. data:: AUTHOR_FEED_RSS = pathlib.Path('feeds') / '{slug}.rss.xml'
 
    The location to save the author RSS feeds. [2]_
 
@@ -1083,7 +1083,7 @@ section for more information.
    one another. May be a string or a collection of strings. Set to ``None`` or
    ``False`` to disable the identification of translations.
 
-.. data:: TRANSLATION_FEED_ATOM = 'feeds/all-{lang}.atom.xml'
+.. data:: TRANSLATION_FEED_ATOM = pathlib.Path('feeds') / 'all-{lang}.atom.xml'
 
    The location to save the Atom feed for translations. [3]_
 

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -217,7 +217,7 @@ class Content(object):
         if not klass:
             klass = self.__class__.__name__
         fq_key = ('%s_%s' % (klass, key)).upper()
-        return self.settings[fq_key].format(**self.url_format)
+        return str(self.settings[fq_key]).format(**self.url_format)
 
     def get_url_setting(self, key):
         if hasattr(self, 'override_' + key):

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -20,7 +20,6 @@ from pelican.readers import Readers
 from pelican.utils import (DateFormatter, copy, mkdir_p, order_content,
                            posixize_path, process_translations)
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -324,8 +323,9 @@ class ArticlesGenerator(CachingGenerator):
             all_articles = list(self.articles)
             for article in self.articles:
                 all_articles.extend(article.translations)
-            order_content(all_articles,
-                          order_by=self.settings['ARTICLE_ORDER_BY'])
+            order_content(
+                all_articles, order_by=self.settings['ARTICLE_ORDER_BY']
+            )
 
             if self.settings.get('FEED_ALL_ATOM'):
                 writer.write_feed(
@@ -354,7 +354,7 @@ class ArticlesGenerator(CachingGenerator):
                     self.settings['CATEGORY_FEED_ATOM'].format(slug=cat.slug),
                     self.settings.get(
                         'CATEGORY_FEED_ATOM_URL',
-                        self.settings['CATEGORY_FEED_ATOM']).format(
+                        str(self.settings['CATEGORY_FEED_ATOM'])).format(
                             slug=cat.slug
                         ),
                     feed_title=cat.name
@@ -367,7 +367,7 @@ class ArticlesGenerator(CachingGenerator):
                     self.settings['CATEGORY_FEED_RSS'].format(slug=cat.slug),
                     self.settings.get(
                         'CATEGORY_FEED_RSS_URL',
-                        self.settings['CATEGORY_FEED_RSS']).format(
+                        str(self.settings['CATEGORY_FEED_RSS'])).format(
                             slug=cat.slug
                         ),
                     feed_title=cat.name,
@@ -382,8 +382,9 @@ class ArticlesGenerator(CachingGenerator):
                     self.settings['AUTHOR_FEED_ATOM'].format(slug=auth.slug),
                     self.settings.get(
                         'AUTHOR_FEED_ATOM_URL',
-                        self.settings['AUTHOR_FEED_ATOM']
-                        ).format(slug=auth.slug),
+                        str(self.settings['AUTHOR_FEED_ATOM'])).format(
+                            slug=auth.slug
+                        ),
                     feed_title=auth.name
                     )
 
@@ -394,8 +395,9 @@ class ArticlesGenerator(CachingGenerator):
                     self.settings['AUTHOR_FEED_RSS'].format(slug=auth.slug),
                     self.settings.get(
                         'AUTHOR_FEED_RSS_URL',
-                        self.settings['AUTHOR_FEED_RSS']
-                        ).format(slug=auth.slug),
+                        str(self.settings['AUTHOR_FEED_RSS'])).format(
+                            slug=auth.slug
+                        ),
                     feed_title=auth.name,
                     feed_type='rss'
                     )
@@ -410,8 +412,9 @@ class ArticlesGenerator(CachingGenerator):
                         self.settings['TAG_FEED_ATOM'].format(slug=tag.slug),
                         self.settings.get(
                             'TAG_FEED_ATOM_URL',
-                            self.settings['TAG_FEED_ATOM']
-                            ).format(slug=tag.slug),
+                            str(self.settings['TAG_FEED_ATOM'])).format(
+                                slug=tag.slug
+                            ),
                         feed_title=tag.name
                         )
 
@@ -422,8 +425,9 @@ class ArticlesGenerator(CachingGenerator):
                         self.settings['TAG_FEED_RSS'].format(slug=tag.slug),
                         self.settings.get(
                             'TAG_FEED_RSS_URL',
-                            self.settings['TAG_FEED_RSS']
-                            ).format(slug=tag.slug),
+                            str(self.settings['TAG_FEED_RSS'])).format(
+                                slug=tag.slug
+                            ),
                         feed_title=tag.name,
                         feed_type='rss'
                         )
@@ -445,7 +449,8 @@ class ArticlesGenerator(CachingGenerator):
                             .format(lang=lang),
                         self.settings.get(
                             'TRANSLATION_FEED_ATOM_URL',
-                            self.settings['TRANSLATION_FEED_ATOM']
+                            str(
+                                self.settings['TRANSLATION_FEED_ATOM'])
                             ).format(lang=lang),
                         )
                 if self.settings.get('TRANSLATION_FEED_RSS'):
@@ -456,8 +461,9 @@ class ArticlesGenerator(CachingGenerator):
                             .format(lang=lang),
                         self.settings.get(
                             'TRANSLATION_FEED_RSS_URL',
-                            self.settings['TRANSLATION_FEED_RSS']
-                            ).format(lang=lang),
+                            str(self.settings['TRANSLATION_FEED_RSS'])).format(
+                                lang=lang
+                            ),
                         feed_type='rss'
                         )
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -351,12 +351,12 @@ class ArticlesGenerator(CachingGenerator):
                 writer.write_feed(
                     arts,
                     self.context,
-                    self.settings['CATEGORY_FEED_ATOM'].format(slug=cat.slug),
+                    str(self.settings['CATEGORY_FEED_ATOM']).format(slug=cat.slug),
                     self.settings.get(
                         'CATEGORY_FEED_ATOM_URL',
-                        str(self.settings['CATEGORY_FEED_ATOM'])).format(
+                        str(self.settings['CATEGORY_FEED_ATOM']).format(
                             slug=cat.slug
-                        ),
+                        )),
                     feed_title=cat.name
                     )
 
@@ -364,12 +364,12 @@ class ArticlesGenerator(CachingGenerator):
                 writer.write_feed(
                     arts,
                     self.context,
-                    self.settings['CATEGORY_FEED_RSS'].format(slug=cat.slug),
+                    str(self.settings['CATEGORY_FEED_RSS']).format(slug=cat.slug),
                     self.settings.get(
                         'CATEGORY_FEED_RSS_URL',
-                        str(self.settings['CATEGORY_FEED_RSS'])).format(
+                        str(self.settings['CATEGORY_FEED_RSS']).format(
                             slug=cat.slug
-                        ),
+                        )),
                     feed_title=cat.name,
                     feed_type='rss'
                     )
@@ -379,12 +379,12 @@ class ArticlesGenerator(CachingGenerator):
                 writer.write_feed(
                     arts,
                     self.context,
-                    self.settings['AUTHOR_FEED_ATOM'].format(slug=auth.slug),
+                    str(self.settings['AUTHOR_FEED_ATOM']).format(slug=auth.slug),
                     self.settings.get(
                         'AUTHOR_FEED_ATOM_URL',
-                        str(self.settings['AUTHOR_FEED_ATOM'])).format(
+                        str(self.settings['AUTHOR_FEED_ATOM']).format(
                             slug=auth.slug
-                        ),
+                        )),
                     feed_title=auth.name
                     )
 
@@ -392,12 +392,12 @@ class ArticlesGenerator(CachingGenerator):
                 writer.write_feed(
                     arts,
                     self.context,
-                    self.settings['AUTHOR_FEED_RSS'].format(slug=auth.slug),
+                    str(self.settings['AUTHOR_FEED_RSS']).format(slug=auth.slug),
                     self.settings.get(
                         'AUTHOR_FEED_RSS_URL',
-                        str(self.settings['AUTHOR_FEED_RSS'])).format(
+                        str(self.settings['AUTHOR_FEED_RSS']).format(
                             slug=auth.slug
-                        ),
+                        )),
                     feed_title=auth.name,
                     feed_type='rss'
                     )
@@ -409,12 +409,12 @@ class ArticlesGenerator(CachingGenerator):
                     writer.write_feed(
                         arts,
                         self.context,
-                        self.settings['TAG_FEED_ATOM'].format(slug=tag.slug),
+                        str(self.settings['TAG_FEED_ATOM']).format(slug=tag.slug),
                         self.settings.get(
                             'TAG_FEED_ATOM_URL',
-                            str(self.settings['TAG_FEED_ATOM'])).format(
+                            str(self.settings['TAG_FEED_ATOM']).format(
                                 slug=tag.slug
-                            ),
+                            )),
                         feed_title=tag.name
                         )
 
@@ -422,12 +422,12 @@ class ArticlesGenerator(CachingGenerator):
                     writer.write_feed(
                         arts,
                         self.context,
-                        self.settings['TAG_FEED_RSS'].format(slug=tag.slug),
+                        str(self.settings['TAG_FEED_RSS']).format(slug=tag.slug),
                         self.settings.get(
                             'TAG_FEED_RSS_URL',
-                            str(self.settings['TAG_FEED_RSS'])).format(
+                            str(self.settings['TAG_FEED_RSS']).format(
                                 slug=tag.slug
-                            ),
+                            )),
                         feed_title=tag.name,
                         feed_type='rss'
                         )
@@ -445,27 +445,31 @@ class ArticlesGenerator(CachingGenerator):
                     writer.write_feed(
                         items,
                         self.context,
-                        self.settings['TRANSLATION_FEED_ATOM']
-                            .format(lang=lang),
+                        str(
+                            self.settings['TRANSLATION_FEED_ATOM']
+                        ).format(lang=lang),
                         self.settings.get(
                             'TRANSLATION_FEED_ATOM_URL',
                             str(
-                                self.settings['TRANSLATION_FEED_ATOM'])
+                                self.settings['TRANSLATION_FEED_ATOM']
                             ).format(lang=lang),
                         )
+                    )
                 if self.settings.get('TRANSLATION_FEED_RSS'):
                     writer.write_feed(
                         items,
                         self.context,
-                        self.settings['TRANSLATION_FEED_RSS']
-                            .format(lang=lang),
+                        str(
+                            self.settings['TRANSLATION_FEED_RSS']
+                        ).format(lang=lang),
                         self.settings.get(
                             'TRANSLATION_FEED_RSS_URL',
-                            str(self.settings['TRANSLATION_FEED_RSS'])).format(
+                            str(self.settings['TRANSLATION_FEED_RSS']).format(
                                 lang=lang
                             ),
                         feed_type='rss'
                         )
+                    )
 
     def generate_articles(self, write):
         """Generate the articles."""

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 from os.path import isabs
-from posixpath import join as posix_join
+from pathlib import Path
 
 from pelican.log import LimitFilter
 
@@ -38,11 +38,11 @@ DEFAULT_CONFIG = {
     'STATIC_EXCLUDE_SOURCES': True,
     'THEME_STATIC_DIR': 'theme',
     'THEME_STATIC_PATHS': ['static', ],
-    'FEED_ALL_ATOM': posix_join('feeds', 'all.atom.xml'),
-    'CATEGORY_FEED_ATOM': posix_join('feeds', '{slug}.atom.xml'),
-    'AUTHOR_FEED_ATOM': posix_join('feeds', '{slug}.atom.xml'),
-    'AUTHOR_FEED_RSS': posix_join('feeds', '{slug}.rss.xml'),
-    'TRANSLATION_FEED_ATOM': posix_join('feeds', 'all-{lang}.atom.xml'),
+    'FEED_ALL_ATOM': Path('feeds') / 'all.atom.xml',
+    'CATEGORY_FEED_ATOM': Path('feeds') / '{slug}.atom.xml',
+    'AUTHOR_FEED_ATOM': Path('feeds') / '{slug}.atom.xml',
+    'AUTHOR_FEED_RSS': Path('feeds',) / '{slug}.rss.xml',
+    'TRANSLATION_FEED_ATOM': Path('feeds') / 'all-{lang}.atom.xml',
     'FEED_MAX_ITEMS': '',
     'RSS_FEED_SUMMARY_ONLY': True,
     'SITEURL': '',
@@ -66,30 +66,29 @@ DEFAULT_CONFIG = {
     'ARTICLE_ORDER_BY': 'reversed-date',
     'ARTICLE_LANG_URL': '{slug}-{lang}.html',
     'ARTICLE_LANG_SAVE_AS': '{slug}-{lang}.html',
-    'DRAFT_URL': 'drafts/{slug}.html',
-    'DRAFT_SAVE_AS': posix_join('drafts', '{slug}.html'),
-    'DRAFT_LANG_URL': 'drafts/{slug}-{lang}.html',
-    'DRAFT_LANG_SAVE_AS': posix_join('drafts', '{slug}-{lang}.html'),
-    'PAGE_URL': 'pages/{slug}.html',
-    'PAGE_SAVE_AS': posix_join('pages', '{slug}.html'),
+    'DRAFT_URL': Path('drafts') / '{slug}.html',
+    'DRAFT_SAVE_AS': Path('drafts') / '{slug}.html',
+    'DRAFT_LANG_URL': Path('drafts') / '{slug}-{lang}.html',
+    'DRAFT_LANG_SAVE_AS': Path('drafts') / '{slug}-{lang}.html',
+    'PAGE_URL': Path('pages') / '{slug}.html',
+    'PAGE_SAVE_AS': Path('pages') / '{slug}.html',
     'PAGE_ORDER_BY': 'basename',
-    'PAGE_LANG_URL': 'pages/{slug}-{lang}.html',
-    'PAGE_LANG_SAVE_AS': posix_join('pages', '{slug}-{lang}.html'),
-    'DRAFT_PAGE_URL': 'drafts/pages/{slug}.html',
-    'DRAFT_PAGE_SAVE_AS': posix_join('drafts', 'pages', '{slug}.html'),
-    'DRAFT_PAGE_LANG_URL': 'drafts/pages/{slug}-{lang}.html',
-    'DRAFT_PAGE_LANG_SAVE_AS': posix_join('drafts', 'pages',
-                                          '{slug}-{lang}.html'),
+    'PAGE_LANG_URL': Path('pages') / '{slug}-{lang}.html',
+    'PAGE_LANG_SAVE_AS': Path('pages') / '{slug}-{lang}.html',
+    'DRAFT_PAGE_URL': Path('drafts') / 'pages' / '{slug}.html',
+    'DRAFT_PAGE_SAVE_AS': Path('drafts') / 'pages' / '{slug}.html',
+    'DRAFT_PAGE_LANG_URL': Path('drafts') / 'pages' / '{slug}-{lang}.html',
+    'DRAFT_PAGE_LANG_SAVE_AS': Path('drafts') / 'pages' / '{slug}-{lang}.html',
     'STATIC_URL': '{path}',
     'STATIC_SAVE_AS': '{path}',
     'STATIC_CREATE_LINKS': False,
     'STATIC_CHECK_IF_MODIFIED': False,
-    'CATEGORY_URL': 'category/{slug}.html',
-    'CATEGORY_SAVE_AS': posix_join('category', '{slug}.html'),
-    'TAG_URL': 'tag/{slug}.html',
-    'TAG_SAVE_AS': posix_join('tag', '{slug}.html'),
-    'AUTHOR_URL': 'author/{slug}.html',
-    'AUTHOR_SAVE_AS': posix_join('author', '{slug}.html'),
+    'CATEGORY_URL': Path('category') / '{slug}.html',
+    'CATEGORY_SAVE_AS': Path('category') / '{slug}.html',
+    'TAG_URL': Path('tag') / '{slug}.html',
+    'TAG_SAVE_AS': Path('tag') / '{slug}.html',
+    'AUTHOR_URL': Path('author') / '{slug}.html',
+    'AUTHOR_SAVE_AS': Path('author') / '{slug}.html',
     'PAGINATION_PATTERNS': [
         (1, '{name}{extension}', '{name}{extension}'),
         (2, '{name}{number}{extension}', '{name}{number}{extension}'),
@@ -446,8 +445,8 @@ def handle_deprecated_settings(settings):
 
         settings['ARTICLE_URL'] = '{slug}/'
         settings['ARTICLE_LANG_URL'] = '{slug}-{lang}/'
-        settings['PAGE_URL'] = 'pages/{slug}/'
-        settings['PAGE_LANG_URL'] = 'pages/{slug}-{lang}/'
+        settings['PAGE_URL'] = Path('pages') / '{slug}/'
+        settings['PAGE_LANG_URL'] = Path('pages') / '{slug}-{lang}/'
 
         for setting in ('ARTICLE_URL', 'ARTICLE_LANG_URL', 'PAGE_URL',
                         'PAGE_LANG_URL'):

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -409,7 +409,7 @@ def handle_deprecated_settings(settings):
     for key in ['TRANSLATION_FEED_ATOM',
                 'TRANSLATION_FEED_RSS'
                 ]:
-        if settings.get(key) and '%s' in settings[key]:
+        if settings.get(key) and not isinstance(settings[key], Path) and '%s' in settings[key]:
             logger.warning('%%s usage in %s is deprecated, use {lang} '
                            'instead.', key)
             try:
@@ -426,7 +426,7 @@ def handle_deprecated_settings(settings):
                 'TAG_FEED_ATOM',
                 'TAG_FEED_RSS',
                 ]:
-        if settings.get(key) and '%s' in settings[key]:
+        if settings.get(key) and not isinstance(settings[key], Path) and '%s' in settings[key]:
             logger.warning('%%s usage in %s is deprecated, use {slug} '
                            'instead.', key)
             try:

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -3,6 +3,7 @@
 import functools
 import logging
 import os
+import pathlib
 
 from pelican.utils import slugify
 
@@ -112,6 +113,8 @@ class URLWrapper(object):
         """
         setting = "%s_%s" % (self.__class__.__name__.upper(), key)
         value = self.settings[setting]
+        if isinstance(value, pathlib.Path):
+            value = str(value)
         if not isinstance(value, str):
             logger.warning('%s is set to %s', setting, value)
             return value

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -5,6 +5,7 @@ import fnmatch
 import locale
 import logging
 import os
+import pathlib
 import re
 import shutil
 import sys
@@ -815,17 +816,28 @@ def split_all(path):
     >>> split_all(os.path.join('a', 'b', 'c'))
     ['a', 'b', 'c']
     """
-    components = []
-    path = path.lstrip('/')
-    while path:
-        head, tail = os.path.split(path)
-        if tail:
-            components.insert(0, tail)
-        elif head == path:
-            components.insert(0, head)
-            break
-        path = head
-    return components
+    if isinstance(path, str):
+        components = []
+        path = path.lstrip('/')
+        while path:
+            head, tail = os.path.split(path)
+            if tail:
+                components.insert(0, tail)
+            elif head == path:
+                components.insert(0, head)
+                break
+            path = head
+        return components
+    elif isinstance(path, pathlib.Path):
+        return path.parts
+    elif path is None:
+        return None
+    else:
+        raise TypeError(
+            '"path" was {}, must be string, None, or pathlib.Path'.format(
+                type(path)
+            )
+        )
 
 
 def is_selected_for_writing(settings, path):

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -30,7 +30,7 @@ class Writer(object):
             self.urljoiner = os.path.join
         else:
             self.urljoiner = lambda base, url: urljoin(
-                base if base.endswith('/') else base + '/', url)
+                base if base.endswith('/') else base + '/', str(url))
 
     def _create_new_feed(self, feed_type, feed_title, context):
         feed_class = Rss201rev2Feed if feed_type == 'rss' else Atom1Feed


### PR DESCRIPTION
The discussion in #2431 suggested that it would be better to deal with the various path settings using Pathlib. This accomplishes that. The earlier discussion suggested that this would effectively drop support for Python 3.5; this does not address that.

It also updates the documentation to show the new defaults.

Any paths with `{slug}` or `{lang}` need to be cast as strings to allow the appropriate replacements.

This would supersedes #2431, and thus closes #2431.