### PR TITLE
ignore None return value from get_generators signal

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -181,10 +181,10 @@ class Pelican:
         for receiver, values in signals.get_generators.send(self):
             if not isinstance(values, Iterable):
                 values = (values,)
-
-            discovered_generators.extend(
-                [(generator, receiver.__module__) for generator in values]
-            )
+            for generator in values:
+                if generator is None:
+                    continue  # plugin did not return a generator
+                discovered_generators.append((generator, receiver.__module__))
 
         # StaticGenerator must run last, so it can identify files that
         # were skipped by the other generators, and so static files can


### PR DESCRIPTION
Resolves: #2834

Ignores if nothing was returned from `get_generators` signal. Some plugins were using this signal primarily because it provided a convenient place in the run timeline and did not return any generator to register. They were cluttering log with error messages even though everything was working as expected.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [+] Ensured **tests pass** and (if applicable) updated functional test output
- [+] Conformed to **code style guidelines** by running appropriate linting tools

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
