### PR TITLE
Use `(?P=)` to replace `\2` for intrasite link

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -341,7 +341,7 @@ class Content:
 
             (?P<quote>["\'])      # require value to be quoted
             (?P<path>{}(?P<value>.*?))  # the url value
-            \2""".format(intrasite_link_regex)
+            (?P=quote)""".format(intrasite_link_regex)
         return re.compile(regex, re.X)
 
     def _update_content(self, content, siteurl):


### PR DESCRIPTION
# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

# Description

This PR converts a normal (Perl-style?) regex to refer back to a matching group `\2` to the Python-specific extended form `(?P=quote)`.
This PR does this change because this whole regex already uses Python-specific extensions, so it is natural to make them consistent, and it is easier to read as well (of course, requiring understanding the syntax).

(I just recently learned this syntax. I can be totally wrong on understanding the intention.)