### PR TITLE
Support compound file extensions. Fix #2780

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Support matching compound file extensions for custom readers; e.g., `.md.html`

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from functools import partial
 from itertools import chain, groupby
 from operator import attrgetter
+from pathlib import Path
 
 from jinja2 import (BaseLoader, ChoiceLoader, Environment, FileSystemLoader,
                     PrefixLoader, TemplateNotFound)
@@ -123,7 +124,7 @@ class Generator:
         if any(fnmatch.fnmatch(basename, ignore) for ignore in ignores):
             return False
 
-        ext = os.path.splitext(basename)[1][1:]
+        ext = ''.join(Path(basename).suffixes)[1:]
         if extensions is False or ext in extensions:
             return True
 

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -41,6 +41,17 @@ class TestGenerator(unittest.TestCase):
         ignored_file = os.path.join(CUR_DIR, 'content', 'ignored1.rst')
         self.assertFalse(include_path(ignored_file))
 
+    def test_include_path_handles_compound_extensions(self):
+        """
+        Test that Generator._include_path properly handles
+        compound extensions such as .md.html
+        """
+        filename = os.path.join(CUR_DIR, 'content', 'article.md.html')
+        include_path = self.generator._include_path
+        self.assertTrue(include_path(filename, extensions=('md.html',)))
+        self.assertFalse(include_path(filename, extensions=('md',)))
+        self.assertFalse(include_path(filename, extensions=('html',)))
+
     def test_get_files_exclude(self):
         """Test that Generator.get_files() properly excludes directories.
         """


### PR DESCRIPTION
Before this commit, the file extension matcher could not match compound
file extensions; e.g., '.md.html' would match `.html`

# Pull Request Checklist

Resolves: #2780 <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
