### PR TITLE
Add "http://" prefix to `pelican --listen` output

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -469,7 +469,7 @@ def listen(server, port, output, excqueue=None):
         return
 
     try:
-        print("\nServing site at: {}:{} - Tap CTRL-C to stop".format(
+        print("\nServing site at: http://{}:{} - Tap CTRL-C to stop".format(
             server, port))
         httpd.serve_forever()
     except Exception as e:


### PR DESCRIPTION
Normally my terminal highlights URLs and i can not only easily spot them, but also make the open in a browser with one click.
This obviously cannot happen, if there is no url to be found.

This change adds ``http://`` before the ip and port in the log output so terminals that support URL parsing can pick this up.