### PR TITLE
fix usage of pelican_open in pelican_internals doc page

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -44,17 +44,22 @@ HTML content and some metadata.
 
 Take a look at the Markdown reader::
 
+    from pelican.readers import BaseReader
+    from pelican.utils import pelican_open
+    from markdown import Markdown
+
     class MarkdownReader(BaseReader):
-        enabled = bool(Markdown)
+        enabled = True
 
         def read(self, source_path):
             """Parse content and metadata of markdown files"""
-            text = pelican_open(source_path)
-            md_extensions = {'markdown.extensions.meta': {},
-                             'markdown.extensions.codehilite': {}}
-            md = Markdown(extensions=md_extensions.keys(),
-                          extension_configs=md_extensions)
-            content = md.convert(text)
+
+            with pelican_open(source_path) as text:
+                md_extensions = {'markdown.extensions.meta': {},
+                                 'markdown.extensions.codehilite': {}}
+                md = Markdown(extensions=md_extensions.keys(),
+                              extension_configs=md_extensions)
+                content = md.convert(text)
 
             metadata = {}
             for name, value in md.Meta.items():


### PR DESCRIPTION
Thanks for making Pelican available for everyone!

`pelican_open` returns a `ContextManager` object, this PR fixes the code sample in `pelican_internals` that assumes that `pelican_open` returns a string.