### PR TITLE
[WIP] Read content selectively

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -808,13 +808,21 @@ class StaticGenerator(Generator):
                 if self._is_potential_source_path(f):
                     continue
 
-            static = self.readers.read_file(
-                base_path=self.path, path=f, content_class=Static,
-                fmt='static', context=self.context,
-                preread_signal=signals.static_generator_preread,
-                preread_sender=self,
-                context_signal=signals.static_generator_context,
-                context_sender=self)
+            try:
+                static = self.readers.read_file(
+                    base_path=self.path, path=f, content_class=Static,
+                    fmt='static', context=self.context,
+                    preread_signal=signals.static_generator_preread,
+                    preread_sender=self,
+                    context_signal=signals.static_generator_context,
+                    context_sender=self)
+            except Exception as e:
+                logger.error(
+                    'Could not process %s\n%s', f, e,
+                    exc_info=self.settings.get('DEBUG', False))
+                self._add_failed_source_path(f, static=True)
+                continue
+
             self.staticfiles.append(static)
             self.add_source_path(static, static=True)
         self._update_context(('staticfiles',))

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -14,7 +14,7 @@ from jinja2 import (BaseLoader, ChoiceLoader, Environment, FileSystemLoader,
 from pelican.cache import FileStampDataCacher
 from pelican.contents import Article, Page, Static
 from pelican.plugins import signals
-from pelican.readers import Readers
+from pelican.readers import PelicanFileSkipped, Readers
 from pelican.utils import (DateFormatter, copy, mkdir_p, order_content,
                            posixize_path, process_translations)
 
@@ -621,9 +621,12 @@ class ArticlesGenerator(CachingGenerator):
                         context_signal=signals.article_generator_context,
                         context_sender=self)
                 except Exception as e:
-                    logger.error(
-                        'Could not process %s\n%s', f, e,
-                        exc_info=self.settings.get('DEBUG', False))
+                    if isinstance(e, PelicanFileSkipped):
+                        logger.debug('Skipping %s', f)
+                    else:
+                        logger.error(
+                            'Could not process %s\n%s', f, e,
+                            exc_info=self.settings.get('DEBUG', False))
                     self._add_failed_source_path(f)
                     continue
 
@@ -726,9 +729,12 @@ class PagesGenerator(CachingGenerator):
                         context_signal=signals.page_generator_context,
                         context_sender=self)
                 except Exception as e:
-                    logger.error(
-                        'Could not process %s\n%s', f, e,
-                        exc_info=self.settings.get('DEBUG', False))
+                    if isinstance(e, PelicanFileSkipped):
+                        logger.debug('Skipping %s', f)
+                    else:
+                        logger.error(
+                            'Could not process %s\n%s', f, e,
+                            exc_info=self.settings.get('DEBUG', False))
                     self._add_failed_source_path(f)
                     continue
 
@@ -817,9 +823,12 @@ class StaticGenerator(Generator):
                     context_signal=signals.static_generator_context,
                     context_sender=self)
             except Exception as e:
-                logger.error(
-                    'Could not process %s\n%s', f, e,
-                    exc_info=self.settings.get('DEBUG', False))
+                if isinstance(e, PelicanFileSkipped):
+                    logger.debug('Skipping %s', f)
+                else:
+                    logger.error(
+                        'Could not process %s\n%s', f, e,
+                        exc_info=self.settings.get('DEBUG', False))
                 self._add_failed_source_path(f, static=True)
                 continue
 

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -63,6 +63,10 @@ METADATA_PROCESSORS = {
 logger = logging.getLogger(__name__)
 
 
+class PelicanFileSkipped(Exception):
+    pass
+
+
 def ensure_metadata_list(text):
     """Canonicalize the format of a list of authors or tags.  This works
        the same way as Docutils' "authors" field: if it's already a list,
@@ -538,7 +542,7 @@ class Readers(FileStampDataCacher):
         path = os.path.abspath(os.path.join(base_path, path))
         source_path = posixize_path(os.path.relpath(path, base_path))
         if 'READ_SELECTED' in self.settings and self.settings['READ_SELECTED'] not in source_path:
-            raise ValueError(f"Skipping {source_path}")
+            raise PelicanFileSkipped(source_path)
         logger.debug(
             'Read file %s -> %s',
             source_path, content_class.__name__)

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -537,6 +537,8 @@ class Readers(FileStampDataCacher):
 
         path = os.path.abspath(os.path.join(base_path, path))
         source_path = posixize_path(os.path.relpath(path, base_path))
+        if 'READ_SELECTED' in self.settings and self.settings['READ_SELECTED'] not in source_path:
+            raise ValueError(f"Skipping {source_path}")
         logger.debug(
             'Read file %s -> %s',
             source_path, content_class.__name__)


### PR DESCRIPTION
This is quick and dirty version of new setting that allows pelican to **read** content selectively, which provides tangible improvement of site build speed. See https://github.com/getpelican/pelican/issues/2678#issuecomment-776614289 for rationale. I am putting it here mostly as a reminder for me, and also to give a little head-start to anyone willing to work on this.

Speed comparison on my website:
- baseline: 0.91 second
- WRITE_SELECTED: 0.85 second
- READ_SELECTED: 0.13 second

Things I would like to get done before opening it for possible merge:

- [ ] Make READ_SELECTED a list of paths/patterns, and compare specific path to each of them
- [ ] Smarter handling of static files (especially static files that are `{attach}`ed in read post, but are outside of read paths themselves)
- [x] Don't pollute STDOUT with "errors" about skipped files (I'm thinking of creating new exception for that, and modifying all generators to only `logger.debug` when this exception is seen)
- [ ] Document new setting
- [ ] Remove `WRITE_SELECTED` support

Also, it makes perfect sense to me that `--autoreload` would use this feature to generate only files that actually changed, but that might require changes to `FileSystemWatcher`, so I would leave it for another PR. 