### PR TITLE
Allow dataclasses in settings

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -5,6 +5,7 @@ import locale
 import logging
 import os
 import re
+import sys
 from os.path import isabs
 
 from pelican.log import LimitFilter
@@ -13,6 +14,7 @@ from pelican.log import LimitFilter
 def load_source(name, path):
     spec = importlib.util.spec_from_file_location(name, path)
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod
 


### PR DESCRIPTION
This allows using `dataclasses.dataclass` inside the settings to allow clean access for more complex data structures (in my case: a list of images configured through an external file which are iterated over inside the theme). Previously, this would fail with a strange AttributeError. Some more background on this is available in https://github.com/mkdocs/mkdocs/issues/3141 for example

# Pull Request Checklist

- [X] Ensured **tests pass** and (if applicable) updated functional test output
- [X] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [X] Updated **documentation** for changed code
