### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -30,7 +30,7 @@ For Apache::
     ErrorDocument 404 /404.html
 
 For Amazon S3, first navigate to the ``Static Site Hosting`` menu in the bucket
-settings on your AWS cosole. From there::
+settings on your AWS console. From there::
 
     Error Document: 404.html
 

--- a/pelican/tests/__init__.py
+++ b/pelican/tests/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 from pelican.log import log_warnings
 
-# redirect warnings modulole to use logging instead
+# redirect warnings module to use logging instead
 log_warnings()
 
 # setup warnings to log DeprecationWarning's and error on


### PR DESCRIPTION
There are small typos in:
- docs/tips.rst
- pelican/tests/__init__.py

Fixes:
- Should read `module` rather than `modulole`.
- Should read `console` rather than `cosole`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md