### PR TITLE
Remove shebang lines from generated pelicanconf.py and publishconf.py

### DIFF
--- a/pelican/tools/templates/pelicanconf.py.jinja2
+++ b/pelican/tools/templates/pelicanconf.py.jinja2
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- #
-
 AUTHOR = {{author}}
 SITENAME = {{sitename}}
 SITEURL = ''

--- a/pelican/tools/templates/publishconf.py.jinja2
+++ b/pelican/tools/templates/publishconf.py.jinja2
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*- #
-
 # This file is only used if you use `make publish` or
 # explicitly specify it as your config file.
 


### PR DESCRIPTION
These configuration files don't need a #! line as they are not executed directly and not marked as executable. (In practise this doesn't cause any problems - it just came up in a Guix bug report because Guix transforms the #! lines.)

The "coding: utf-8" lines are also no longer required now that Pelican is Python 3 only.