### PR TITLE
Use `--no-jekyll` flag when invoking `ghp-import`

### DIFF
--- a/pelican/tools/templates/Makefile.jinja2
+++ b/pelican/tools/templates/Makefile.jinja2
@@ -161,7 +161,7 @@ cf_upload: publish
 {% if github %}
 {% set upload = upload + ["github"] %}
 github: publish
-	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) "$(OUTPUTDIR)"
+	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) "$(OUTPUTDIR)" --no-jekyll
 	git push origin $(GITHUB_PAGES_BRANCH)
 
 {% endif %}


### PR DESCRIPTION
It will include a .nojekyll file in the branch so GitHub won't run Jekyll-related actions