### PR TITLE
Only run 'Deploy' action on main repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     environment: Deployment
     needs: [test, lint, docs]
     runs-on: ubuntu-latest
-    if: github.ref=='refs/heads/master' && github.event_name!='pull_request'
+    if: github.ref=='refs/heads/master' && github.event_name!='pull_request' && github.repository == 'getpelican/pelican'
 
     permissions:
       contents: write


### PR DESCRIPTION
Deploy action will always fail on forks as the token is not there, this happens on the fork especially, when you are syncing with, main one. This will improve the setup for collaborators.
