### PR TITLE
livereload task improvements

### DIFF
--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -99,23 +99,31 @@ def preview(c):
 def livereload(c):
     """Automatically reload browser tab upon file modification."""
     from livereload import Server
-    build(c)
+
+    def cached_build():
+        cmd = '-s {settings_base} -e CACHE_CONTENT=True LOAD_CONTENT_CACHE=True'
+        pelican_run(cmd.format(**CONFIG))
+
+    cached_build()
     server = Server()
-    # Watch the base settings file
-    server.watch(CONFIG['settings_base'], lambda: build(c))
-    # Watch content source files
+    theme_path = SETTINGS['THEME']
+    watched_globs = [
+        CONFIG['settings_base'],
+        '{}/templates/**/*.html'.format(theme_path),
+    ]
+
     content_file_extensions = ['.md', '.rst']
     for extension in content_file_extensions:
-        content_blob = '{0}/**/*{1}'.format(SETTINGS['PATH'], extension)
-        server.watch(content_blob, lambda: build(c))
-    # Watch the theme's templates and static assets
-    theme_path = SETTINGS['THEME']
-    server.watch('{}/templates/*.html'.format(theme_path), lambda: build(c))
+        content_glob = '{0}/**/*{1}'.format(SETTINGS['PATH'], extension)
+        watched_globs.append(content_glob)
+
     static_file_extensions = ['.css', '.js']
     for extension in static_file_extensions:
-        static_file = '{0}/static/**/*{1}'.format(theme_path, extension)
-        server.watch(static_file, lambda: build(c))
-    # Serve output path on configured host and port
+        static_file_glob = '{0}/static/**/*{1}'.format(theme_path, extension)
+        watched_globs.append(static_file_glob)
+
+    for glob in watched_globs:
+        server.watch(glob, cached_build)
     server.serve(host=CONFIG['host'], port=CONFIG['port'], root=CONFIG['deploy_path'])
 
 {% if cloudfiles %}


### PR DESCRIPTION
- use custom build command, with caching turned on - this reduces site build time by around 40% on my testing machines
- collect all glob patterns in a list and then call `server.watch` on each item - this allows to have single place where callback function must be specified
- use '**/*.html' as glob in template, to track changes in subdirectories (some themes include "partials" directory, where they store common widgets used in few different templates)