### PR TITLE
Force git subprocess in tests to use utf-8

### DIFF
--- a/pelican/tests/support.py
+++ b/pelican/tests/support.py
@@ -232,7 +232,7 @@ def diff_subproc(first, second):
          '-w', first, second],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        encoding="utf-8",
     )
 
 


### PR DESCRIPTION
Setting `text=True` does not always yield correct encoding and can fail. Force subprocess to use `utf-8`, instead.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
