### PR TITLE
Support date format codes G, V, and u (used by ISO dates)

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -513,6 +513,9 @@ class TestUtils(LoggedTestCase):
         d = utils.SafeDatetime(2012, 8, 9)
         self.assertEqual(utils.strftime(d, '%-d/%-m/%y'), '9/8/12')
 
+        d = utils.SafeDatetime(2021, 1, 8)
+        self.assertEqual(utils.strftime(d, '%G - %-V - %u'), '2021 - 1 - 5')
+
     # test the output of utils.strftime in a different locale
     # Turkish locale
     @unittest.skipUnless(locale_available('tr_TR.UTF-8') or

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -99,6 +99,7 @@ class SafeDatetime(datetime.datetime):
         else:
             return super().strftime(fmt)
 
+
 class DateFormatter:
     '''A date formatter object used as a jinja filter
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -50,7 +50,8 @@ def strftime(date, date_format):
     '''
     def strip_zeros(x):
         return x.lstrip('0') or '0'
-    c89_directives = 'aAbBcdfHIjmMpSUwWxXyYzZ%'
+    # includes ISO date parameters added by Python 3.6
+    c89_directives = 'aAbBcdfGHIjmMpSUuVwWxXyYzZ%'
 
     # grab candidate format options
     format_options = '%[-]?.'
@@ -97,7 +98,6 @@ class SafeDatetime(datetime.datetime):
             return strftime(self, fmt)
         else:
             return super().strftime(fmt)
-
 
 class DateFormatter:
     '''A date formatter object used as a jinja filter


### PR DESCRIPTION
Current behaviour:

~~~python-repl
>>> from pelican.utils import SafeDatetime
>>> from datetime import datetime
>>> "{a:%G}-{a:%V}-{a:%u}".format(a=SafeDatetime.now())
'%G-%V-%u'
>>> "{a:%G}-{a:%V}-{a:%u}".format(a=datetime.now())
'2021-27-7'
~~~

(`%G` gives you the ISO year, `%V` gives you the ISO week, and `%u` gives you the ISO day)

These codes aren't part of the C89 spec, but were added in Python 3.6 (which is the minimum officially supported version of Python for Pelican), so I don't expect any issues with supporting them.

(As a side, this also lead me to discover why `%-d` works in Pelican and nowhere else!)

**Usecase**: I want to create a weekly "period archive" and it would be simpliest to use the ISO dating, as that is already built into Python's standard library.

This also adds a test to make sure these are working as expected.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ? ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
