### PR TITLE
Windows invoke support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 feedgenerator = "^1.9"
 jinja2 = "~2.11"
 pygments = "~2.6.1"
@@ -56,6 +56,8 @@ tox = "^3.13"
 flake8 = "^3.7"
 flake8-import-order = "^0.18.1"
 invoke = "^1.3"
+isort = "^4.3.21"
+black = {version = "^19.10b0", allow-prereleases = true}
 
 [tool.poetry.extras]
 markdown = ["markdown"]


### PR DESCRIPTION
This add basic support for Windows to the project's `tasks.py` to support Windows development. In particular:

- it adds *invoke* and *black* to the dev dependencies, which are expected by `tasks.py`
- increases the Python version to 3.6, as *black* doesn't support Python 3.5 (and *poetry* won't install it otherwise...)
- notes that virtualenv binaries are stored in a different path on Windows
- notes that *pip* can't directly update itself on Windows