### PR TITLE
Fix Paginator Page _from_settings() exception when INDEX_URL is ""

### DIFF
--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -155,7 +155,7 @@ class Page:
         # changed to lstrip() because that would remove all leading slashes and
         # thus make the workaround impossible. See
         # test_custom_pagination_pattern() for a verification of this.
-        if ret[0] == '/':
+        if ret.startswith('/'):
             ret = ret[1:]
         return ret
 


### PR DESCRIPTION
Check whether 'ret' starts with a slash, even when it's empty "".

ret can be an empty string -- such as when INDEX_URL is set to "" -- so the current code which checks ret[0] triggers an exception in that situation, "IndexError: string index out of range."

My INDEX_URL, INDEX_SAVE_AS are as follows:

INDEX_URL, INDEX_SAVE_AS = ("", "index.html")

My PAGINATION_PATTERNS are as follows:

PAGINATION_PATTERNS = (
    (1, '{url}', '{base_name}/index.html'),
    (2, '{url}/p{number}/',  '{base_name}/page/{number}/index.html'),
)

This is my first Pull Request on Github, so please forgive me if I do it wrong.

(I did try running the tests on a fresh clone of Pelican using "invoke tests", but many of the tests don't seem to be working. Should they?)