### PR TITLE
Add GH pages action to fix file permissions

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -44,6 +44,11 @@ jobs:
             --settings "${{ inputs.settings }}" \
             --extra-settings SITEURL='"${{ steps.pages.outputs.base_url }}"' \
             --output "${{ inputs.output-path }}"
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "${{ inputs.output-path }}" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: patch
-
-Added Github pages action to fix files with invalid permissions in output file directory.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Added Github pages action to fix files with invalid permissions in output file directory.


### PR DESCRIPTION
# Pull Request Checklist

Resolves: #3244 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code (verified by building a test site and checking the GH pages workflow)
- [ ] Updated **documentation** for changed code (N/A)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->


Adds a Github action that fixes file permissions before uploading (such as cache files created by Pelican Webassets if the cache is not disabled). Raises a warning for each file without proper permissions.