### PR TITLE
Force root logger to be of FatalLogger class

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -76,10 +76,14 @@ section.
 The only rule to follow for plugins is to define a ``register`` callable, in
 which you map the signals to your plugin logic. Let's take a simple example::
 
+    import logging
+
     from pelican import signals
 
+    log = logging.getLogger(__name__)
+
     def test(sender):
-        print("{} initialized !!".format(sender))
+        log.debug("%s initialized !!", sender)
 
     def register():
         signals.initialized.connect(test)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -742,8 +742,8 @@ Time and Date
 
    .. parsed-literal::
 
-       LOCALE = ('usa', 'jpn',      # On Windows
-                 'en_US', 'ja_JP'   # On Unix/Linux
+      LOCALE = ('usa', 'jpn',      # On Windows
+                'en_US', 'ja_JP'   # On Unix/Linux
       )
 
    For a list of available locales refer to `locales on Windows`_  or on

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -165,6 +165,8 @@ class FatalLogger(LimitLogger):
 
 
 logging.setLoggerClass(FatalLogger)
+# force root logger to be of our preferred class
+logging.getLogger().__class__ = FatalLogger
 
 
 def supports_color():


### PR DESCRIPTION
This enforces [`FatalLogger` policy](https://github.com/getpelican/pelican/blob/78edd878a31d9dd900e79477a0a2789384ff75f1/pelican/log.py#L152-L167) (`--fatal` CLI switch) upon plugins that might contain codes such as:
```py
import logging
log = logging.getLogger()

log.warning(...)
# or
logging.warning(...)
```
It might look like a hack, but it's valid and it quacks. :laughing: 


# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
