### PR TITLE
Better logging if writing a tag/category/author page fails

### DIFF
--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -586,9 +586,10 @@ class ArticlesGenerator(CachingGenerator):
                 )
             except RuntimeError:
                 if not tag.slug:
-                    logger.warning(
+                    logger.info(
                         'Tag "%s" has an invalid slug; skipping writing tag page...',
                         tag,
+                        extra={"limit_msg": "Further tags with invalid slugs."},
                     )
                     continue
                 else:
@@ -616,9 +617,10 @@ class ArticlesGenerator(CachingGenerator):
                 )
             except RuntimeError:
                 if not cat.slug:
-                    logger.warning(
+                    logger.info(
                         'Category "%s" has an invalid slug; skipping writing category page...',
                         cat,
+                        extra={"limit_msg": "Further categories with invalid slugs."},
                     )
                     continue
                 else:
@@ -646,9 +648,10 @@ class ArticlesGenerator(CachingGenerator):
                 )
             except RuntimeError:
                 if not aut.slug:
-                    logger.warning(
+                    logger.info(
                         'Author "%s" has an invalid slug; skipping writing author page...',
                         aut,
+                        extra={"limit_msg": "Further authors with invalid slugs."},
                     )
                     continue
                 else:

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -570,57 +570,69 @@ class ArticlesGenerator(CachingGenerator):
         tag_template = self.get_template("tag")
         for tag, articles in self.tags.items():
             dates = [article for article in self.dates if article in articles]
-            write(
-                tag.save_as,
-                tag_template,
-                self.context,
-                tag=tag,
-                url=tag.url,
-                articles=articles,
-                dates=dates,
-                template_name="tag",
-                blog=True,
-                page_name=tag.page_name,
-                all_articles=self.articles,
-            )
+            try:
+                write(
+                    tag.save_as,
+                    tag_template,
+                    self.context,
+                    tag=tag,
+                    url=tag.url,
+                    articles=articles,
+                    dates=dates,
+                    template_name="tag",
+                    blog=True,
+                    page_name=tag.page_name,
+                    all_articles=self.articles,
+                )
+            except RuntimeError as e:
+                logger.error('Trying to write Tag page for "%s".' % (tag))
+                raise e
 
     def generate_categories(self, write):
         """Generate category pages."""
         category_template = self.get_template("category")
         for cat, articles in self.categories:
             dates = [article for article in self.dates if article in articles]
-            write(
-                cat.save_as,
-                category_template,
-                self.context,
-                url=cat.url,
-                category=cat,
-                articles=articles,
-                dates=dates,
-                template_name="category",
-                blog=True,
-                page_name=cat.page_name,
-                all_articles=self.articles,
-            )
+            try:
+                write(
+                    cat.save_as,
+                    category_template,
+                    self.context,
+                    url=cat.url,
+                    category=cat,
+                    articles=articles,
+                    dates=dates,
+                    template_name="category",
+                    blog=True,
+                    page_name=cat.page_name,
+                    all_articles=self.articles,
+                )
+            except RuntimeError as e:
+                logger.error('Trying to write Category page for "%s".' % (cat))
+                raise e
 
     def generate_authors(self, write):
         """Generate Author pages."""
         author_template = self.get_template("author")
         for aut, articles in self.authors:
             dates = [article for article in self.dates if article in articles]
-            write(
-                aut.save_as,
-                author_template,
-                self.context,
-                url=aut.url,
-                author=aut,
-                articles=articles,
-                dates=dates,
-                template_name="author",
-                blog=True,
-                page_name=aut.page_name,
-                all_articles=self.articles,
-            )
+            try:
+                write(
+                    aut.save_as,
+                    author_template,
+                    self.context,
+                    url=aut.url,
+                    author=aut,
+                    articles=articles,
+                    dates=dates,
+                    template_name="author",
+                    blog=True,
+                    page_name=aut.page_name,
+                    all_articles=self.articles,
+                )
+            except RuntimeError as e:
+                logger.error('Trying to write Author page for "%s".' % (aut))
+                raise e
 
     def generate_drafts(self, write):
         """Generate drafts pages."""

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -584,9 +584,16 @@ class ArticlesGenerator(CachingGenerator):
                     page_name=tag.page_name,
                     all_articles=self.articles,
                 )
-            except RuntimeError as e:
-                logger.error('Trying to write Tag page for "%s".' % (tag))
-                raise e
+            except RuntimeError:
+                if not tag.slug:
+                    logger.warning(
+                        'Tag "%s" has an invalid slug; skipping writing tag page...',
+                        tag,
+                    )
+                    continue
+                else:
+                    logger.error('Failed to write Tag page for "%s".', tag)
+                    raise
 
     def generate_categories(self, write):
         """Generate category pages."""
@@ -607,9 +614,16 @@ class ArticlesGenerator(CachingGenerator):
                     page_name=cat.page_name,
                     all_articles=self.articles,
                 )
-            except RuntimeError as e:
-                logger.error('Trying to write Category page for "%s".' % (cat))
-                raise e
+            except RuntimeError:
+                if not cat.slug:
+                    logger.warning(
+                        'Category "%s" has an invalid slug; skipping writing category page...',
+                        cat,
+                    )
+                    continue
+                else:
+                    logger.error('Failed to write Category page for "%s".', cat)
+                    raise
 
     def generate_authors(self, write):
         """Generate Author pages."""
@@ -630,9 +644,16 @@ class ArticlesGenerator(CachingGenerator):
                     page_name=aut.page_name,
                     all_articles=self.articles,
                 )
-            except RuntimeError as e:
-                logger.error('Trying to write Author page for "%s".' % (aut))
-                raise e
+            except RuntimeError:
+                if not aut.slug:
+                    logger.warning(
+                        'Author "%s" has an invalid slug; skipping writing author page...',
+                        aut,
+                    )
+                    continue
+                else:
+                    logger.error('Failed to write Author page for "%s".', aut)
+                    raise
 
     def generate_drafts(self, write):
         """Generate drafts pages."""

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -30,6 +30,7 @@ from pelican.utils import (
     posixize_path,
     process_translations,
 )
+from pelican.writers import FileOverwriteFailedError
 
 logger = logging.getLogger(__name__)
 
@@ -584,7 +585,7 @@ class ArticlesGenerator(CachingGenerator):
                     page_name=tag.page_name,
                     all_articles=self.articles,
                 )
-            except RuntimeError:
+            except FileOverwriteFailedError:
                 if not tag.slug:
                     logger.info(
                         'Tag "%s" has an invalid slug; skipping writing tag page...',
@@ -615,7 +616,7 @@ class ArticlesGenerator(CachingGenerator):
                     page_name=cat.page_name,
                     all_articles=self.articles,
                 )
-            except RuntimeError:
+            except FileOverwriteFailedError:
                 if not cat.slug:
                     logger.info(
                         'Category "%s" has an invalid slug; skipping writing category page...',
@@ -646,7 +647,7 @@ class ArticlesGenerator(CachingGenerator):
                     page_name=aut.page_name,
                     all_articles=self.articles,
                 )
-            except RuntimeError:
+            except FileOverwriteFailedError:
                 if not aut.slug:
                     logger.info(
                         'Author "%s" has an invalid slug; skipping writing author page...',

--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -42,11 +42,18 @@ class URLWrapper:
                 preserve_case=preserve_case,
                 use_unicode=self.settings.get("SLUGIFY_USE_UNICODE", False),
             )
+            if not self._slug:
+                logger.warning(
+                    'Unable to generate valid slug for %s "%s".',
+                    self.__class__.__name__,
+                    self.name,
+                    extra={"limit_msg": "Other invalid slugs."},
+                )
         return self._slug
 
     @slug.setter
     def slug(self, slug):
-        # if slug is expliticly set, changing name won't alter slug
+        # if slug is explicitly set, changing name won't alter slug
         self._slug_from_name = False
         self._slug = slug
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -259,7 +259,7 @@ def slugify(
     Normalizes string, converts to lowercase, removes non-alpha characters,
     and converts spaces to hyphens.
 
-    Took from Django sources.
+    Taken from Django sources.
 
     For a set of sensible default regex substitutions to pass to regex_subs
     look into pelican.settings.DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS'].

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -112,15 +112,19 @@ class Writer:
         if filename in self._overridden_files:
             if override:
                 raise FileOverwriteFailedError(
-                    f"File {filename} is set to be overridden twice"
+                    f'Failed to overwrite "{filename}" a second time '
+                    "(was previously overwritten)"
                 )
-            logger.info("Skipping %s", filename)
+            logger.info('Skipping "%s", not overwriting', filename)
             filename = os.devnull
         elif filename in self._written_files:
             if override:
-                logger.info("Overwriting %s", filename)
+                logger.info('Overwriting "%s"', filename)
             else:
-                raise FileOverwriteFailedError(f"File {filename} is to be overwritten")
+                raise FileOverwriteFailedError(
+                    f'Failed to overwrite "{filename}" as Pelican has already '
+                    "written to it previously (set `override=True` if intended)"
+                )
         if override:
             self._overridden_files.add(filename)
         self._written_files.add(filename)
@@ -171,7 +175,7 @@ class Writer:
 
             with self._open_w(complete_path, "utf-8", override_output) as fp:
                 feed.write(fp, "utf-8")
-                logger.info("Writing %s", complete_path)
+                logger.info('Writing "%s"', complete_path)
 
             signals.feed_written.send(complete_path, context=context, feed=feed)
         return feed
@@ -222,7 +226,7 @@ class Writer:
 
             with self._open_w(path, "utf-8", override=override) as f:
                 f.write(output)
-            logger.info("Writing %s", path)
+            logger.info('Writing "%s"', path)
 
             # Send a signal to say we're writing a file with some specific
             # local context.

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -18,6 +18,10 @@ from pelican.utils import (
 logger = logging.getLogger(__name__)
 
 
+class FileOverwriteFailedError(RuntimeError):
+    """Failed to overwrite an existing file."""
+
+
 class Writer:
     def __init__(self, output_path, settings=None):
         self.output_path = output_path
@@ -107,14 +111,16 @@ class Writer:
         """
         if filename in self._overridden_files:
             if override:
-                raise RuntimeError(f"File {filename} is set to be overridden twice")
+                raise FileOverwriteFailedError(
+                    f"File {filename} is set to be overridden twice"
+                )
             logger.info("Skipping %s", filename)
             filename = os.devnull
         elif filename in self._written_files:
             if override:
                 logger.info("Overwriting %s", filename)
             else:
-                raise RuntimeError(f"File {filename} is to be overwritten")
+                raise FileOverwriteFailedError(f"File {filename} is to be overwritten")
         if override:
             self._overridden_files.add(filename)
         self._written_files.add(filename)


### PR DESCRIPTION
Add a short logging message if for some reason an invalid tag is provided, and Pelican instead tries to overwrite the index page.

Before:

```
           CRITICAL RuntimeError: File D:/Code/obsidian-vault/zz_output/tags/index.html is to be         __init__.py:666
                    overwritten
```

After:

```
[21:56:21] ERROR    Trying to write tag page for "**".                                                 generators.py:580
           CRITICAL RuntimeError: File D:/Code/obsidian-vault/zz_output/tags/index.html is to be         __init__.py:666
                    overwritten
```

(For some reason, the tag `**` is mapped onto the index page. Perhaps that is another issue that should be fixed...)

Fix is applied when writing Tag, Category, and Author pages. Let me know if it should be added other places.

# Pull Request Checklist

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [-] Updated **documentation** for changed code

