### PR TITLE
Adds the alternative of the sftp command for SSH

### DIFF
--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -70,6 +70,7 @@ help:
 	@echo '   make serve-global [SERVER=0.0.0.0]  serve (as root) to $(SERVER):80    '
 	@echo '   make devserver [PORT=8000]          serve and regenerate together      '
 	@echo '   make ssh_upload                     upload the web site via SSH        '
+    @echo '   make sftp_upload                    upload the web site via sftp       '
 	@echo '   make rsync_upload                   upload the web site via rsync+ssh  '
 {% if dropbox %}
 	@echo '   make dropbox_upload                 upload the web site via Dropbox    '
@@ -120,6 +121,9 @@ publish:
 {% set upload = upload + ["ssh_upload"] %}
 ssh_upload: publish
 	scp -P $(SSH_PORT) -r "$(OUTPUTDIR)"/* "$(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)"
+
+sftp_upload: publish 
+	printf 'put -r $(OUTPUTDIR)/*' | sftp $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
 
 {% set upload = upload + ["rsync_upload"] %}
 rsync_upload: publish


### PR DESCRIPTION
Some managed web hosts (e.g. gandi.net) do not allow uploads with scp or rsync, so the sftp command is a necessary alternative.

# Pull Request Checklist



<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [NA] Ensured **tests pass** and (if applicable) updated functional test output
- [o] Conformed to **code style guidelines** by running appropriate linting tools
- [NA] Added **tests** for changed code
- [NA] Updated **documentation** for changed code

