### PR TITLE
Really Allow Alternate Writers

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -213,7 +213,7 @@ class Pelican:
         return generators
 
     def _get_writer(self):
-        writers = [w for _, w in signals.get_writer.send(self) if isinstance(w, type)]
+        writers = [w for w, _ in signals.get_writer.send(self) if isinstance(w, type)]
         num_writers = len(writers)
 
         if num_writers == 0:

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -224,7 +224,7 @@ class Pelican:
 
         writer = writers[0]
 
-        logger.debug("Found writer: %s", writer)
+        logger.debug("Found writer: %s (%s)" % (writer.__name__, writer.__module__))
         return writer(self.output_path, settings=self.settings)
 
 


### PR DESCRIPTION
Further to #2882, the blinker signal returns both the *class of the custom Writer* and an *instance of the custom Writer*. Previously, Pelican was only keeping the instance, and this would fail the `isinstance(w, type)` check, which meant that Pelican would always default to the built-in Writer. This now keeps the class reference instead and actually allows one to provide a custom Writer.

This also updates the formating of the debug message to match the Generators (below is with rich logging active):

```
           DEBUG    Found generator: ArticlesGenerator (internal)                                        __init__.py:211
           DEBUG    Found generator: PagesGenerator (internal)                                           __init__.py:211
           DEBUG    Found generator: GPXGenerator (pelican.plugins.gpx_reader)                           __init__.py:211
           DEBUG    Found generator: StaticGenerator (internal)                                          __init__.py:211
...
           DEBUG    Found writer: XMLWriter (pelican.plugins.xml_writer.writer)                          __init__.py:228
```

I am working on a custom writer, and so will update here when I have it on GitHub so you can test it locally.

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ n/a ] Added **tests** for changed code
- [ n/a ] Updated **documentation** for changed code


