### PR TITLE
Automatically open browser when Invoke task starts web server

### DIFF
--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -82,6 +82,11 @@ def serve(c):
         (CONFIG['host'], CONFIG['port']),
         ComplexHTTPRequestHandler)
 
+    if OPEN_BROWSER_ON_SERVE:
+        # Open site in default browser
+        import webbrowser
+        webbrowser.open("http://{host}:{port}".format(**CONFIG))
+
     sys.stderr.write('Serving at {host}:{port} ...\n'.format(**CONFIG))
     server.serve_forever()
 

--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -13,6 +13,7 @@ from pelican import main as pelican_main
 from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
 from pelican.settings import DEFAULT_CONFIG, get_settings_from_file
 
+OPEN_BROWSER_ON_SERVE = True
 SETTINGS_FILE_BASE = 'pelicanconf.py'
 SETTINGS = {}
 SETTINGS.update(DEFAULT_CONFIG)
@@ -124,6 +125,12 @@ def livereload(c):
 
     for glob in watched_globs:
         server.watch(glob, cached_build)
+
+    if OPEN_BROWSER_ON_SERVE:
+        # Open site in default browser
+        import webbrowser
+        webbrowser.open("http://{host}:{port}".format(**CONFIG))
+
     server.serve(host=CONFIG['host'], port=CONFIG['port'], root=CONFIG['deploy_path'])
 
 {% if cloudfiles %}


### PR DESCRIPTION
When the livereload target is invoked, a web brower will be automatically opened pointing to the locally-served website.

In case of no web browser can be found by the module, the open call returns False but no exception is raised. This means that it is still possible to call livereload on a remote machine and access it without any error being triggered.

# Pull Request Checklist

- [x] Conformed to **code style guidelines** by running appropriate linting tools

Other fields in the checklist have been removed, as they are considered *not applicable* for this contribution.