### PR TITLE
Replace `pytz` dependency in tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,0 @@
-Release type: patch
-
-External dependency `pytz` has already been removed from the main code, but this PR also
-removes it from the tests.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+External dependency `pytz` has already been removed from the main code, but this PR also
+removes it from the tests.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,7 +64,6 @@ automatically installed without any action on your part:
 * `pygments <https://pypi.org/project/Pygments/>`_, for syntax highlighting
 * `docutils <https://pypi.org/project/docutils/>`_, for supporting
   reStructuredText as an input format
-* `pytz <https://pypi.org/project/pytz/>`_, for timezone definitions
 * `blinker <https://pypi.org/project/blinker/>`_, an object-to-object and
   broadcast signaling system
 * `unidecode <https://pypi.org/project/Unidecode/>`_, for ASCII

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -9,9 +9,9 @@ from html import unescape
 from urllib.parse import unquote, urljoin, urlparse, urlunparse
 
 try:
-    import zoneinfo
+    from zoneinfo import ZoneInfo
 except ModuleNotFoundError:
-    from backports import zoneinfo
+    from backports.zoneinfo import ZoneInfo
 
 
 from pelican.plugins import signals
@@ -127,7 +127,7 @@ class Content:
         # manage timezone
         default_timezone = settings.get("TIMEZONE", "UTC")
         timezone = getattr(self, "timezone", default_timezone)
-        self.timezone = zoneinfo.ZoneInfo(timezone)
+        self.timezone = ZoneInfo(timezone)
 
         if hasattr(self, 'date'):
             self.date = set_date_tzinfo(self.date, timezone)

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -3,10 +3,14 @@ import logging
 import os
 import shutil
 import time
+from datetime import timezone
 from sys import platform
 from tempfile import mkdtemp
 
-import pytz
+try:
+    from zoneinfo import ZoneInfo
+except ModuleNotFoundError:
+    from backports.zoneinfo import ZoneInfo
 
 from pelican import utils
 from pelican.generators import TemplatePagesGenerator
@@ -50,21 +54,21 @@ class TestUtils(LoggedTestCase):
             year=2012, month=11, day=22, hour=22, minute=11)
         date_hour_z = utils.SafeDatetime(
             year=2012, month=11, day=22, hour=22, minute=11,
-            tzinfo=pytz.timezone('UTC'))
+            tzinfo=timezone.utc)
         date_hour_est = utils.SafeDatetime(
             year=2012, month=11, day=22, hour=22, minute=11,
-            tzinfo=pytz.timezone('EST'))
+            tzinfo=ZoneInfo("EST"))
         date_hour_sec = utils.SafeDatetime(
             year=2012, month=11, day=22, hour=22, minute=11, second=10)
         date_hour_sec_z = utils.SafeDatetime(
             year=2012, month=11, day=22, hour=22, minute=11, second=10,
-            tzinfo=pytz.timezone('UTC'))
+            tzinfo=timezone.utc)
         date_hour_sec_est = utils.SafeDatetime(
             year=2012, month=11, day=22, hour=22, minute=11, second=10,
-            tzinfo=pytz.timezone('EST'))
+            tzinfo=ZoneInfo("EST"))
         date_hour_sec_frac_z = utils.SafeDatetime(
             year=2012, month=11, day=22, hour=22, minute=11, second=10,
-            microsecond=123000, tzinfo=pytz.timezone('UTC'))
+            microsecond=123000, tzinfo=timezone.utc)
         dates = {
             '2012-11-22': date,
             '2012/11/22': date,
@@ -86,13 +90,13 @@ class TestUtils(LoggedTestCase):
         iso_8601_date = utils.SafeDatetime(year=1997, month=7, day=16)
         iso_8601_date_hour_tz = utils.SafeDatetime(
             year=1997, month=7, day=16, hour=19, minute=20,
-            tzinfo=pytz.timezone('CET'))
+            tzinfo=ZoneInfo("Europe/London"))
         iso_8601_date_hour_sec_tz = utils.SafeDatetime(
             year=1997, month=7, day=16, hour=19, minute=20, second=30,
-            tzinfo=pytz.timezone('CET'))
+            tzinfo=ZoneInfo("Europe/London"))
         iso_8601_date_hour_sec_ms_tz = utils.SafeDatetime(
             year=1997, month=7, day=16, hour=19, minute=20, second=30,
-            microsecond=450000, tzinfo=pytz.timezone('CET'))
+            microsecond=450000, tzinfo=ZoneInfo("Europe/London"))
         iso_8601 = {
             '1997-07-16': iso_8601_date,
             '1997-07-16T19:20+01:00': iso_8601_date_hour_tz,

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -19,9 +19,9 @@ from operator import attrgetter
 import dateutil.parser
 
 try:
-    import zoneinfo
+    from zoneinfo import ZoneInfo
 except ModuleNotFoundError:
-    from backports import zoneinfo
+    from backports.zoneinfo import ZoneInfo
 from markupsafe import Markup
 
 
@@ -921,7 +921,7 @@ class FileSystemWatcher:
 def set_date_tzinfo(d, tz_name=None):
     """Set the timezone for dates that don't have tzinfo"""
     if tz_name and not d.tzinfo:
-        timezone = zoneinfo.ZoneInfo(tz_name)
+        timezone = ZoneInfo(tz_name)
         d = d.replace(tzinfo=timezone)
         return SafeDatetime(
             d.year, d.month, d.day, d.hour, d.minute, d.second, d.microsecond, d.tzinfo


### PR DESCRIPTION
# Pull Request Checklist

Resolves: #2958 (something like a further resolution because it now includes a resolution within the tests) <!-- Only if related issue *already* exists — otherwise remove this line -->

External dependency `pytz` has already been removed from the main code, but this PR also removes it from the tests.
Why have I changed the test timezone from CET to Europe/London? The tests were written with the [W3 examples](http://www.w3.org/TR/NOTE-datetime) in mind, but not accounting for the summertime offset. As such, they originally assumed that datetime(year=1997, month=7, day=16, hour=19, minute=20, tzinfo=ZoneInfo("CET")) would evaluate to 1997-07-16T19:20+01:00. But it doesn't; in summertime (July), CET is actually +02:00 and an example of a +01:00 timezone would be "Europe/London". With the shift to the built in ZoneInfo module, the test therefore needs to be adapted.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [X] Ensured **tests pass** and (if applicable) updated functional test output
- [X] Conformed to **code style guidelines** by running appropriate linting tools
- [X] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->