### PR TITLE
Include Jinja2 templates in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
-recursive-include pelican *.html *.css *png *.rst *.markdown *.md *.mkd *.xml *.py
+recursive-include pelican *.html *.css *png *.rst *.markdown *.md *.mkd *.xml *.py *.jinja2
 include LICENSE THANKS docs/changelog.rst pyproject.toml


### PR DESCRIPTION
This commit includes jinja2 templates (in pelican/tools/templates) in the MANIFEST.in file so that setuptools can pick them up when doing `setup(..., include_package_data=True)`

During my tests, if running `python setup.py` inside the git repo, setup.py will actually pick those files. But running `python setup.py` from outside the git repo will not include them. Can be tested from running setup.py in the uncompressed source tarball.