### PR TITLE
Fix docs/quickstart.rst to use reStructured Text.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,14 +38,18 @@ Create an article
 You cannot run Pelican until you have created some content. Use your preferred
 text editor to create your first article with the following content::
 
-    Title: My First Review
-    Date: 2010-12-03 10:20
-    Category: Review
-
+    My First Review
+    ###############
+    
+    :date: 2010-12-03 10:20
+    :tags: reviews
+    :category: Review
+    :summary: My First Review
+    
     Following is a review of my favorite mechanical keyboard.
 
-Given that this example article is in Markdown format, save it as
-``~/projects/yoursite/content/keyboard-review.md``.
+Given that this example article is in reStructuredText format, save it as
+``~/projects/yoursite/content/keyboard-review.rst``.
 
 Generate your site
 ------------------


### PR DESCRIPTION
I was following the quickstart but the described page did not show up.

Previously the docs described making a .md, but markdown isn't in the default installation, so using a format which is.  An alternative fix would be to show how to install markdown in the quickstart.
