### PR TITLE
Add Python 3.11 to CI and Tox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
             python: "3.9"
           - os: ubuntu
             python: "3.10"
+          - os: ubuntu
+            python: "3.11"
           - os: macos
             python: "3.7"
           - os: windows
@@ -34,30 +36,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.python }}
-      - name: Set up Pip cache (Linux)
-        uses: actions/cache@v3
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Set up Pip cache (macOS)
-        uses: actions/cache@v3
-        if: startsWith(runner.os, 'macOS')
-        with:
-          path: ~/Library/Caches/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Setup pip cache (Windows)
-        uses: actions/cache@v3
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: '**/requirements/*'
       - name: Install locale (Linux)
         if: startsWith(runner.os, 'Linux')
         run: sudo locale-gen fr_FR.UTF-8 tr_TR.UTF-8
@@ -87,14 +67,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Set pip cache (Linux)
-        uses: actions/cache@v3
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: '**/requirements/*'
       - name: Install tox
         run: python -m pip install -U pip tox
       - name: Check
@@ -111,14 +85,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Set pip cache (Linux)
-        uses: actions/cache@v3
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: '**/requirements/*'
       - name: Install tox
         run: python -m pip install -U pip tox
       - name: Check

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -2,7 +2,6 @@ import copy
 import locale
 import os
 from os.path import abspath, dirname, join
-from sys import platform
 
 
 from pelican.settings import (DEFAULT_CONFIG, DEFAULT_THEME,
@@ -136,18 +135,19 @@ class TestSettingsConfiguration(unittest.TestCase):
             settings['ARTICLE_DIR']
             settings['PAGE_DIR']
 
-    # locale.getdefaultlocale() is broken on Windows
-    # See: https://bugs.python.org/issue37945
-    @unittest.skipIf(platform == 'win32', "Doesn't work on Windows")
     def test_default_encoding(self):
-        # Test that the default locale is set if not specified in settings
+        # Test that the user locale is set if not specified in settings
 
-        # Reset locale to Python's default locale
         locale.setlocale(locale.LC_ALL, 'C')
-        self.assertEqual(self.settings['LOCALE'], DEFAULT_CONFIG['LOCALE'])
+        # empty string = user system locale
+        self.assertEqual(self.settings['LOCALE'], [''])
 
         configure_settings(self.settings)
-        self.assertEqual(locale.getlocale(), locale.getdefaultlocale())
+        lc_time = locale.getlocale(locale.LC_TIME)  # should be set to user locale
+
+        # explicitly set locale to user pref and test
+        locale.setlocale(locale.LC_TIME, '')
+        self.assertEqual(lc_time, locale.getlocale(locale.LC_TIME))
 
     def test_invalid_settings_throw_exception(self):
         # Test that the path name is valid

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.7,3.8,3.9,3.10},docs,flake8
+envlist = py{3.7,3.8,3.9,3.10,3.11},docs,flake8
 
 [testenv]
 basepython =
@@ -7,6 +7,7 @@ basepython =
     py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
+    py3.11: python3.11
 passenv = *
 usedevelop=True
 deps =


### PR DESCRIPTION
* adds python 3.11 to CI and tox
* `setup-python` action added `pip` cache functionality with considerably less configuration. changed the workflow to use that.
* updates one failing test that was using `locale.getdefaultlocale()` which is deprecated in 3.11. on the plus side, new test should work on windows and no need to skip

<hr>
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
