### PR TITLE
Remove Posterous integration

### DIFF
--- a/docs/importer.rst
+++ b/docs/importer.rst
@@ -11,7 +11,6 @@ software to reStructuredText or Markdown. The supported import formats are:
 
 - Blogger XML export
 - Dotclear export
-- Posterous API
 - Tumblr API
 - WordPress XML export
 - RSS/Atom feed
@@ -48,16 +47,15 @@ Usage
 
 ::
 
-    pelican-import [-h] [--blogger] [--dotclear] [--posterous] [--tumblr] [--wpfile] [--feed]
+    pelican-import [-h] [--blogger] [--dotclear] [--tumblr] [--wpfile] [--feed]
                    [-o OUTPUT] [-m MARKUP] [--dir-cat] [--dir-page] [--strip-raw] [--wp-custpost]
-                   [--wp-attach] [--disable-slugs] [-e EMAIL] [-p PASSWORD] [-b BLOGNAME]
-                   input|api_token|api_key
+                   [--wp-attach] [--disable-slugs] [-b BLOGNAME]
+                   input|api_key
 
 Positional arguments
 --------------------
   =============         ============================================================================
   ``input``             The input file to read
-  ``api_token``         (Posterous only) api_token can be obtained from http://posterous.com/api/
   ``api_key``           (Tumblr only) api_key can be obtained from https://www.tumblr.com/oauth/apps
   =============         ============================================================================
 
@@ -67,7 +65,6 @@ Optional arguments
   -h, --help            Show this help message and exit
   --blogger             Blogger XML export (default: False)
   --dotclear            Dotclear export (default: False)
-  --posterous           Posterous API (default: False)
   --tumblr              Tumblr API (default: False)
   --wpfile              WordPress XML export (default: False)
   --feed                Feed to parse (default: False)
@@ -101,10 +98,6 @@ Optional arguments
                         output. With this disabled, your Pelican URLs may not
                         be consistent with your original posts. (default:
                         False)
-  -e EMAIL, --email=EMAIL
-                        Email used to authenticate Posterous API
-  -p PASSWORD, --password=PASSWORD
-                        Password used to authenticate Posterous API
   -b BLOGNAME, --blogname=BLOGNAME
                         Blog name used in Tumblr API
 
@@ -120,13 +113,9 @@ For Dotclear::
 
     $ pelican-import --dotclear -o ~/output ~/backup.txt
 
-for Posterous::
-
-    $ pelican-import --posterous -o ~/output --email=<email_address> --password=<password> <api_token>
-
 For Tumblr::
 
-    $ pelican-import --tumblr -o ~/output --blogname=<blogname> <api_token>
+    $ pelican-import --tumblr -o ~/output --blogname=<blogname> <api_key>
 
 For WordPress::
 

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -383,51 +383,6 @@ def dc2fields(file):
                post_format)
 
 
-def posterous2fields(api_token, email, password):
-    """Imports posterous posts"""
-    import base64
-    from datetime import timedelta
-    import json
-    import urllib.request as urllib_request
-
-    def get_posterous_posts(api_token, email, password, page=1):
-        base64string = base64.encodestring(
-            ("{}:{}".format(email, password)).encode('utf-8')).replace('\n', '')
-        url = ("http://posterous.com/api/v2/users/me/sites/primary/"
-               "posts?api_token=%s&page=%d") % (api_token, page)
-        request = urllib_request.Request(url)
-        request.add_header('Authorization', 'Basic %s' % base64string.decode())
-        handle = urllib_request.urlopen(request)
-        posts = json.loads(handle.read().decode('utf-8'))
-        return posts
-
-    page = 1
-    posts = get_posterous_posts(api_token, email, password, page)
-    subs = DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS']
-    while len(posts) > 0:
-        posts = get_posterous_posts(api_token, email, password, page)
-        page += 1
-
-        for post in posts:
-            slug = post.get('slug')
-            if not slug:
-                slug = slugify(post.get('title'), regex_subs=subs)
-            tags = [tag.get('name') for tag in post.get('tags')]
-            raw_date = post.get('display_date')
-            date_object = SafeDatetime.strptime(
-                raw_date[:-6], '%Y/%m/%d %H:%M:%S')
-            offset = int(raw_date[-5:])
-            delta = timedelta(hours=(offset / 100))
-            date_object -= delta
-            date = date_object.strftime('%Y-%m-%d %H:%M')
-            kind = 'article'      # TODO: Recognise pages
-            status = 'published'  # TODO: Find a way for draft posts
-
-            yield (post.get('title'), post.get('body_cleaned'),
-                   slug, date, post.get('user').get('display_name'),
-                   [], tags, status, kind, 'html')
-
-
 def tumblr2fields(api_key, blogname):
     """ Imports Tumblr posts (API v2)"""
     import json
@@ -886,7 +841,7 @@ def fields2pelican(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Transform feed, Blogger, Dotclear, Posterous, Tumblr, or "
+        description="Transform feed, Blogger, Dotclear, Tumblr, or "
                     "WordPress files into reST (rst) or Markdown (md) files. "
                     "Be sure to have pandoc installed.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -899,9 +854,6 @@ def main():
     parser.add_argument(
         '--dotclear', action='store_true', dest='dotclear',
         help='Dotclear export')
-    parser.add_argument(
-        '--posterous', action='store_true', dest='posterous',
-        help='Posterous export')
     parser.add_argument(
         '--tumblr', action='store_true', dest='tumblr',
         help='Tumblr export')
@@ -953,12 +905,6 @@ def main():
              'With this disabled, your Pelican URLs may not be consistent '
              'with your original posts.')
     parser.add_argument(
-        '-e', '--email', dest='email',
-        help="Email address (posterous import only)")
-    parser.add_argument(
-        '-p', '--password', dest='password',
-        help="Password (posterous import only)")
-    parser.add_argument(
         '-b', '--blogname', dest='blogname',
         help="Blog name (Tumblr import only)")
 
@@ -969,8 +915,6 @@ def main():
         input_type = 'blogger'
     elif args.dotclear:
         input_type = 'dotclear'
-    elif args.posterous:
-        input_type = 'posterous'
     elif args.tumblr:
         input_type = 'tumblr'
     elif args.wpfile:
@@ -979,7 +923,7 @@ def main():
         input_type = 'feed'
     else:
         error = ('You must provide either --blogger, --dotclear, '
-                 '--posterous, --tumblr, --wpfile or --feed options')
+                 '--tumblr, --wpfile or --feed options')
         exit(error)
 
     if not os.path.exists(args.output):
@@ -998,8 +942,6 @@ def main():
         fields = blogger2fields(args.input)
     elif input_type == 'dotclear':
         fields = dc2fields(args.input)
-    elif input_type == 'posterous':
-        fields = posterous2fields(args.input, args.email, args.password)
     elif input_type == 'tumblr':
         fields = tumblr2fields(args.input, args.blogname)
     elif input_type == 'wordpress':


### PR DESCRIPTION
At first my intention was to replace the `base64.encodestring` by `base64.encodebytes` (the former has been removed in python 3.11) but I realised this code was actually not working.

This PR is a suggestion to fully remove the Posterous import.

Posterous closed down in 2013.
The API is no longer accessible and the code did not work in python 3 (`base64.encodestring` was expecting bytes, not string)



# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
