### PR TITLE
Server: actually return MIME type

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -91,7 +91,9 @@ class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
     def guess_type(self, path):
         """Guess at the mime type for the specified file.
         """
-        mimetype = server.SimpleHTTPRequestHandler.guess_type(self, path)
+        # strip trailing slash
+        path = path.rstrip().strip("/").strip(os.sep)
+        mimetype = super().guess_type(path)
 
         # If the default guess is too generic, try the python-magic library
         if mimetype == 'application/octet-stream' and magic_from_file:

--- a/pelican/server.py
+++ b/pelican/server.py
@@ -92,7 +92,7 @@ class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
         """Guess at the mime type for the specified file.
         """
         # strip trailing slash
-        path = path.rstrip().strip("/").strip(os.sep)
+        path = path.rstrip().rstrip("/").rstrip(os.sep)
         mimetype = super().guess_type(path)
 
         # If the default guess is too generic, try the python-magic library


### PR DESCRIPTION
The original paths being provided had a tailing slash, and so everything was returning as "application/octet-stream" (at least on Windows)

# Pull Request Checklist

Resolves: #2880 

Refer to that issue for the discussion.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ n/a ] Added **tests** for changed code
- [ n/a ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

**P.S.** If this could be marked "hacktoberfest-accepted" (so it counts towards my Hacktoberfest Pull Requests), that would be appreciated!
