### PR TITLE
Test content generation with git diff return value

### DIFF
--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -218,6 +218,23 @@ class LogCountHandler(BufferingHandler):
         ])
 
 
+def diff_subproc(first, second):
+    """
+    Return a subprocess that runs a diff on the two paths.
+
+    Check results with::
+
+        >>> out_stream, err_stream = proc.communicate()
+        >>> didCheckFail = proc.returnCode != 0
+    """
+    return subprocess.Popen(
+        ['git', '--no-pager', 'diff', '--no-ext-diff', '--exit-code',
+         '-w', first, second],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+
 class LoggedTestCase(unittest.TestCase):
     """A test case that captures log messages."""
 

--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -231,7 +231,8 @@ def diff_subproc(first, second):
         ['git', '--no-pager', 'diff', '--no-ext-diff', '--exit-code',
          '-w', first, second],
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
+        text=True,
     )
 
 

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -15,7 +15,8 @@ from pelican.tests.support import (
     LoggedTestCase,
     diff_subproc,
     locale_available,
-    mute
+    mute,
+    skipIfNoExecutable,
 )
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -69,7 +70,8 @@ class TestPelican(LoggedTestCase):
         if proc.returncode != 0:
             msg = self._formatMessage(
                 msg,
-                "%s and %s differ:\n%s" % (left_path, right_path, err)
+                "%s and %s differ:\nstdout:\n%s\nstderr\n%s" %
+                (left_path, right_path, out, err)
             )
             raise self.failureException(msg)
 
@@ -88,6 +90,7 @@ class TestPelican(LoggedTestCase):
             generator_classes, Sequence,
             "_get_generator_classes() must return a Sequence to preserve order")
 
+    @skipIfNoExecutable(['git', '--version'])
     def test_basic_generation_works(self):
         # when running pelican without settings, it should pick up the default
         # ones and generate correct output without raising any exception
@@ -107,6 +110,7 @@ class TestPelican(LoggedTestCase):
             msg="Unable to find.*skipping url replacement",
             level=logging.WARNING)
 
+    @skipIfNoExecutable(['git', '--version'])
     def test_custom_generation_works(self):
         # the same thing with a specified set of settings should work
         settings = read_settings(path=SAMPLE_CONFIG, override={
@@ -121,6 +125,7 @@ class TestPelican(LoggedTestCase):
             self.temp_path, os.path.join(OUTPUT_PATH, 'custom')
         )
 
+    @skipIfNoExecutable(['git', '--version'])
     @unittest.skipUnless(locale_available('fr_FR.UTF-8') or
                          locale_available('French'), 'French locale needed')
     def test_custom_locale_generation_works(self):


### PR DESCRIPTION
Rather than trying to parse output of subprocess, just check the return value.

Fix #3042

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
