### PR TITLE
Change default of --fatal command line arg to terminate on error

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: major
+
+Change default of `--fatal` command line switch to terminate on error.

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -438,12 +438,12 @@ def parse_arguments(argv=None):
 
     parser.add_argument(
         "--fatal",
-        metavar="errors|warnings",
-        choices=("errors", "warnings"),
-        default="",
+        metavar="errors|warnings|ignore",
+        choices=("errors", "warnings", "ignore"),
+        default="errors",
         help=(
             "Exit the program with non-zero status if any "
-            "errors/warnings encountered."
+            "errors/warnings encountered, or ignore any errors."
         ),
     )
 
@@ -634,7 +634,7 @@ def main(argv=None):
     logs_dedup_min_level = getattr(logging, args.logs_dedup_min_level)
     init_logging(
         level=args.verbosity,
-        fatal=args.fatal,
+        fatal=args.fatal if args.fatal != "ignore" else "",
         name=__name__,
         handler=args.log_handler,
         logs_dedup_min_level=logs_dedup_min_level,

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -131,7 +131,7 @@ DEFAULT_LOG_HANDLER = RichHandler(console=console)
 
 def init(
     level=None,
-    fatal="",
+    fatal="errors",
     handler=DEFAULT_LOG_HANDLER,
     name=None,
     logs_dedup_min_level=None,

--- a/pelican/tests/test_init.py
+++ b/pelican/tests/test_init.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pelican import DEFAULT_LOG_HANDLER, main
+
+
+class TestLog(unittest.TestCase):
+    @patch("pelican.get_instance")
+    @patch("pelican.init_logging")
+    def test_main_fatal_default(self, init_logging_mock, get_instance):
+        get_instance.side_effect = lambda *args, **kwargs: (MagicMock(), MagicMock())
+        main()
+        init_logging_mock.assert_called_once_with(
+            level=None,
+            # default is "errors"
+            fatal="errors",
+            name="pelican",
+            handler=DEFAULT_LOG_HANDLER,
+            logs_dedup_min_level=30,
+        )


### PR DESCRIPTION
I noticed #3173 is now conflicted and also in the "pelican 5.0" milestone.

So, this is a re-implementation, along with a simple unit test.

I don't know how to test it well, so it's worth comparing carefully to #3173 during review.

Resolves: 3172

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] Updated **documentation** for changed code