### PR TITLE
Update docs with example on injecting articles

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add additional documention on how to add new articles programatically.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -301,6 +301,43 @@ Here is a basic example of how to set up your own writer::
         signals.get_writer.connect(add_writer)
 
 
+Modifying Generators to Inject Content
+---------------------------------------
+
+You can programatically inject articles or pages using plugins. This can be 
+useful if you plan to fetch articles from an API, for example. 
+
+Here is a very simple example of how we can build a plugin that injects
+custom articles, using the article `article_generator_pretaxonomy` signal::
+
+    from pelican import signals
+    from pelican.contents import Article
+    from pelican.readers import BaseReader
+    import datetime
+
+    def addArticle(articleGenerator):
+        settings = articleGenerator.settings
+
+        # Author, category, and tags are objects, not strings, so they need to
+        # be handled using BaseReader's process_metadata.
+        baseReader = BaseReader(settings) 
+
+        content = "I am the body of an injected article!"
+
+        newArticle = Article(content, {
+            "title": "Injected Article!",
+            "date": datetime.datetime.now(),
+            "category": baseReader.process_metadata('category', 'fromAPI'),
+            "tags": baseReader.process_metadata("tags", 'tagA, tagB')
+        })
+
+        articleGenerator.articles.insert(0, newArticle)
+
+    def register():
+        signals.article_generator_pretaxonomy.connect(addArticle)
+
+
+
 .. _Pip: https://pip.pypa.io/
 .. _pelican-plugins bug #314: https://github.com/getpelican/pelican-plugins/issues/314
 .. _Blinker: https://pythonhosted.org/blinker/

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -301,14 +301,14 @@ Here is a basic example of how to set up your own writer::
         signals.get_writer.connect(add_writer)
 
 
-Modifying Generators to Inject Content
+Using Plugins to Inject Content
 ---------------------------------------
 
 You can programatically inject articles or pages using plugins. This can be 
 useful if you plan to fetch articles from an API, for example. 
 
-Here is a very simple example of how we can build a plugin that injects
-custom articles, using the article `article_generator_pretaxonomy` signal::
+Here is a very simple example of how we can build a plugin that injects a
+custom article, using the article `article_generator_pretaxonomy` signal::
 
     from pelican import signals
     from pelican.contents import Article
@@ -327,8 +327,8 @@ custom articles, using the article `article_generator_pretaxonomy` signal::
         newArticle = Article(content, {
             "title": "Injected Article!",
             "date": datetime.datetime.now(),
-            "category": baseReader.process_metadata('category', 'fromAPI'),
-            "tags": baseReader.process_metadata("tags", 'tagA, tagB')
+            "category": baseReader.process_metadata("category", "fromAPI"),
+            "tags": baseReader.process_metadata("tags", "tagA, tagB")
         })
 
         articleGenerator.articles.insert(0, newArticle)


### PR DESCRIPTION
Updated the plugin documentation to add a recipe for adding articles programmatically when pelican is running.

I struggled to understand how to dynamically add content to Pelican (for example, if I wanted to fetch content via an API rather than from Markdown). Once I got it working, I wanted to update the docs so it was a bit easier for the next person. Hopefully this is the preferred way to inject dynamic content (as far as I can tell - this seems like it would be the correct signal). 

# Pull Request Checklist

N/A - updating documentation only - no code changes. 