### PR TITLE
Better error logging if a plugin refuses to load

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -80,8 +80,14 @@ class Pelican:
                 plugin.register()
                 self.plugins.append(plugin)
             except Exception as e:
-                logger.error("Cannot register plugin `%s`\n%s", name, e, stacklevel=3)
-                print(e.stacktrace)
+                logger.error(
+                    "Cannot register plugin `%s`\n%s",
+                    name,
+                    e,
+                    stacklevel=2,
+                )
+                if self.settings.get("DEBUG", False):
+                    console.print_exception()
 
         self.settings["PLUGINS"] = [get_plugin_name(p) for p in self.plugins]
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -80,7 +80,8 @@ class Pelican:
                 plugin.register()
                 self.plugins.append(plugin)
             except Exception as e:
-                logger.error("Cannot register plugin `%s`\n%s", name, e)
+                logger.error("Cannot register plugin `%s`\n%s", name, e, stacklevel=3)
+                print(e.stacktrace)
 
         self.settings["PLUGINS"] = [get_plugin_name(p) for p in self.plugins]
 

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -88,12 +88,16 @@ class FatalLogger(LimitLogger):
     # adding `stacklevel=2` means that the displayed filename and line number
     # will match the "original" calling location, rather than the wrapper here
     def warning(self, *args, **kwargs):
-        super().warning(*args, stacklevel=2, **kwargs)
+        if "stacklevel" not in kwargs.keys():
+            kwargs["stacklevel"] = 2
+        super().warning(*args, **kwargs)
         if FatalLogger.warnings_fatal:
             raise RuntimeError("Warning encountered")
 
     def error(self, *args, **kwargs):
-        super().error(*args, stacklevel=2, **kwargs)
+        if "stacklevel" not in kwargs.keys():
+            kwargs["stacklevel"] = 2
+        super().error(*args, **kwargs)
         if FatalLogger.errors_fatal:
             raise RuntimeError("Error encountered")
 

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -85,19 +85,39 @@ class FatalLogger(LimitLogger):
     warnings_fatal = False
     errors_fatal = False
 
-    # adding `stacklevel=2` means that the displayed filename and line number
-    # will match the "original" calling location, rather than the wrapper here
-    def warning(self, *args, **kwargs):
-        if "stacklevel" not in kwargs.keys():
-            kwargs["stacklevel"] = 2
-        super().warning(*args, **kwargs)
+    def warning(self, *args, stacklevel=1, **kwargs):
+        """
+        Displays a logging warning.
+
+        Wrapping it here allows Pelican to filter warnings, and conditionally
+        make warnings fatal.
+
+        Args:
+            stacklevel (int): the stacklevel that would be used to display the
+            calling location, except for this function. Adjusting the
+            stacklevel allows you to see the "true" calling location of the
+            warning, rather than this wrapper location.
+        """
+        stacklevel += 1
+        super().warning(*args, stacklevel=stacklevel, **kwargs)
         if FatalLogger.warnings_fatal:
             raise RuntimeError("Warning encountered")
 
-    def error(self, *args, **kwargs):
-        if "stacklevel" not in kwargs.keys():
-            kwargs["stacklevel"] = 2
-        super().error(*args, **kwargs)
+    def error(self, *args, stacklevel=1, **kwargs):
+        """
+        Displays a logging error.
+
+        Wrapping it here allows Pelican to filter errors, and conditionally
+        make errors non-fatal.
+
+        Args:
+            stacklevel (int): the stacklevel that would be used to display the
+            calling location, except for this function. Adjusting the
+            stacklevel allows you to see the "true" calling location of the
+            error, rather than this wrapper location.
+        """
+        stacklevel += 1
+        super().error(*args, stacklevel=stacklevel, **kwargs)
         if FatalLogger.errors_fatal:
             raise RuntimeError("Error encountered")
 


### PR DESCRIPTION
Further to https://github.com/getpelican/pelican/pull/3257, this will print the proper line number if a plugin fails to load, and will print the stacktrace, if *pelican* is run with `--debug`.

Useful when you're first trying to get a plugin to load, or have issue when Pelican first imports/loads the plugin.

