### PR TITLE
Add `tzdata` requirement on Windows

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+* Ensure ``tzdata`` dependency is installed on Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "unidecode>=1.3.7",
     "backports-zoneinfo>=0.2.1; python_version < \"3.9\"",
     "watchfiles>=0.21.0",
+    "tzdata; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -3,7 +3,6 @@ Pygments==2.14.0
 pytest
 pytest-cov
 pytest-xdist[psutil]
-tzdata
 
 # Optional Packages
 Markdown==3.5.1


### PR DESCRIPTION
Further to https://github.com/getpelican/pelican/pull/3161, `tzdata` is required on Windows, even when using a version of Python that includes `zoneinfo` in the standard library. This is because Windows doesn't ship with the "standard" timezone database; c.f. [PEP 615](https://peps.python.org/pep-0615/#sources-for-time-zone-data).

Without this, Pelican 4.9.0 will spit out a series of errors (one for each entry), like:

```
[10:53:22] ERROR    Could not process .\20121024-push-a-hg-repo-to-github.md                                   log.py:94
                    'No time zone found with key America/Edmonton'
```

and then finally has a fatal error:

```
           CRITICAL ZoneInfoNotFoundError: 'No time zone found with key UTC'                             __init__.py:666
```

I also note that `tzdata` is listed as a requirement for [testing](https://github.com/getpelican/pelican/blob/master/requirements/test.pip#L6); it may no longer be needed there.