### PR TITLE
Log the original calling location, rather than the wrapper function

### DIFF
--- a/pelican/log.py
+++ b/pelican/log.py
@@ -85,13 +85,15 @@ class FatalLogger(LimitLogger):
     warnings_fatal = False
     errors_fatal = False
 
+    # adding `stacklevel=2` means that the displayed filename and line number
+    # will match the "original" calling location, rather than the wrapper here
     def warning(self, *args, **kwargs):
-        super().warning(*args, **kwargs)
+        super().warning(*args, stacklevel=2, **kwargs)
         if FatalLogger.warnings_fatal:
             raise RuntimeError("Warning encountered")
 
     def error(self, *args, **kwargs):
-        super().error(*args, **kwargs)
+        super().error(*args, stacklevel=2, **kwargs)
         if FatalLogger.errors_fatal:
             raise RuntimeError("Error encountered")
 


### PR DESCRIPTION
I've noticed that when Pelican logs warnings and errors, the file number and line number are always the same. It turns out we wrap the calling of warnings and errors (but not other logging levels) to allow warnings to be fatal, etc, but it is thus reporting the location of that wrapper function, rather than the "true" caller.

This isn't as helpful as it could be when trying to understand what is going on under the covers.

This is a small patch that allows the logger to show the "true" caller.

Before:

```
[20:40:37] WARNING  [Seafoam] Development Mode is active. Image Process has been disabled.                     log.py:94
           WARNING  AUTHOR_URL is set to None                                                                  log.py:94
Done: Processed 4 articles, 0 drafts, 0 hidden articles, 0 pages, 0 hidden pages and 0 draft pages in 0.51 seconds.
```

After:

```
[20:51:24] WARNING  [Seafoam] Development Mode is active. Image Process has been disabled.              initialize.py:51
           WARNING  AUTHOR_URL is set to None                                                         urlwrappers.py:116
Done: Processed 4 articles, 0 drafts, 0 hidden articles, 0 pages, 0 hidden pages and 0 draft pages in 0.48 seconds.
```

The required feature was added in Python 3.8.
c.f. https://stackoverflow.com/a/55998744/4276230