### PR TITLE
Resolve intrasite links in summaries.

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -120,11 +120,14 @@ class Pelican:
             if hasattr(p, "generate_context"):
                 p.generate_context()
 
+        # for plugins that create/edit the summary
+        logger.debug("Signal all_generators_finalized.send(<generators>)")
+        signals.all_generators_finalized.send(generators)
+
+        # update links in the summary, etc
         for p in generators:
             if hasattr(p, "refresh_metadata_intersite_links"):
                 p.refresh_metadata_intersite_links()
-
-        signals.all_generators_finalized.send(generators)
 
         writer = self._get_writer()
 

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -520,12 +520,17 @@ class Content:
 
         # _summary is an internal variable that some plugins may be writing to,
         # so ensure changes to it are picked up
-        if (
-            "summary" in self.settings["FORMATTED_FIELDS"]
-            and "summary" in self.metadata
-        ):
-            self._summary = self._update_content(self._summary, self.get_siteurl())
-            self.metadata["summary"] = self._summary
+        if "summary" in self.settings["FORMATTED_FIELDS"]:
+            if hasattr(self, "_summary"):
+                self.metadata["summary"] = self._summary
+
+            if "summary" in self.metadata:
+                self.metadata["summary"] = self._update_content(
+                    self.metadata["summary"], self.get_siteurl()
+                )
+
+            if hasattr(self, "_summary") and "summary" in self.metadata:
+                self._summary = self.metadata["summary"]
 
 
 class Page(Content):

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -519,7 +519,7 @@ class Content:
                 setattr(self, key.lower(), value)
 
         # _summary is an internal variable that some plugins may be writing to,
-        # so ensure changes to it are picked up
+        # so ensure changes to it are picked up, and write summary back to it
         if "summary" in self.settings["FORMATTED_FIELDS"]:
             if hasattr(self, "_summary"):
                 self.metadata["summary"] = self._summary
@@ -528,8 +528,6 @@ class Content:
                 self.metadata["summary"] = self._update_content(
                     self.metadata["summary"], self.get_siteurl()
                 )
-
-            if hasattr(self, "_summary") and "summary" in self.metadata:
                 self._summary = self.metadata["summary"]
 
 


### PR DESCRIPTION
Closes [#3265](https://github.com/getpelican/pelican/issues/3265)
Closes https://github.com/MinchinWeb/minchin.pelican.plugins.summary/issues/5

Changes the order of when intrasite links are resolved, so it is after summary plugins are called.

Also allows `Articles` not to have a `_summary` attribute.

Related history includes:

- https://github.com/getpelican/pelican-plugins/issues/314
- https://github.com/getpelican/pelican/pull/1616
- https://github.com/getpelican/pelican-plugins/pull/410
- https://github.com/getpelican/pelican/pull/2226
- https://github.com/getpelican/pelican/pull/2288
- https://github.com/getpelican/pelican/issues/3265
- https://github.com/MinchinWeb/minchin.pelican.plugins.summary/issues/5
