### PR TITLE
Fix `invoke tests` task problem on Windows

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -42,7 +42,8 @@ def docserve(c):
 @task
 def tests(c):
     """Run the test suite"""
-    c.run(f"{VENV_BIN}/pytest", pty=True)
+    PTY = True if os.name != "nt" else False
+    c.run(f"{VENV_BIN}/pytest", pty=PTY)
 
 
 @task


### PR DESCRIPTION
PTY is not supported on Windows.

# Pull Request Checklist

- [ n/a ] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ n/a ] Added **tests** for changed code
- [ n/a ] Updated **documentation** for changed code

Just something I stumbled across while working on `jinja_filters`.
