### PR TITLE
Proof of concept for specialised writers

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -25,7 +25,7 @@ from pelican.readers import Readers
 from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
 from pelican.settings import coerce_overrides, read_settings
 from pelican.utils import (FileSystemWatcher, clean_output_dir, maybe_pluralize)
-from pelican.writers import Writer, CollectionRSSWriter
+from pelican.writers import CollectionRSSWriter, Writer
 
 try:
     __version__ = __import__('pkg_resources') \

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -268,3 +268,7 @@ class Writer:
                 context, name, kwargs, relative_urls)
             _write_file(template, localcontext, self.output_path, name,
                         override_output)
+
+
+class CollectionRSSWriter(Writer):
+    pass


### PR DESCRIPTION
**This is a proof of concept for the possible new writers system**
This PR is not meant to be merged in the current state without a discussion on its content.

The idea is to split writers (and in particular `Writer`) into several writers that are capable of writing content (single articles) or collections, and potentially other types of data, should the need arise.

`CollectionRSSWriter` is an example of such a new-generation writer, even though for simplicity's sake in this POF it is just a copy of `Writer`.

For each generator, Pelican runs the method `generate_data` which is currently not in use. Since it is skipped if not present, this is backward compatible with the current code base. The data returned by `generate_data` is stored according to the category provided by the attribute `data_type` of the generator itself. The data type `DataType.ALL` is meant to be a way to migrate the current writers, as they effectively manage both content and collections. Last, each writer is run on the collected data.

The method `_get_writers` is returning a fixed dictionary in this POF but the idea is to model it after `_get_generator_classes` where writers can come both from the internal code and from plugins.

A plugin such as https://github.com/getpelican/pelican-plugins/tree/master/pdf would for example provide a writer and not a generator, as what the plugin currently does is to skip the default writer and use the custom one on all content (articles and pages).

The suggested division between content and collections can (and in my opinion should) be further refined, for example to separate articles from pages.