### PR TITLE
Add progress spinner animation during generation

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -13,6 +13,8 @@ from collections.abc import Iterable
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
+from rich.console import Console
+
 # pelican.log has to be the first pelican module to be loaded
 # because logging.setLoggerClass has to be called before logging.getLogger
 from pelican.log import init as init_logging
@@ -35,6 +37,7 @@ except Exception:
 
 DEFAULT_CONFIG_NAME = 'pelicanconf.py'
 logger = logging.getLogger(__name__)
+console = Console()
 
 
 class Pelican:
@@ -524,7 +527,8 @@ def main(argv=None):
         else:
             watcher = FileSystemWatcher(args.settings, Readers, settings)
             watcher.check()
-            pelican.run()
+            with console.status("Generating..."):
+                pelican.run()
     except KeyboardInterrupt:
         logger.warning('Keyboard interrupt received. Exiting.')
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ jinja2 = ">=2.7"
 pygments = ">=2.6"
 python-dateutil = ">=2.8"
 pytz = ">=2020.1"
+rich = ">=10.1"
 unidecode = ">=1.1"
 markdown = {version = ">=3.1", optional = true}
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ version = "4.6.0"
 
 requires = ['feedgenerator >= 1.9', 'jinja2 >= 2.7', 'pygments',
             'docutils>=0.15', 'pytz >= 0a', 'blinker', 'unidecode',
-            'python-dateutil']
+            'python-dateutil', 'rich']
 
 entry_points = {
     'console_scripts': [


### PR DESCRIPTION
I thought it would be nice to enhance Pelican's console output aesthetics via the [Rich][] project, and adding an animated spinner during site generation is the most naive initial implementation I could conceive.

There are [many other ways](https://github.com/willmcgugan/rich#rich-library) in which we could use [Rich][] to enhance console output, including prettier text colors, nicer logging formatting, and more readable tracebacks.

I'd love to replace the `Generating...` spinner in this PR with per-task progress bars (generating, writing, etc.). If someone wants to submit a follow-up PR to implement that, I'd be most grateful!  🚀

[Rich]: https://github.com/willmcgugan/rich