### PR TITLE
Allow easy subclassing of Writer

### DIFF
--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -25,7 +25,7 @@ class Writer:
         self._overridden_files = set()
 
         # See Content._link_replacer for details
-        if self.settings['RELATIVE_URLS']:
+        if "RELATIVE_URLS" in self.settings and self.settings['RELATIVE_URLS']:
             self.urljoiner = posix_join
         else:
             self.urljoiner = lambda base, url: urljoin(


### PR DESCRIPTION
When you write a custom Writer, it gets called with `settings=None`. If you writer is simply a subclass of the built-in Writer, Pelican will through the error `CRITICAL: 'RELATIVE_URLS'`.

The source of the error is from `Pelican._get_writer()` in `__init__.py`.

With this in place, your custom writer can be as simple as:

~~~python
from pelican.writers import Writer

class CustomWriter(Writer):
    pass
~~~

I realize the above example doesn't do much, but it makes starting easier.

# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [?] Added **tests** for changed code
- [ n/a ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
