### PR TITLE
`Pelican --listen`  directory fix

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -43,6 +43,8 @@ class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
     SUFFIXES = ['.html', '/index.html', '/', '']
 
     def translate_path(self, path):
+        """Translate a /-separated PATH to the local filename syntax."""
+
         # abandon query parameters
         path = path.split('?', 1)[0]
         path = path.split('#', 1)[0]
@@ -52,15 +54,20 @@ class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
         path = posixpath.normpath(path)
         words = path.split('/')
         words = filter(None, words)
-        path = self.base_path
+
+        return_path = self.directory
+        # actually care about the defined output directory
+        if self.base_path:
+            return_path = os.path.join(return_path, self.base_path)
+
         for word in words:
             if os.path.dirname(word) or word in (os.curdir, os.pardir):
                 # Ignore components that are not a simple file/directory name
                 continue
-            path = os.path.join(path, word)
+            return_path = os.path.join(return_path, word)
         if trailing_slash:
-            path += '/'
-        return path
+            return_path += os.sep
+        return return_path
 
     def do_GET(self):
         # cut off a query string


### PR DESCRIPTION
When trying to fix some issues with `pelican --listen`, I couldn't get it to work. It turns out it was trying to serve from the project root directly, rather than the output directory.

It now serves the output directory, although it still needs to be invoked from the project's root (i.e. the folder that holds your `pelicanconf.py` file).

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
