### PR TITLE
Adding missing tests for truncate_html_words()

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -6,9 +6,9 @@ import time
 from sys import platform
 from tempfile import mkdtemp
 
-import pytz
-
 from markupsafe import Markup
+
+import pytz
 
 from pelican import utils
 from pelican.generators import TemplatePagesGenerator
@@ -239,26 +239,26 @@ class TestUtils(LoggedTestCase):
         # marker containing HTML tags.
         self.assertEqual(
             utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20,
-                '<span>marker</span>'),
+                                      '<span>marker</span>'),
             '<p>' + 'word ' * 20 + '<span>marker</span></p>')
         self.assertEqual(
             utils.truncate_html_words(
-                '<span\nstyle="\n…\n">' + 'word ' * 100 + '</span>', 20,
-                '<span>marker</span>'),
+                    '<span\nstyle="\n…\n">' + 'word ' * 100 + '</span>', 20,
+                    '<span>marker</span>'),
             '<span\nstyle="\n…\n">' + 'word ' * 20 + '<span>marker</span></span>')
         self.assertEqual(
             utils.truncate_html_words('<br>' + 'word ' * 100, 20,
-                '<span>marker</span>'),
+                                      '<span>marker</span>'),
             '<br>' + 'word ' * 20 + '<span>marker</span>')
         self.assertEqual(
             utils.truncate_html_words('<!-- comment -->' + 'word ' * 100, 20,
-                '<span>marker</span>'),
+                                      '<span>marker</span>'),
             '<!-- comment -->' + 'word ' * 20 + '<span>marker</span>')
 
         # Words with HTML tags and a Jinja2 generated end marker (Markup)
         self.assertEqual(
             utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20,
-                Markup('<span>marker</span>')),
+                                      Markup('<span>marker</span>')),
             '<p>' + 'word ' * 20 + '<span>marker</span></p>')
 
         # Words with hypens and apostrophes.

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -255,12 +255,6 @@ class TestUtils(LoggedTestCase):
                                       '<span>marker</span>'),
             '<!-- comment -->' + 'word ' * 20 + '<span>marker</span>')
 
-        # Words with HTML tags and a Jinja2 generated end marker (Markup)
-        self.assertEqual(
-            utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20,
-                                      Markup('<span>marker</span>')),
-            '<p>' + 'word ' * 20 + '<span>marker</span></p>')
-
         # Words with hypens and apostrophes.
         self.assertEqual(
             utils.truncate_html_words("a-b " * 100, 20),

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -6,8 +6,6 @@ import time
 from sys import platform
 from tempfile import mkdtemp
 
-from markupsafe import Markup
-
 import pytz
 
 from pelican import utils

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -8,6 +8,8 @@ from tempfile import mkdtemp
 
 import pytz
 
+from markupsafe import Markup
+
 from pelican import utils
 from pelican.generators import TemplatePagesGenerator
 from pelican.readers import Readers
@@ -232,6 +234,32 @@ class TestUtils(LoggedTestCase):
         self.assertEqual(
             utils.truncate_html_words('<!-- comment -->' + 'word ' * 100, 20),
             '<!-- comment -->' + 'word ' * 20 + '…')
+
+        # Words enclosed or intervaled by HTML tags with a custom end
+        # marker containing HTML tags.
+        self.assertEqual(
+            utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20,
+                '<span>marker</span>'),
+            '<p>' + 'word ' * 20 + '<span>marker</span></p>')
+        self.assertEqual(
+            utils.truncate_html_words(
+                '<span\nstyle="\n…\n">' + 'word ' * 100 + '</span>', 20,
+                '<span>marker</span>'),
+            '<span\nstyle="\n…\n">' + 'word ' * 20 + '<span>marker</span></span>')
+        self.assertEqual(
+            utils.truncate_html_words('<br>' + 'word ' * 100, 20,
+                '<span>marker</span>'),
+            '<br>' + 'word ' * 20 + '<span>marker</span>')
+        self.assertEqual(
+            utils.truncate_html_words('<!-- comment -->' + 'word ' * 100, 20,
+                '<span>marker</span>'),
+            '<!-- comment -->' + 'word ' * 20 + '<span>marker</span>')
+
+        # Words with HTML tags and a Jinja2 generated end marker (Markup)
+        self.assertEqual(
+            utils.truncate_html_words('<p>' + 'word ' * 100 + '</p>', 20,
+                Markup('<span>marker</span>')),
+            '<p>' + 'word ' * 20 + '<span>marker</span></p>')
 
         # Words with hypens and apostrophes.
         self.assertEqual(

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -580,6 +580,9 @@ def truncate_html_words(s, num, end_text='…'):
         return s
     out = s[:truncator.truncate_at]
     if end_text:
+        # check if the passed terminator was Jinja2 generated (i.e. Markup)
+        if isinstance(end_text, Markup):
+            end_text = end_text.unescape()
         out += ' ' + end_text
     # Close any tags still open
     for tag in truncator.open_tags:

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -580,9 +580,6 @@ def truncate_html_words(s, num, end_text='…'):
         return s
     out = s[:truncator.truncate_at]
     if end_text:
-        # check if the passed terminator was Jinja2 generated (i.e. Markup)
-        if isinstance(end_text, Markup):
-            end_text = end_text.unescape()
         out += ' ' + end_text
     # Close any tags still open
     for tag in truncator.open_tags:


### PR DESCRIPTION
Added support for Jinja2 generated end marker when the passed variable
is an instance of Markup.  This makes the function compatible with
Jinja2's environments where autoescape is enabled.

# Pull Request Checklist

Resolves: #2917 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
