### PR TITLE
fix: use relative urls when github publish enabled

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -496,6 +496,7 @@ This would save your articles into something like
    Defines whether Pelican should use document-relative URLs or not. Only set
    this to ``True`` when developing/testing and only if you fully understand
    the effect it can have on links/feeds. The default is ``False``.
+   This option is enabled by default if you use github pages.
 
 .. data:: ARTICLE_URL
 

--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -46,7 +46,12 @@ ifeq ($(DEBUG), 1)
 	PELICANOPTS += -D
 endif
 
+{% if github %}
+RELATIVE ?= 1
+{% else %}
 RELATIVE ?= 0
+{% endif %}
+
 ifeq ($(RELATIVE), 1)
 	PELICANOPTS += --relative-urls
 endif

--- a/pelican/tools/templates/publishconf.py.jinja2
+++ b/pelican/tools/templates/publishconf.py.jinja2
@@ -9,7 +9,12 @@ from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
 SITEURL = "{{siteurl}}"
+
+{{ if github }}
 RELATIVE_URLS = False
+{{ else }}
+RELATIVE_URLS = True
+{{ endif }}
 
 FEED_ALL_ATOM = "feeds/all.atom.xml"
 CATEGORY_FEED_ATOM = "feeds/{slug}.atom.xml"


### PR DESCRIPTION
# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

I noticed without using relative paths GitHub can't fetch static files. so I enabled it when github config is enabled.