### PR TITLE
Fix typo in pelican-themes.rst

### DIFF
--- a/docs/pelican-themes.rst
+++ b/docs/pelican-themes.rst
@@ -62,7 +62,7 @@ or ``--list`` option:
 In this example, we can see there are three themes available: ``notmyidea``,
 ``simple``, and ``two-column``.
 
-``two-column`` is prefixed with an ``@`` because this theme is not copied to
+``two-column`` is followed by an ``@`` because this theme is not copied to
 the Pelican theme path, but is instead just linked to it (see `Creating
 symbolic links`_ for details about creating symbolic links).
 


### PR DESCRIPTION
The least change would be to just say "suffixed", but I don't think that's a correct english word, so I choose "followed by"

# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
