### PR TITLE
Use default configuration while importing

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -15,7 +15,7 @@ from urllib.request import urlretrieve
 
 # because logging.setLoggerClass has to be called before logging.getLogger
 from pelican.log import init
-from pelican.settings import read_settings
+from pelican.settings import DEFAULT_CONFIG
 from pelican.utils import SafeDatetime, slugify
 
 
@@ -285,8 +285,7 @@ def dc2fields(file):
 
     print("%i posts read." % len(posts))
 
-    settings = read_settings()
-    subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+    subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
     for post in posts:
         fields = post.split('","')
 
@@ -404,8 +403,7 @@ def posterous2fields(api_token, email, password):
 
     page = 1
     posts = get_posterous_posts(api_token, email, password, page)
-    settings = read_settings()
-    subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+    subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
     while len(posts) > 0:
         posts = get_posterous_posts(api_token, email, password, page)
         page += 1
@@ -446,8 +444,7 @@ def tumblr2fields(api_key, blogname):
 
     offset = 0
     posts = get_tumblr_posts(api_key, blogname, offset)
-    settings = read_settings()
-    subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+    subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
     while len(posts) > 0:
         for post in posts:
             title = \
@@ -531,8 +528,7 @@ def feed2fields(file):
     """Read a feed and yield pelican fields"""
     import feedparser
     d = feedparser.parse(file)
-    settings = read_settings()
-    subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+    subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
     for entry in d.entries:
         date = (time.strftime('%Y-%m-%d %H:%M', entry.updated_parsed)
                 if hasattr(entry, 'updated_parsed') else None)
@@ -778,8 +774,7 @@ def fields2pelican(
     pandoc_version = get_pandoc_version()
     posts_require_pandoc = []
 
-    settings = read_settings()
-    slug_subs = settings['SLUG_REGEX_SUBSTITUTIONS']
+    slug_subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
 
     for (title, content, filename, date, author, categories, tags, status,
             kind, in_markup) in fields:


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

Before this commit:

```
$ pelican-import --wpfile -o ./content/ WordPress.xml -m markdown --wp-attach
[12:30:53] WARNING  Feeds generated without SITEURL set properly may not be valid                                                                                                                                                                                      log.py:91
           WARNING  No timezone information specified in the settings. Assuming your timezone is UTC for feed generation. Check https://docs.getpelican.com/en/latest/settings.html#TIMEZONE for more information 
...
```
This is because the code calls read_settings() but no configuration file is provided.

After this commit:
 
No more warning.
