### PR TITLE
Use `git --no-pager` rather than override all environment variables

### DIFF
--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -56,9 +56,8 @@ class TestPelican(LoggedTestCase):
 
     def assertDirsEqual(self, left_path, right_path):
         out, err = subprocess.Popen(
-            ['git', 'diff', '--no-ext-diff', '--exit-code',
+            ['git', '--no-pager', 'diff', '--no-ext-diff', '--exit-code',
              '-w', left_path, right_path],
-            env={'PAGER': ''},
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         ).communicate()


### PR DESCRIPTION
Currently the `assertDirsEqual` test utility uses `subprocess.Popen`'s `env` argument to make git run non-interactively. Unfortunately this overwrites *all* environment variables causing test failures on Guix. The `--no-pager` option is a more targeted way to achieve the same thing.
