### PR TITLE
Add OpenGraph metadata to docs via Sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,9 +8,12 @@ sys.path.append(os.path.abspath(os.pardir))
 
 # -- General configuration ----------------------------------------------------
 templates_path = ['_templates']
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.ifconfig',
-              'sphinx.ext.extlinks']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.extlinks",
+    "sphinxext.opengraph",
+]
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'Pelican'

--- a/requirements/docs.pip
+++ b/requirements/docs.pip
@@ -1,3 +1,4 @@
 sphinx<6.0
+sphinxext-opengraph
 furo
 livereload


### PR DESCRIPTION
Uses the [`sphinxext-opengraph`](https://github.com/wpilibsuite/sphinxext-opengraph) Sphinx extension to generate OpenGraph metadata for Pelican's documentation.