### PR TITLE
Fix dictionary logging in formatter

### DIFF
--- a/pelican/log.py
+++ b/pelican/log.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from collections import defaultdict
+from collections.abc import Mapping
 
 __all__ = [
     'init'
@@ -18,9 +19,10 @@ class BaseFormatter(logging.Formatter):
         record.__dict__['customlevelname'] = customlevel
         # format multiline messages 'nicely' to make it clear they are together
         record.msg = record.msg.replace('\n', '\n  | ')
-        record.args = tuple(arg.replace('\n', '\n  | ') if
-                            isinstance(arg, str) else
-                            arg for arg in record.args)
+        if not isinstance(record.args, Mapping):
+            record.args = tuple(arg.replace('\n', '\n  | ') if
+                                isinstance(arg, str) else
+                                arg for arg in record.args)
         return super().format(record)
 
     def formatException(self, ei):

--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -195,6 +195,15 @@ class LogCountHandler(BufferingHandler):
                (level is None or l.levelno == level)
         ])
 
+    def count_formatted_logs(self, msg=None, level=None):
+        return len([
+            l
+            for l
+            in self.buffer
+            if (msg is None or re.search(msg, self.format(l))) and
+               (level is None or l.levelno == level)
+        ])
+
 
 class LoggedTestCase(unittest.TestCase):
     """A test case that captures log messages."""

--- a/pelican/tests/test_log.py
+++ b/pelican/tests/test_log.py
@@ -1,6 +1,7 @@
 import logging
 import unittest
 from collections import defaultdict
+from contextlib import contextmanager
 
 from pelican import log
 from pelican.tests.support import LogCountHandler
@@ -24,55 +25,59 @@ class TestLog(unittest.TestCase):
         log.LimitFilter._threshold = 5
         log.LimitFilter._group_count = defaultdict(int)
 
+    @contextmanager
+    def reset_logger(self):
+        try:
+            yield None
+        finally:
+            self._reset_limit_filter()
+            self.handler.flush()
+
     def test_log_filter(self):
         def do_logging():
             for i in range(5):
                 self.logger.warning('Log %s', i)
                 self.logger.warning('Another log %s', i)
         # no filter
-        do_logging()
-        self.assertEqual(
-            self.handler.count_logs('Log \\d', logging.WARNING),
-            5)
-        self.assertEqual(
-            self.handler.count_logs('Another log \\d', logging.WARNING),
-            5)
-        self.handler.flush()
-        self._reset_limit_filter()
+        with self.reset_logger():
+            do_logging()
+            self.assertEqual(
+                self.handler.count_logs('Log \\d', logging.WARNING),
+                5)
+            self.assertEqual(
+                self.handler.count_logs('Another log \\d', logging.WARNING),
+                5)
 
         # filter by template
-        log.LimitFilter._ignore.add((logging.WARNING, 'Log %s'))
-        do_logging()
-        self.assertEqual(
-            self.handler.count_logs('Log \\d', logging.WARNING),
-            0)
-        self.assertEqual(
-            self.handler.count_logs('Another log \\d', logging.WARNING),
-            5)
-        self.handler.flush()
-        self._reset_limit_filter()
+        with self.reset_logger():
+            log.LimitFilter._ignore.add((logging.WARNING, 'Log %s'))
+            do_logging()
+            self.assertEqual(
+                self.handler.count_logs('Log \\d', logging.WARNING),
+                0)
+            self.assertEqual(
+                self.handler.count_logs('Another log \\d', logging.WARNING),
+                5)
 
         # filter by exact message
-        log.LimitFilter._ignore.add((logging.WARNING, 'Log 3'))
-        do_logging()
-        self.assertEqual(
-            self.handler.count_logs('Log \\d', logging.WARNING),
-            4)
-        self.assertEqual(
-            self.handler.count_logs('Another log \\d', logging.WARNING),
-            5)
-        self.handler.flush()
-        self._reset_limit_filter()
+        with self.reset_logger():
+            log.LimitFilter._ignore.add((logging.WARNING, 'Log 3'))
+            do_logging()
+            self.assertEqual(
+                self.handler.count_logs('Log \\d', logging.WARNING),
+                4)
+            self.assertEqual(
+                self.handler.count_logs('Another log \\d', logging.WARNING),
+                5)
 
         # filter by both
-        log.LimitFilter._ignore.add((logging.WARNING, 'Log 3'))
-        log.LimitFilter._ignore.add((logging.WARNING, 'Another log %s'))
-        do_logging()
-        self.assertEqual(
-            self.handler.count_logs('Log \\d', logging.WARNING),
-            4)
-        self.assertEqual(
-            self.handler.count_logs('Another log \\d', logging.WARNING),
-            0)
-        self.handler.flush()
-        self._reset_limit_filter()
+        with self.reset_logger():
+            log.LimitFilter._ignore.add((logging.WARNING, 'Log 3'))
+            log.LimitFilter._ignore.add((logging.WARNING, 'Another log %s'))
+            do_logging()
+            self.assertEqual(
+                self.handler.count_logs('Log \\d', logging.WARNING),
+                4)
+            self.assertEqual(
+                self.handler.count_logs('Another log \\d', logging.WARNING),
+                0)


### PR DESCRIPTION
Python special cases single Mapping arguments to logging. This
adjusts BaseFormatter to skip "fancy" formatting if argument
is of type Mapping. Also adds various tests for formatted log outputs.

Fixes #2596