### PR TITLE
Don't specify unlimited feed size by default

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -998,10 +998,10 @@ the ``TAG_FEED_ATOM`` and ``TAG_FEED_RSS`` settings:
    placeholder. If not set, ``TAG_FEED_RSS`` is used both for save location and
    URL.
 
-.. data:: FEED_MAX_ITEMS
+.. data:: FEED_MAX_ITEMS = 100
 
-   Maximum number of items allowed in a feed. Feed item quantity is
-   unrestricted by default.
+   Maximum number of items allowed in a feed. Setting to ``None`` will cause the
+   feed to contains every article. 100 if not specified.
 
 .. data:: RSS_FEED_SUMMARY_ONLY = True
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -40,7 +40,7 @@ DEFAULT_CONFIG = {
     'AUTHOR_FEED_ATOM': 'feeds/{slug}.atom.xml',
     'AUTHOR_FEED_RSS': 'feeds/{slug}.rss.xml',
     'TRANSLATION_FEED_ATOM': 'feeds/all-{lang}.atom.xml',
-    'FEED_MAX_ITEMS': '',
+    'FEED_MAX_ITEMS': 100,
     'RSS_FEED_SUMMARY_ONLY': True,
     'SITEURL': '',
     'SITENAME': 'A Pelican Blog',

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -143,11 +143,9 @@ class Writer:
 
         feed = self._create_new_feed(feed_type, feed_title, context)
 
-        max_items = len(elements)
-        if self.settings['FEED_MAX_ITEMS']:
-            max_items = min(self.settings['FEED_MAX_ITEMS'], max_items)
-        for i in range(max_items):
-            self._add_item_to_the_feed(feed, elements[i])
+        # FEED_MAX_ITEMS = None means [:None] to get every element
+        for element in elements[:self.settings['FEED_MAX_ITEMS']]:
+            self._add_item_to_the_feed(feed, element)
 
         signals.feed_generated.send(context, feed=feed)
         if path:


### PR DESCRIPTION
When not set, the RSS feed contains every article. For site with many articles, this makes a very long feed that can be painful to process.
Having a feed with hundreds of articles, is rarely expected and is probably not the best value.

Set a high fallback value of 100 so it does not change for small sites.

Still allow to have infinite feed by setting `FEED_MAX_ITEM = False`

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [x] Updated **documentation** for changed code
