### PR TITLE
Change reference to Python version 3.6 from documentation (now 3.7)

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,7 +8,7 @@ Installation
 ------------
 
 Install Pelican (and optionally Markdown if you intend to use it) on Python
-3.6+ by running the following command in your preferred terminal, prefixing
+3.7+ by running the following command in your preferred terminal, prefixing
 with ``sudo`` if permissions warrant::
 
     python -m pip install "pelican[markdown]"


### PR DESCRIPTION
#3021 forgot to do it in `docs/quickstart.rst`.