### PR TITLE
Simple theme fixes

### DIFF
--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -22,7 +22,6 @@
 {% endblock %}
 
 {% block content %}
-<section id="content" class="body">
   <header>
     <h1 class="entry-title">
       <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
@@ -60,8 +59,7 @@
     </div>
     {% endif %}
   </footer><!-- /.post-info -->
-  <div class="entry-content">
+  <article>
     {{ article.content }}
-  </div><!-- /.entry-content -->
-</section>
+  </article>
 {% endblock %}

--- a/pelican/themes/simple/templates/article.html
+++ b/pelican/themes/simple/templates/article.html
@@ -24,9 +24,9 @@
 {% block content %}
 <section id="content" class="body">
   <header>
-    <h2 class="entry-title">
+    <h1 class="entry-title">
       <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark"
-         title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h2>
+         title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></h1>
  {% import 'translations.html' as translations with context %}
  {{ translations.translations_for(article) }}
   </header>

--- a/pelican/themes/simple/templates/author.html
+++ b/pelican/themes/simple/templates/author.html
@@ -3,6 +3,6 @@
 {% block title %}{{ SITENAME }} - Articles by {{ author }}{% endblock %}
 
 {% block content_title %}
-<h2>Articles by {{ author }}</h2>
+<h1>Articles by {{ author }}</h1>
 {% endblock %}
 

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -33,11 +33,11 @@
         {% endblock head %}
 </head>
 
-<body id="index" class="home">
-        <header id="banner" class="body">
+<body>
+        <header>
                 <h1><a href="{{ SITEURL }}/">{{ SITENAME }}{% if SITESUBTITLE %} <strong>{{ SITESUBTITLE }}</strong>{% endif %}</a></h1>
-        </header><!-- /#banner -->
-        <nav id="menu"><ul>
+        </header>
+        <nav><ul>
         {% for title, link in MENUITEMS %}
             <li><a href="{{ link }}">{{ title }}</a></li>
         {% endfor %}
@@ -51,16 +51,16 @@
             <li{% if cat == category %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ cat.url }}">{{ cat }}</a></li>
           {% endfor %}
         {% endif %}
-        </ul></nav><!-- /#menu -->
+        </ul></nav>
         <main>
         {% block content %}
         {% endblock %}
         </main>
-        <footer id="contentinfo" class="body">
+        <footer>
                 <address id="about" class="vcard body">
                 Proudly powered by <a href="https://getpelican.com/">Pelican</a>,
                 which takes great advantage of <a href="https://www.python.org/">Python</a>.
                 </address><!-- /#about -->
-        </footer><!-- /#contentinfo -->
+        </footer>
 </body>
 </html>

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -51,8 +51,10 @@
           {% endfor %}
         {% endif %}
         </ul></nav><!-- /#menu -->
+        <main>
         {% block content %}
         {% endblock %}
+        </main>
         <footer id="contentinfo" class="body">
                 <address id="about" class="vcard body">
                 Proudly powered by <a href="https://getpelican.com/">Pelican</a>,

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -5,6 +5,7 @@
         <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         {% if FEED_ALL_ATOM %}
         <link href="{{ FEED_DOMAIN }}/{% if FEED_ALL_ATOM_URL %}{{ FEED_ALL_ATOM_URL }}{% else %}{{ FEED_ALL_ATOM }}{% endif %}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
         {% endif %}

--- a/pelican/themes/simple/templates/category.html
+++ b/pelican/themes/simple/templates/category.html
@@ -3,6 +3,6 @@
 {% block title %}{{ SITENAME }} - {{ category }} category{% endblock %}
 
 {% block content_title %}
-<h2>Articles in the {{ category }} category</h2>
+<h1>Articles in the {{ category }} category</h1>
 {% endblock %}
 

--- a/pelican/themes/simple/templates/tag.html
+++ b/pelican/themes/simple/templates/tag.html
@@ -3,5 +3,5 @@
 {% block title %}{{ SITENAME }} - {{ tag }} tag{% endblock %}
 
 {% block content_title %}
-<h2>Articles tagged with {{ tag }}</h2>
+<h1>Articles tagged with {{ tag }}</h1>
 {% endblock %}


### PR DESCRIPTION
A set of changes for the `simple` theme to be mobile-friendly and to use `h1` consistently throughout the template files. Please check individual commit messages for more info.