### PR TITLE
Add all-numeric period variable for the period_archives template

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add a `period_num` variable for the `period_archives` template.

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -327,6 +327,8 @@ period                  A tuple of the form (`year`, `month`, `day`) that
                         given year. It contains both `year` and `month`
                         if the time period is over years and months and
                         so on.
+period_num              A tuple of the form (`year`, `month`, `day`), as in
+                        `period`, except all values are numbers.
 
 ===================     ===================================================
 

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -511,6 +511,7 @@ class ArticlesGenerator(CachingGenerator):
 
                 if key == period_date_key['year']:
                     context["period"] = (_period,)
+                    context["period_num"] = (_period,)
                 else:
                     month_name = calendar.month_name[_period[1]]
                     if key == period_date_key['month']:
@@ -520,6 +521,7 @@ class ArticlesGenerator(CachingGenerator):
                         context["period"] = (_period[0],
                                              month_name,
                                              _period[2])
+                    context["period_num"] = tuple(_period)
 
                 write(save_as, template, context, articles=articles,
                       dates=archive, template_name='period_archives',

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -413,6 +413,7 @@ class TestArticlesGenerator(unittest.TestCase):
         self.assertEqual(len(dates), 1)
         # among other things it must have at least been called with this
         context["period"] = (1970,)
+        context["period_num"] = (1970,)
         write.assert_called_with("posts/1970/index.html",
                                  generator.get_template("period_archives"),
                                  context, blog=True, articles=articles,
@@ -437,6 +438,7 @@ class TestArticlesGenerator(unittest.TestCase):
                     if d.date.year == 1970 and d.date.month == 1]
         self.assertEqual(len(dates), 1)
         context["period"] = (1970, "January")
+        context["period_num"] = (1970, 1)
         # among other things it must have at least been called with this
         write.assert_called_with("posts/1970/Jan/index.html",
                                  generator.get_template("period_archives"),
@@ -470,6 +472,7 @@ class TestArticlesGenerator(unittest.TestCase):
         ]
         self.assertEqual(len(dates), 1)
         context["period"] = (1970, "January", 1)
+        context["period_num"] = (1970, 1, 1)
         # among other things it must have at least been called with this
         write.assert_called_with("posts/1970/Jan/01/index.html",
                                  generator.get_template("period_archives"),


### PR DESCRIPTION
Hello!
I would like to use the language-agnostic date format `2020-12-29` in my Period Archive, but the template only gets [a localized name for the month](https://docs.getpelican.com/en/stable/themes.html?highlight=period_archives#period-archives-html).
Would it be possible to provide an all-numeric `period` as well?

Here is an idea of how it could work.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
