### PR TITLE
docs: adding section on where to find themes

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -59,8 +59,11 @@ individual repositories. Legacy plugins are located in the `pelican-plugins
 repository`_ and will be gradually phased out in favor of the namespace
 versions.
 
+You can also search packaqges with the `Pelican::Plugins Pypi classifier`_.
+
 .. _pelican-plugins organization: https://github.com/pelican-plugins
 .. _pelican-plugins repository: https://github.com/getpelican/pelican-plugins
+.. _Pelican::Plugins Pypi classifier: https://pypi.org/search/?c=Framework+%3A%3A+Pelican+%3A%3A+Plugins
 
 Please note that while we do our best to review and maintain these plugins,
 they are submitted by the Pelican community and thus may have varying levels of

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -1,7 +1,26 @@
 .. _theming-pelican:
 
+Themes
+######
+
+Where to find them?
+*******************
+Namespace themes can be found in the `pelican-themes repository`_.
+Please note that while we do our best to review and maintain these themes,
+they are submitted by the Pelican community and thus may have varying levels of
+support and interoperability.
+
+You can also search packaqges with the `Pelican::Themes Pypi classifier`_.
+
+.. _pelican-themes repository: https://github.com/getpelican/pelican-themes
+.. _Pelican::Themes Pypi classifier: https://pypi.org/search/?c=Framework+%3A%3A+Pelican+%3A%3A+Themes
+
+A Pelican contributor also built a web page inventoring many Pelican themes: 
+`<http://www.pelicanthemes.com>`_
+
+
 Creating themes
-###############
+***************
 
 To generate its HTML output, Pelican uses the `Jinja
 <https://palletsprojects.com/p/jinja/>`_ templating engine due to its flexibility and


### PR DESCRIPTION
\+ mention Pypi classifiers

Resulting theme page preview:
<img width="518" alt="2021-08-05 12_12_23-" src="https://user-images.githubusercontent.com/925560/128333649-cfd87710-e50c-4157-9bd5-ba6ba06a930b.png">