### PR TITLE
Choose logging handler via `--log-handler` CLI option

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -19,7 +19,7 @@ __path__ = extend_path(__path__, __name__)
 
 # pelican.log has to be the first pelican module to be loaded
 # because logging.setLoggerClass has to be called before logging.getLogger
-from pelican.log import console
+from pelican.log import console, DEFAULT_LOG_HANDLER
 from pelican.log import init as init_logging
 from pelican.generators import (
     ArticlesGenerator,  # noqa: I100
@@ -455,6 +455,17 @@ def parse_arguments(argv=None):
         ),
     )
 
+    LOGS_HANDLERS = {"plain": None, "rich": DEFAULT_LOG_HANDLER}
+    parser.add_argument(
+        "--logs-handler",
+        default="rich",
+        choices=LOGS_HANDLERS,
+        help=(
+            "Which handler to to format log messages. "
+            "The `rich` handler prints output in columns."
+        ),
+    )
+
     parser.add_argument(
         "--logs-dedup-min-level",
         default="WARNING",
@@ -508,6 +519,8 @@ def parse_arguments(argv=None):
         logger.warning("--port without --listen has no effect")
     if args.bind is not None and not args.listen:
         logger.warning("--bind without --listen has no effect")
+
+    args.logs_handler = LOGS_HANDLERS[args.logs_handler]
 
     return args
 
@@ -631,6 +644,7 @@ def main(argv=None):
         level=args.verbosity,
         fatal=args.fatal,
         name=__name__,
+        handler=args.logs_handler,
         logs_dedup_min_level=logs_dedup_min_level,
     )
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -455,11 +455,11 @@ def parse_arguments(argv=None):
         ),
     )
 
-    LOGS_HANDLERS = {"plain": None, "rich": DEFAULT_LOG_HANDLER}
+    LOG_HANDLERS = {"plain": None, "rich": DEFAULT_LOG_HANDLER}
     parser.add_argument(
-        "--logs-handler",
+        "--log-handler",
         default="rich",
-        choices=LOGS_HANDLERS,
+        choices=LOG_HANDLERS,
         help=(
             "Which handler to use to format log messages. "
             "The `rich` handler prints output in columns."
@@ -520,7 +520,7 @@ def parse_arguments(argv=None):
     if args.bind is not None and not args.listen:
         logger.warning("--bind without --listen has no effect")
 
-    args.logs_handler = LOGS_HANDLERS[args.logs_handler]
+    args.log_handler = LOG_HANDLERS[args.log_handler]
 
     return args
 
@@ -644,7 +644,7 @@ def main(argv=None):
         level=args.verbosity,
         fatal=args.fatal,
         name=__name__,
-        handler=args.logs_handler,
+        handler=args.log_handler,
         logs_dedup_min_level=logs_dedup_min_level,
     )
 

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -461,7 +461,7 @@ def parse_arguments(argv=None):
         default="rich",
         choices=LOGS_HANDLERS,
         help=(
-            "Which handler to to format log messages. "
+            "Which handler to use to format log messages. "
             "The `rich` handler prints output in columns."
         ),
     )

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -126,11 +126,13 @@ logging.setLoggerClass(FatalLogger)
 # force root logger to be of our preferred class
 logging.getLogger().__class__ = FatalLogger
 
+DEFAULT_LOG_HANDLER = RichHandler(console=console)
+
 
 def init(
     level=None,
     fatal="",
-    handler=RichHandler(console=console),
+    handler=DEFAULT_LOG_HANDLER,
     name=None,
     logs_dedup_min_level=None,
 ):
@@ -139,7 +141,10 @@ def init(
 
     LOG_FORMAT = "%(message)s"
     logging.basicConfig(
-        level=level, format=LOG_FORMAT, datefmt="[%H:%M:%S]", handlers=[handler]
+        level=level,
+        format=LOG_FORMAT,
+        datefmt="[%H:%M:%S]",
+        handlers=[handler] if handler else [],
     )
 
     logger = logging.getLogger(name)


### PR DESCRIPTION
* `pelican/__init__.py` (parse_arguments): Declare new `--log-handler argument`. 
  Uses a string instead of a `type=` argument to get better error messages when passed an incorrect choice.
  (main): Pass `args.logs_handler` to `init_logging`
* pelican/log.py: Expose default log handler as `DEFAULT_LOG_HANDLER`.
  (init): Pass handler to `logging.basicConfig`.

# Pull Request Checklist

Resolves: GH-3292

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
  **Question:** I think there's no tests for the logger?
- [x] Updated **documentation** for changed code
  **Question:** I think there's no separate documentation for the CLI, I just added an argparse `help`
