### PR TITLE
Distribute sample data used to run tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.rst
 recursive-include pelican *.html *.css *png *.rst *.markdown *.md *.mkd *.xml *.py *.jinja2
-recursive-include samples *
 include LICENSE THANKS docs/changelog.rst pyproject.toml
+graft samples
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
Pelican distributes the unit tests, but doesn't distribute the sample data such as `samples/pelican.conf.py` required to run them.

I noticed this when updating the OS package for Guix which is based on the PyPI distribution of pelican.