### PR TITLE
Use tmp dir for test output

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -20,6 +20,14 @@ from pelican.writers import Writer
 class TestUtils(LoggedTestCase):
     _new_attribute = 'new_value'
 
+    def setUp(self):
+        super().setUp()
+        self.temp_output = mkdtemp(prefix='pelicantests.')
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.temp_output)
+
     @utils.deprecated_attribute(
         old='_old_attribute', new='_new_attribute',
         since=(3, 1, 0), remove=(4, 1, 3))
@@ -468,7 +476,7 @@ class TestUtils(LoggedTestCase):
 
     def test_clean_output_dir(self):
         retention = ()
-        test_directory = os.path.join(os.path.dirname(__file__),
+        test_directory = os.path.join(self.temp_output,
                                       'clean_output')
         content = os.path.join(os.path.dirname(__file__), 'content')
         shutil.copytree(content, test_directory)
@@ -479,14 +487,14 @@ class TestUtils(LoggedTestCase):
 
     def test_clean_output_dir_not_there(self):
         retention = ()
-        test_directory = os.path.join(os.path.dirname(__file__),
+        test_directory = os.path.join(self.temp_output,
                                       'does_not_exist')
         utils.clean_output_dir(test_directory, retention)
         self.assertFalse(os.path.exists(test_directory))
 
     def test_clean_output_dir_is_file(self):
         retention = ()
-        test_directory = os.path.join(os.path.dirname(__file__),
+        test_directory = os.path.join(self.temp_output,
                                       'this_is_a_file')
         f = open(test_directory, 'w')
         f.write('')


### PR DESCRIPTION
On some filesystems, the `shutil.rmtree` call in `TestUtils.test_clean_output_dir` would fail while removing the `pelican/tests/clean_output` directory if an application with a filewatcher had the pelican project open.

Using `tempfile.mkdtmp` for test directories circumvents this.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
