### PR TITLE
Allow to cap the pagination

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1038,6 +1038,11 @@ You can use the following settings to configure the pagination.
    The maximum number of articles to include on a page, not including orphans.
    False to disable pagination.
 
+.. data:: MAX_PAGINATION = False
+
+   The maximum number of pages generated. ``False`` to paginate all available
+   pages.
+
 .. data:: PAGINATED_TEMPLATES = {'index': None, 'tag': None, 'category': None, 'author': None}
 
    The templates to use pagination with, and the number of articles to include

--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -47,6 +47,8 @@ class Paginator:
         if self._num_pages is None:
             hits = max(1, self.count - self.orphans)
             self._num_pages = int(ceil(hits / (float(self.per_page) or 1)))
+        if self.settings["MAX_PAGINATION"]:
+            self._num_pages = min(self.settings["MAX_PAGINATION"], self._num_pages)
         return self._num_pages
     num_pages = property(_get_num_pages)
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -90,6 +90,7 @@ DEFAULT_CONFIG = {
         (1, '{name}{extension}', '{name}{extension}'),
         (2, '{name}{number}{extension}', '{name}{number}{extension}'),
     ],
+    'MAX_PAGINATION': False,
     'YEAR_ARCHIVE_URL': '',
     'YEAR_ARCHIVE_SAVE_AS': '',
     'MONTH_ARCHIVE_URL': '',

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -102,3 +102,21 @@ class TestPage(unittest.TestCase):
         page3 = paginator.page(3)
         self.assertEqual(page3.save_as, 'blog/index.html')
         self.assertEqual(page3.url, '//blog.my.site/')
+
+    def test_max_pagination(self):
+        from pelican.paginator import PaginationRule
+        settings = get_settings()
+        settings['MAX_PAGINATION'] = 2
+        settings['PAGINATION_PATTERNS'] = [PaginationRule(*r) for r in [
+            (1, '/{url}{number}/', '{base_name}/{number}/index.html')
+        ]]
+
+        self.page_kwargs['metadata']['author'] = Author('Blogger', settings)
+        object_list = [Article(**self.page_kwargs),
+                       Article(**self.page_kwargs),
+                       Article(**self.page_kwargs)]
+        paginator = Paginator('blog/index.html', '//blog.my.site/',
+                              object_list, settings, 1)
+        self.assertEqual(paginator.count, 3)
+        self.assertEqual(paginator.per_page, 1)
+        self.assertEqual(paginator.num_pages, 2)


### PR DESCRIPTION
This way one could only generate one page of content by using `MAX_PAGINATION = 1`

My request is similar to what was tried at #2548.
On [my site](https://mart-e.be/ ) I have an index page with 10 articles and then, a `/archives` listing *all* articles without any pagination. I still want to use 10 for `DEFAULT_PAGINATION` but stop after the first page. As [mentioned by avaris](https://github.com/getpelican/pelican/pull/2548#issuecomment-490971787), the easiest is to have a new parameter.

An alternative could be to have a boolean value like `PAGINATE = False` to disable the iteration but it gets a bit confusing when mixing with `DEFAULT_PAGINATION`...

## Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
