### PR TITLE
Rename setting SUMMARY_END_MARKER → SUMMARY_END_SUFFIX

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -303,10 +303,10 @@ Basic settings
    does not otherwise specify a summary. Setting to ``None`` will cause the
    summary to be a copy of the original content.
 
-.. data:: SUMMARY_END_MARKER = '…'
+.. data:: SUMMARY_END_SUFFIX = '…'
 
    When creating a short summary of an article and the result was truncated to
-   match the required word length, this will be used as the truncation marker.
+   match the required word length, this will be used as the truncation suffix.
 
 .. data:: WITH_FUTURE_DATES = True
 

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -392,7 +392,7 @@ class Content:
 
         return truncate_html_words(self.content,
                                    self.settings['SUMMARY_MAX_LENGTH'],
-                                   self.settings['SUMMARY_END_MARKER'])
+                                   self.settings['SUMMARY_END_SUFFIX'])
 
     @property
     def summary(self):

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -136,7 +136,7 @@ DEFAULT_CONFIG = {
     'TYPOGRIFY': False,
     'TYPOGRIFY_IGNORE_TAGS': [],
     'TYPOGRIFY_DASHES': 'default',
-    'SUMMARY_END_MARKER': '…',
+    'SUMMARY_END_SUFFIX': '…',
     'SUMMARY_MAX_LENGTH': 50,
     'PLUGIN_PATHS': [],
     'PLUGINS': None,

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -110,7 +110,7 @@ class TestPage(TestBase):
         page = Page(**page_kwargs)
         self.assertEqual(page.summary, '')
 
-    def test_summary_end_marker(self):
+    def test_summary_end_suffix(self):
         # If a :SUMMARY_END_SUFFIX: is set, and there is no other summary,
         # generated summary should contain the specified marker at the end.
         page_kwargs = self._copy_page_kwargs()

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -111,13 +111,13 @@ class TestPage(TestBase):
         self.assertEqual(page.summary, '')
 
     def test_summary_end_marker(self):
-        # If a :SUMMARY_END_MARKER: is set, and there is no other summary,
+        # If a :SUMMARY_END_SUFFIX: is set, and there is no other summary,
         # generated summary should contain the specified marker at the end.
         page_kwargs = self._copy_page_kwargs()
         settings = get_settings()
         page_kwargs['settings'] = settings
         del page_kwargs['metadata']['summary']
-        settings['SUMMARY_END_MARKER'] = 'test_marker'
+        settings['SUMMARY_END_SUFFIX'] = 'test_marker'
         settings['SUMMARY_MAX_LENGTH'] = 10
         page = Page(**page_kwargs)
         self.assertEqual(page.summary, truncate_html_words(TEST_CONTENT, 10,


### PR DESCRIPTION
Avoids clash with 'summary' plugin.
Pelican with previous setting as yet unreleased, so no harm done.

Refs: https://github.com/getpelican/pelican-plugins/pull/1284#issuecomment-660715086

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
