### PR TITLE
Fix and update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         name: Flake8 on commit diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -11,6 +11,9 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
       - id: flake8
         name: Flake8 on commit diff
         description: This hook limits Flake8 checks to changed lines of code.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix and update pre-commit hooks

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: patch
-
-Fix and update pre-commit hooks


### PR DESCRIPTION
flake8 is no longer in the pre-commit repo, and now has its own repository
I also ran `pre-commit autoupdate` which failed before to update all hooks to the latest version.
# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code
---
Most of those are not really applicable in my case...
