### PR TITLE
Include more files in PDM `sdist` builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,14 @@ dev = [
     "tomli;python_version<'3.11'",
 ]
 
+[tool.pdm.build]
+source-includes = [
+    "CONTRIBUTING.rst",
+    "THANKS",
+    "docs/changelog.rst",
+    "samples/",
+]
+
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"


### PR DESCRIPTION
This was previously the job of directives in `MANIFEST.in`, which should be covered by this PDM-specific configuration.