### PR TITLE
Improve logging of generators and writer loaders

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Improve logging of generators and writer loaders

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -189,8 +189,6 @@ class Pelican:
 
         generators = []
 
-        logger.debug("Loading generators:")
-
         for generator, receiver in discovered_generators:
             if receiver is None:
                 origin = "internal"
@@ -198,12 +196,10 @@ class Pelican:
                 origin = receiver.__module__
 
             if not isinstance(generator, type):
-                logger.error("Generator {g} ({o}) cannot be loaded".format(
-                    g=generator, o=origin
-                ))
+                logger.error("Generator %s (%s) cannot be loaded" % (generator, origin))
                 continue
 
-            logger.debug("* {g} ({o})".format(g=generator.__name__, o=origin))
+            logger.debug("Found generator: %s (%s)" % (generator.__name__, origin))
             generators.append(generator)
 
         return generators
@@ -216,13 +212,11 @@ class Pelican:
             return Writer(self.output_path, settings=self.settings)
 
         if num_writers > 1:
-            logger.warning(
-                "{n} writers found, using only first one".format(n=num_writers)
-            )
+            logger.warning("%s writers found, using only first one" % num_writers)
 
         writer = writers[0]
 
-        logger.debug("Found writer: {w}".format(w=writer))
+        logger.debug("Found writer: %s" % writer)
         return writer(self.output_path, settings=self.settings)
 
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -195,13 +195,15 @@ class Pelican:
             if receiver is None:
                 origin = "internal"
             else:
-                origin = f"{receiver.__module__}"
+                origin = receiver.__module__
 
             if not isinstance(generator, type):
-                logger.error(f"Generator {generator} ({origin}) cannot be loaded")
+                logger.error("Generator {g} ({o}) cannot be loaded".format(
+                    g=generator, o=origin
+                ))
                 continue
 
-            logger.debug(f"* {generator.__name__} ({origin})")
+            logger.debug("* {g} ({o})".format(g=generator.__name__, o=origin))
             generators.append(generator)
 
         return generators
@@ -215,12 +217,12 @@ class Pelican:
 
         if num_writers > 1:
             logger.warning(
-                f"{num_writers} writers found, using only first one"
+                "{n} writers found, using only first one".format(n=num_writers)
             )
 
         writer = writers[0]
 
-        logger.debug(f"Found writer: {writer}")
+        logger.debug("Found writer: {w}".format(w=writer))
         return writer(self.output_path, settings=self.settings)
 
 

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -84,14 +84,14 @@ class TestPelican(LoggedTestCase):
         # have their output paths overridden by the {attach} link syntax.
 
         pelican = Pelican(settings=read_settings(path=None))
-        generator_classes = pelican.get_generator_classes()
+        generator_classes = pelican._get_generator_classes()
 
         self.assertTrue(
             generator_classes[-1] is StaticGenerator,
             "StaticGenerator must be the last generator, but it isn't!")
         self.assertIsInstance(
             generator_classes, Sequence,
-            "get_generator_classes() must return a Sequence to preserve order")
+            "_get_generator_classes() must return a Sequence to preserve order")
 
     def test_basic_generation_works(self):
         # when running pelican without settings, it should pick up the default


### PR DESCRIPTION
This improves the logging of `get_generator_classes()` to provide the source of the generator (either internal or from a plugin). It also reviews the code to make it clearer (in my opinion, but I'm biased :wink:), renames `get_writer()` to `_get_writer_class()` for consistency with the renamed `_get_generator_classes()`. Both are purely internal methods so I think it makes sense to signal it with the initial underscore.

Aside from cosmetic changes this doesn't affect the Pelican loading mechanism at all.

This is my first PR for this project, so please help me double checking that everything was done according to the guidelines.

# Pull Request Checklist

- [X] Ensured **tests pass** and (if applicable) updated functional test output
- [X] Conformed to **code style guidelines** by running appropriate linting tools
