### PR TITLE
fix: keep newline at the end of the file in tools

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Keep the newline at the end of the file in generating tools scripts

--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -44,6 +44,7 @@ _TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templ
 _jinja_env = Environment(
     loader=FileSystemLoader(_TEMPLATES_DIR),
     trim_blocks=True,
+    keep_trailing_newline=True,
 )
 
 


### PR DESCRIPTION
As referenced in Jinja documentation about whitespace control: <https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control>
>  To keep single trailing newlines, configure Jinja to
>  `keep_trailing_newline`
I added this to our Jinja environment to keep EOL new line in tools scripts

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code # NOT REQUIRED
- [x] Updated **documentation** for changed code # NOT REQUIRED

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
