### PR TITLE
Extend docstring of slugify util

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -230,6 +230,9 @@ def slugify(value, regex_subs=(), preserve_case=False, use_unicode=False):
     and converts spaces to hyphens.
 
     Took from Django sources.
+
+    For a set of sensible default regex substitutions to pass to regex_subs
+    look into pelican.settings.DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS'].
     """
 
     import unicodedata


### PR DESCRIPTION
We want to hint at the location of our default set of substitutions.
This should allow easier reuse for plugin authors who need to access
this utility as well.

Closes #2845

# Pull Request Checklist

Resolves: #2845
