### PR TITLE
Override settings from the commandline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.swo
 *.pyc
 .DS_Store
+.idea
 docs/_build
 docs/fr/_build
 build

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -1,6 +1,7 @@
 import copy
 import importlib.util
 import inspect
+import json
 import locale
 import logging
 import os
@@ -660,3 +661,23 @@ def configure_settings(settings):
             continue            # setting not specified, nothing to do
 
     return settings
+
+
+def coerce_overrides(overrides):
+    coerced = {}
+    types_to_cast = {int, str}
+    for k, v in overrides.items():
+        if k not in overrides:
+            logger.warning('Override for unknown setting %s, ignoring', k)
+            continue
+        setting_type = type(DEFAULT_CONFIG[k])
+        if setting_type not in types_to_cast:
+            coerced[k] = json.loads(v)
+        else:
+            try:
+                coerced[k] = setting_type(v)
+            except ValueError:
+                logger.debug('ValueError for %s override with %s, try to '
+                             'load as json', k, v)
+                coerced[k] = json.loads(v)
+    return coerced

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -7,8 +7,8 @@ from sys import platform
 
 from pelican.settings import (DEFAULT_CONFIG, DEFAULT_THEME,
                               _printf_s_to_format_field,
-                              configure_settings, handle_deprecated_settings,
-                              read_settings)
+                              coerce_overrides, configure_settings,
+                              handle_deprecated_settings, read_settings)
 from pelican.tests.support import unittest
 
 
@@ -304,3 +304,18 @@ class TestSettingsConfiguration(unittest.TestCase):
                          [(r'C\+\+', 'cpp')] +
                          self.settings['SLUG_REGEX_SUBSTITUTIONS'])
         self.assertNotIn('SLUG_SUBSTITUTIONS', settings)
+
+    def test_coerce_overrides(self):
+        overrides = coerce_overrides({
+            'ARTICLE_EXCLUDES': '["testexcl"]',
+            'READERS': '{"foo": "bar"}',
+            'STATIC_EXCLUDE_SOURCES': 'true',
+            'THEME_STATIC_DIR': 'theme',
+            })
+        expected = {
+            'ARTICLE_EXCLUDES': ["testexcl"],
+            'READERS': {"foo": "bar"},
+            'STATIC_EXCLUDE_SOURCES': True,
+            'THEME_STATIC_DIR': 'theme',
+        }
+        self.assertDictEqual(overrides, expected)


### PR DESCRIPTION
Add a --setting-overrides KEY=VAL commandline option to override
arbitrary items from pelicanconf.py settings files. This adds
flexibility in running pelican and helps reduce sprawl of settings
files