### PR TITLE
Docs: Hidden posts also excluded from author index

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -626,7 +626,7 @@ Hidden Posts
 
 Like pages, posts can also be marked as ``hidden`` with the ``Status: hidden``
 attribute. Hidden posts will be output to ``ARTICLE_SAVE_AS`` as expected, but
-are not included by default in tag, category and author indexes, nor in the 
+are not included by default in tag, category, and author indexes, nor in the 
 main article feed. This has the effect of creating an "unlisted" post.
 
 .. _W3C ISO 8601: https://www.w3.org/TR/NOTE-datetime

--- a/docs/content.rst
+++ b/docs/content.rst
@@ -626,8 +626,8 @@ Hidden Posts
 
 Like pages, posts can also be marked as ``hidden`` with the ``Status: hidden``
 attribute. Hidden posts will be output to ``ARTICLE_SAVE_AS`` as expected, but
-are not included by default in tag or category indexes, nor in the main
-article feed. This has the effect of creating an "unlisted" post.
+are not included by default in tag, category and author indexes, nor in the 
+main article feed. This has the effect of creating an "unlisted" post.
 
 .. _W3C ISO 8601: https://www.w3.org/TR/NOTE-datetime
 .. _AsciiDoc: https://www.methods.co.nz/asciidoc/


### PR DESCRIPTION
### 1. Summary

I added, that `Status: hidden` exclude posts from `author` indexing too.

### 2. Argumentation

Specifying `tag` and `category`, but not specifying `author`, may confuse users. It’s not clear from the documentation what effect `Status: hidden` has on `author`. In my opinion, the documentation should give complete and clear information about the software product.

Thanks.
