### PR TITLE
Fix orphaned embedded video links from Tumblr. Fix #3177

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add exception to deal with broken embedded video links when importing from Tumblr.

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -499,8 +499,11 @@ def tumblr2fields(api_key, blogname):
                     fmtstr = '<p><a href="%s">via</a></p>\n'
                 source = fmtstr % post.get('source_url')
                 caption = post.get('caption')
-                players = '\n'.join(player.get('embed_code')
-                                    for player in post.get('player'))
+                try:
+                    players = '\n'.join(player.get('embed_code')
+                                        for player in post.get('player'))
+                except TypeError:
+                    players = '\n'
                 content = source + caption + players
             elif type == 'answer':
                 title = post.get('question')


### PR DESCRIPTION
Where a Tumblr video links to an orphaned video (eg https://www.tumblr.com/boxydog/148936576299/two-opposite-personalities-one-driven-to-big), `pelican-import` crashes as it tries to define a `players` variable from a "player" record in Tumblr's JSON API output which doesn't exist.

# Pull Request Checklist

Resolves: #3177 <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [X] Ensured **tests pass** and (if applicable) updated functional test output
- [X] Conformed to **code style guidelines** by running appropriate linting tools
- [X] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
