### PR TITLE
Don't copy file file ownership, permissions and metadata

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -300,7 +300,7 @@ def copy(source, destination, ignores=None):
             logger.info('Creating directory %s', dst_dir)
             os.makedirs(dst_dir)
         logger.info('Copying %s to %s', source_, destination_)
-        copy_file_metadata(source_, destination_)
+        copy_file(source_, destination_)
 
     elif os.path.isdir(source_):
         if not os.path.exists(destination_):
@@ -330,20 +330,17 @@ def copy(source, destination, ignores=None):
                 dst_path = os.path.join(dst_dir, o)
                 if os.path.isfile(src_path):
                     logger.info('Copying %s to %s', src_path, dst_path)
-                    copy_file_metadata(src_path, dst_path)
+                    copy_file(src_path, dst_path)
                 else:
                     logger.warning('Skipped copy %s (not a file or '
                                    'directory) to %s',
                                    src_path, dst_path)
 
 
-def copy_file_metadata(source, destination):
-    '''Copy a file and its metadata (perm bits, access times, ...)'''
-
-    # This function is a workaround for Android python copystat
-    # bug ([issue28141]) https://bugs.python.org/issue28141
+def copy_file(source, destination):
+    '''Copy a file'''
     try:
-        shutil.copy2(source, destination)
+        shutil.copyfile(source, destination)
     except OSError as e:
         logger.warning("A problem occurred copying file %s to %s; %s",
                        source, destination, e)


### PR DESCRIPTION
When building the default template with pelican installed through a distro package manager, the copied files are usually owned by root and likely have 644 or 444 set which aborts the build. Ownership and permissions should be based on the destination directory and umask, not on the referenced files.

# Pull Request Checklist

Resolves: #1463

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
