### PR TITLE
Use rich logging for Pelican server

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -476,6 +476,10 @@ def autoreload(args, excqueue=None):
 
 
 def listen(server, port, output, excqueue=None):
+    # set logging level to at least "INFO" (so we can see the server requests)
+    if logger.level < logging.INFO:
+        logger.setLevel(logging.INFO)
+
     RootedHTTPServer.allow_reuse_address = True
     try:
         httpd = RootedHTTPServer(

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -487,8 +487,8 @@ def listen(server, port, output, excqueue=None):
         return
 
     try:
-        print("\nServing site at: http://{}:{} - Tap CTRL-C to stop".format(
-            server, port))
+        console.print("Serving site at: http://{}:{} - Tap CTRL-C to stop".format(
+                      server, port))
         httpd.serve_forever()
     except Exception as e:
         if excqueue is not None:

--- a/pelican/server.py
+++ b/pelican/server.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     magic_from_file = None
 
+from pelican.log import console  # noqa: F401
 from pelican.log import init as init_logging
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,9 @@ class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
             mimetype = magic_from_file(path, mime=True)
 
         return mimetype
+
+    def log_message(self, format, *args):
+        logger.info(format, *args)
 
 
 class RootedHTTPServer(server.HTTPServer):


### PR DESCRIPTION
Further to #2897, this enables *rich* logging for `pelican.server.

![image](https://user-images.githubusercontent.com/1548809/135697236-b6d496d7-6d9b-47a0-9977-6a0e075cffa0.png)

Surprisingly (at least to me), all that was needed was to import `console` from `pelican.log`.

Note this is working for `python -m pelican.server`, but doesn't seem to work on `pelican -l`. The latter seems to be drawing its logging from elsewhere.

P.S. If this could be marked "hacktoberfest-accepted" (so it counts towards my Hacktoberfest Pull Requests), that would be appreciated!
