### PR TITLE
Fix FILENAME_METADATA doc to render correctly

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -815,7 +815,7 @@ Metadata
 
    The default metadata you want to use for all articles and pages.
 
-.. data:: FILENAME_METADATA = r'(?P<date>\d{4}-\d{2}-\d{2}).*'
+.. data:: FILENAME_METADATA = r'(?P<date>\\d{4}-\\d{2}-\\d{2}).*'
 
    The regexp that will be used to extract any metadata from the filename. All
    named groups that are matched will be set in the metadata object.  The


### PR DESCRIPTION
I was rewriting my website with pelican and did a blind copy paste of the (alleged) FILENAME_METADATA default value from the docs as a starting point, but I was having trouble getting what I needed working. Then, I realized that the regexp I copied was different from the actual default value, as it got incorrectly rendered on the docs due to some missing backslashes. whoops! 