### PR TITLE
Content expansion

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -337,7 +337,7 @@ class Content:
         intrasite_link_regex = self.settings['INTRASITE_LINK_REGEX']
         regex = r"""
             (?P<markup><[^\>]+  # match tag with all url-value attributes
-                (?:href|src|poster|data|cite|formaction|action)\s*=\s*)
+                (?:href|src|poster|data|cite|formaction|action|content)\s*=\s*)
 
             (?P<quote>["\'])      # require value to be quoted
             (?P<path>{}(?P<value>.*?))  # the url value

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -522,6 +522,16 @@ class TestPage(TestBase):
             '<img src="http://static.cool.site/images/poster.jpg"/>'
         )
 
+        # Image link will go to static
+        args['content'] = (
+            '<meta content="{static}/images/poster.jpg"/>'
+        )
+        content = Page(**args).get_content('http://cool.site')
+        self.assertEqual(
+            content,
+            '<meta content="http://static.cool.site/images/poster.jpg"/>'
+        )
+
     def test_intrasite_link_escape(self):
         article = type(
             '_DummyArticle', (object,), {'url': 'article-spaces.html'})


### PR DESCRIPTION
Suggesting addition of `content` tag for links, which will help with things like twitter social cards. Let me know if this PR doesnt meet standards or if this feature is not needed. Very appreciate the work you all do with pelican


https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image
