### PR TITLE
Use docutils.Node.findall instead of traverse

### DIFF
--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -222,7 +222,14 @@ class RstReader(BaseReader):
                 'Ensure exactly one top level section',
                 source_path)
 
-        for docinfo in document.traverse(docutils.nodes.docinfo):
+        try:
+            # docutils 0.18.1+
+            nodes = document.findall(docutils.nodes.docinfo)
+        except AttributeError:
+            # docutils 0.18.0 or before
+            nodes = document.traverse(docutils.nodes.docinfo)
+
+        for docinfo in nodes:
             for element in docinfo.children:
                 if element.tagname == 'field':  # custom fields (e.g. summary)
                     name_elem, body_elem = element.children


### PR DESCRIPTION
`docutils.Node.traverse` is being deprecated as of `docutils==0.18.1`.

... and causing test errors.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
