### PR TITLE
GitHub actions update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,13 +29,13 @@ jobs:
             python: "3.7"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.config.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.python }}
       - name: Set up Pip cache (Linux)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Set up Pip cache (macOS)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: startsWith(runner.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
@@ -51,7 +51,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
       - name: Setup pip cache (Windows)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: startsWith(runner.os, 'Windows')
         with:
           path: ~\AppData\Local\pip\Cache
@@ -62,7 +62,7 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         run: sudo locale-gen fr_FR.UTF-8 tr_TR.UTF-8
       - name: Install pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: "2.9.2"
       - name: Install tox
@@ -82,13 +82,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Set pip cache (Linux)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
@@ -106,13 +106,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Set pip cache (Linux)
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pip
@@ -132,9 +132,9 @@ jobs:
     if: ${{ github.ref=='refs/heads/master' && github.event_name!='pull_request' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Check release
@@ -144,9 +144,10 @@ jobs:
           pip install poetry
           pip install githubrelease
           pip install --pre autopub
-          echo "##[set-output name=release;]$(autopub check)"
+          autopub check
+        continue-on-error: true
       - name: Publish
-        if: ${{ steps.check_release.outputs.release=='' }}
+        if: steps.check_release.outcome=='success'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.9"
       - name: Set pip cache (Linux)
         uses: actions/cache@v3
         if: startsWith(runner.os, 'Linux')
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.9"
       - name: Set pip cache (Linux)
         uses: actions/cache@v3
         if: startsWith(runner.os, 'Linux')
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.9"
       - name: Check release
         id: check_release
         run: |

--- a/requirements/style.pip
+++ b/requirements/style.pip
@@ -1,2 +1,2 @@
-flake8<4.0
+flake8
 flake8-import-order

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ max-line-length = 88
 
 [testenv:flake8]
 basepython = python3.9
+skip_install = true
 deps =
     -rrequirements/style.pip
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     pytest -s --cov=pelican pelican
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.9
 deps =
     -rrequirements/docs.pip
 changedir = docs
@@ -36,7 +36,7 @@ import-order-style = cryptography
 max-line-length = 88
 
 [testenv:flake8]
-basepython = python3.7
+basepython = python3.9
 deps =
     -rrequirements/style.pip
 commands =


### PR DESCRIPTION
* GitHub is [deprecating](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) `node12` actions in favor of `node16`, so updated the actions with the latest versions. There is only `pandoc` installer still on `node12` and throws warnings but that should be resolved soon within `@v2`.
* `set-output` is also [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), but they added a proper check for step results in the [context](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context), so that ended up simplifying deploy logic (yay!).
* I don't know what happened but there is a weird dependency hell going on with `flake8` and `importlib-metadata`. However, this only affects `python<3.8` (`flake8` uses built-in for later versions), I upgraded the `Lint` job python to 3.9. I think we can unpin `flake8` version but I couldn't remember why it was pinned so I left it alone.
* While I was at it, I also moved the `Build docs` and `Deploy` pythons to 3.9 as well, since 3.7 started to become ancient-ish and will be EOLed in less than a year.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
