### PR TITLE
Add MIME types for web fonts

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -43,6 +43,21 @@ def parse_arguments():
 class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
     SUFFIXES = ['.html', '/index.html', '/', '']
 
+    extensions_map = _encodings_map_default = {
+        # included in Python default implementation
+        '.gz': 'application/gzip',
+        '.Z': 'application/octet-stream',
+        '.bz2': 'application/x-bzip2',
+        '.xz': 'application/x-xz',
+
+        # web fonts
+        ".oft": "font/oft",
+        ".sfnt": "font/sfnt",
+        ".ttf": "font/ttf",
+        ".woff": "font/woff",
+        ".woff2": "font/woff2",
+    }
+
     def translate_path(self, path):
         # abandon query parameters
         path = path.split('?', 1)[0]

--- a/pelican/server.py
+++ b/pelican/server.py
@@ -43,19 +43,16 @@ def parse_arguments():
 class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
     SUFFIXES = ['.html', '/index.html', '/', '']
 
-    extensions_map = _encodings_map_default = {
-        # included in Python default implementation
-        '.gz': 'application/gzip',
-        '.Z': 'application/octet-stream',
-        '.bz2': 'application/x-bzip2',
-        '.xz': 'application/x-xz',
-
-        # web fonts
-        ".oft": "font/oft",
-        ".sfnt": "font/sfnt",
-        ".ttf": "font/ttf",
-        ".woff": "font/woff",
-        ".woff2": "font/woff2",
+    extensions_map = {
+        **server.SimpleHTTPRequestHandler.extensions_map,
+        ** {
+            # web fonts
+            ".oft": "font/oft",
+            ".sfnt": "font/sfnt",
+            ".ttf": "font/ttf",
+            ".woff": "font/woff",
+            ".woff2": "font/woff2",
+        },
     }
 
     def translate_path(self, path):


### PR DESCRIPTION
Building on #2928, it seems Python doesn't recognize/return the proper MIME-type for webfonts. Firefox does seems to work fine either way (as opposed to CSS...), but this seemed simple and proper to fix.

Before:

![](https://user-images.githubusercontent.com/1548809/135722972-0c80df24-001b-4b30-a9fa-4676c5032c69.png)

After:

![image](https://user-images.githubusercontent.com/1548809/135723423-5bb867ea-f6ba-4135-bd48-47e945fce5ab.png)


# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ n/a ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

**P.S.** If this could be marked "hacktoberfest-accepted" (so it counts towards my Hacktoberfest Pull Requests), that would be appreciated!
