### PR TITLE
Fix parsing of settings passed to `--extra-settings`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix incorrect parsing of parameters specified via `-e` / `--extra-settings` option flags (#2938).

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -9,11 +9,12 @@ line::
 If you used the ``pelican-quickstart`` command, your primary settings file will
 be named ``pelicanconf.py`` by default.
 
-You can also specify extra settings via ``-e`` / ``--extra-settings`` option
-flags, which will override default settings as well as any defined within
-settings files::
+You can also specify settings via ``-e`` / ``--extra-settings`` option
+flags. It will override default settings as well as any defined within the
+setting file. Note that values must follow JSON notation::
 
-    pelican content -e DELETE_OUTPUT_DIRECTORY=true
+    pelican content -e SITENAME='"A site"' READERS='{"html": null}' CACHE_CONTENT=true
+
 
 .. note::
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -1,7 +1,6 @@
 import copy
 import importlib.util
 import inspect
-import json
 import locale
 import logging
 import os
@@ -659,25 +658,3 @@ def configure_settings(settings):
             continue            # setting not specified, nothing to do
 
     return settings
-
-
-def coerce_overrides(overrides):
-    if overrides is None:
-        return {}
-    coerced = {}
-    types_to_cast = {int, str, bool}
-    for k, v in overrides.items():
-        if k not in DEFAULT_CONFIG:
-            logger.warning('Override for unknown setting %s, ignoring', k)
-            continue
-        setting_type = type(DEFAULT_CONFIG[k])
-        if setting_type not in types_to_cast:
-            coerced[k] = json.loads(v)
-        else:
-            try:
-                coerced[k] = setting_type(v)
-            except ValueError:
-                logger.debug('ValueError for %s override with %s, try to '
-                             'load as json', k, v)
-                coerced[k] = json.loads(v)
-    return coerced

--- a/pelican/tests/test_cli.py
+++ b/pelican/tests/test_cli.py
@@ -1,0 +1,72 @@
+import unittest
+
+from pelican import get_config, parse_arguments
+
+
+class TestParseOverrides(unittest.TestCase):
+    def test_flags(self):
+        for flag in ['-e', '--extra-settings']:
+            args = parse_arguments([flag, 'k=1'])
+            self.assertDictEqual(args.overrides, {'k': 1})
+
+    def test_parse_multiple_items(self):
+        args = parse_arguments('-e k1=1 k2=2'.split())
+        self.assertDictEqual(args.overrides, {'k1': 1, 'k2': 2})
+
+    def test_parse_valid_json(self):
+        json_values_python_values_map = {
+            '""': '',
+            'null': None,
+            '"string"': 'string',
+            '["foo", 12, "4", {}]': ['foo', 12, '4', {}]
+        }
+        for k, v in json_values_python_values_map.items():
+            args = parse_arguments(['-e', 'k=' + k])
+            self.assertDictEqual(args.overrides, {'k': v})
+
+    def test_parse_invalid_syntax(self):
+        invalid_items = ['k= 1', 'k =1', 'k', 'k v']
+        for item in invalid_items:
+            with self.assertRaises(ValueError):
+                parse_arguments(f'-e {item}'.split())
+
+    def test_parse_invalid_json(self):
+        invalid_json = {
+            '', 'False', 'True', 'None', 'some other string',
+            '{"foo": bar}', '[foo]'
+        }
+        for v in invalid_json:
+            with self.assertRaises(ValueError):
+                parse_arguments(['-e ', 'k=' + v])
+
+
+class TestGetConfigFromArgs(unittest.TestCase):
+    def test_overrides_known_keys(self):
+        args = parse_arguments([
+            '-e',
+            'DELETE_OUTPUT_DIRECTORY=false',
+            'OUTPUT_RETENTION=["1.txt"]',
+            'SITENAME="Title"'
+        ])
+        config = get_config(args)
+        config_must_contain = {
+            'DELETE_OUTPUT_DIRECTORY': False,
+            'OUTPUT_RETENTION': ['1.txt'],
+            'SITENAME': 'Title'
+        }
+        self.assertDictEqual(config, {**config, **config_must_contain})
+
+    def test_overrides_non_default_type(self):
+        args = parse_arguments([
+            '-e',
+            'DISPLAY_PAGES_ON_MENU=123',
+            'PAGE_TRANSLATION_ID=null',
+            'TRANSLATION_FEED_RSS_URL="someurl"'
+        ])
+        config = get_config(args)
+        config_must_contain = {
+            'DISPLAY_PAGES_ON_MENU': 123,
+            'PAGE_TRANSLATION_ID': None,
+            'TRANSLATION_FEED_RSS_URL': 'someurl'
+        }
+        self.assertDictEqual(config, {**config, **config_must_contain})

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -7,7 +7,7 @@ from sys import platform
 
 from pelican.settings import (DEFAULT_CONFIG, DEFAULT_THEME,
                               _printf_s_to_format_field,
-                              coerce_overrides, configure_settings,
+                              configure_settings,
                               handle_deprecated_settings, read_settings)
 from pelican.tests.support import unittest
 
@@ -304,18 +304,3 @@ class TestSettingsConfiguration(unittest.TestCase):
                          [(r'C\+\+', 'cpp')] +
                          self.settings['SLUG_REGEX_SUBSTITUTIONS'])
         self.assertNotIn('SLUG_SUBSTITUTIONS', settings)
-
-    def test_coerce_overrides(self):
-        overrides = coerce_overrides({
-            'ARTICLE_EXCLUDES': '["testexcl"]',
-            'READERS': '{"foo": "bar"}',
-            'STATIC_EXCLUDE_SOURCES': 'true',
-            'THEME_STATIC_DIR': 'theme',
-            })
-        expected = {
-            'ARTICLE_EXCLUDES': ["testexcl"],
-            'READERS': {"foo": "bar"},
-            'STATIC_EXCLUDE_SOURCES': True,
-            'THEME_STATIC_DIR': 'theme',
-        }
-        self.assertDictEqual(overrides, expected)


### PR DESCRIPTION
# Pull Request Checklist

Resolves: #2938

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

It's a proper fix of #2938. The first proposed PR #2939 is only a partial solution.

Now `-e` / `--extra-settings` expect `KEY=VALUE` pairs where VALUE must always be in JSON notation. Harsh, but it should at least work correctly.

A side effect: I removed the `coerce_overrides()` function that warned when unknown setting are overridden. No more such warnings. I think it makes more sense to warn about unknown settings no matter how they are specified (flags or the settings file), and so it's better to be addressed in a separate issue.
