### PR TITLE
Adjust suffix in server to allow redirection when needed

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -75,10 +75,15 @@ class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
 
     def get_path_that_exists(self, original_path):
         # Try to strip trailing slash
+        trailing_slash = original_path.endswith('/')
         original_path = original_path.rstrip('/')
         # Try to detect file by applying various suffixes
         tries = []
         for suffix in self.SUFFIXES:
+            if not trailing_slash and suffix == '/':
+                # if original request does not have trailing slash, skip the '/' suffix
+                # so that base class can redirect if needed
+                continue
             path = original_path + suffix
             if os.path.exists(self.translate_path(path)):
                 return path

--- a/pelican/tests/test_server.py
+++ b/pelican/tests/test_server.py
@@ -43,14 +43,18 @@ class TestServer(unittest.TestCase):
         os.mkdir(os.path.join(self.temp_output, 'baz'))
 
         for suffix in ['', '/']:
+            # foo.html has precedence over foo/index.html
             path = handler.get_path_that_exists('foo' + suffix)
             self.assertEqual(path, 'foo.html')
 
+            # folder with index.html should return folder/index.html
             path = handler.get_path_that_exists('bar' + suffix)
             self.assertEqual(path, 'bar/index.html')
 
+            # folder without index.html should return same as input
             path = handler.get_path_that_exists('baz' + suffix)
-            self.assertEqual(path, 'baz/')
+            self.assertEqual(path, 'baz' + suffix)
 
+            # not existing path should return None
             path = handler.get_path_that_exists('quux' + suffix)
             self.assertIsNone(path)


### PR DESCRIPTION
Folders without index.html has to be redirected (`/foo` -> `/foo/`) for
directory listing to work properly. Skip '/' suffix if original path
does not have it so that base class can return a redirect.

# Pull Request Checklist

Resolves: #2841 <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- N/A Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
