### PR TITLE
Log warnings about files that would have been processed by disabled readers

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -30,7 +30,6 @@ from pelican.generators import (
 )
 from pelican.plugins import signals
 from pelican.plugins._utils import get_plugin_name, load_plugins
-from pelican.readers import Readers
 from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
 from pelican.settings import read_settings
 from pelican.utils import clean_output_dir, maybe_pluralize, wait_for_changes
@@ -126,6 +125,8 @@ class Pelican:
         for p in generators:
             if hasattr(p, "generate_context"):
                 p.generate_context()
+            if hasattr(p, "check_disabled_readers"):
+                p.check_disabled_readers()
 
         # for plugins that create/edit the summary
         logger.debug("Signal all_generators_finalized.send(<generators>)")
@@ -573,7 +574,7 @@ def autoreload(args, excqueue=None):
         try:
             pelican.run()
 
-            changed_files = wait_for_changes(args.settings, Readers, settings)
+            changed_files = wait_for_changes(args.settings, settings)
             changed_files = {c[1] for c in changed_files}
 
             if settings_file in changed_files:

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -17,7 +17,7 @@ from pelican import rstdirectives  # NOQA
 from pelican.cache import FileStampDataCacher
 from pelican.contents import Author, Category, Page, Tag
 from pelican.plugins import signals
-from pelican.utils import get_date, pelican_open, posixize_path
+from pelican.utils import file_suffix, get_date, pelican_open, posixize_path
 
 try:
     from markdown import Markdown
@@ -124,6 +124,10 @@ class BaseReader:
         content = None
         metadata = {}
         return content, metadata
+
+    def disabled_message(self) -> str:
+        """Message about why this plugin was disabled."""
+        return ""
 
 
 class _FieldBodyTranslator(HTMLTranslator):
@@ -347,6 +351,12 @@ class MarkdownReader(BaseReader):
             metadata = {}
         return content, metadata
 
+    def disabled_message(self) -> str:
+        return (
+            "Could not import markdown.Markdown.  "
+            "Have you installed the markdown package?"
+        )
+
 
 class HTMLReader(BaseReader):
     """Parses HTML files as input, looking for meta, title, and body tags"""
@@ -508,17 +518,23 @@ class Readers(FileStampDataCacher):
     def __init__(self, settings=None, cache_name=""):
         self.settings = settings or {}
         self.readers = {}
+        self.disabled_readers = {}
+        # extension => reader for readers that are enabled
         self.reader_classes = {}
+        # extension => reader for readers that are not enabled
+        disabled_reader_classes = {}
 
         for cls in [BaseReader] + BaseReader.__subclasses__():
             if not cls.enabled:
                 logger.debug(
                     "Missing dependencies for %s", ", ".join(cls.file_extensions)
                 )
-                continue
 
             for ext in cls.file_extensions:
-                self.reader_classes[ext] = cls
+                if cls.enabled:
+                    self.reader_classes[ext] = cls
+                else:
+                    disabled_reader_classes[ext] = cls
 
         if self.settings["READERS"]:
             self.reader_classes.update(self.settings["READERS"])
@@ -531,6 +547,9 @@ class Readers(FileStampDataCacher):
 
             self.readers[fmt] = reader_class(self.settings)
 
+        for fmt, reader_class in disabled_reader_classes.items():
+            self.disabled_readers[fmt] = reader_class(self.settings)
+
         # set up caching
         cache_this_level = (
             cache_name != "" and self.settings["CONTENT_CACHING_LAYER"] == "reader"
@@ -541,7 +560,12 @@ class Readers(FileStampDataCacher):
 
     @property
     def extensions(self):
+        """File extensions that will be processed by a reader."""
         return self.readers.keys()
+
+    @property
+    def disabled_extensions(self):
+        return self.disabled_readers.keys()
 
     def read_file(
         self,
@@ -562,8 +586,7 @@ class Readers(FileStampDataCacher):
         logger.debug("Read file %s -> %s", source_path, content_class.__name__)
 
         if not fmt:
-            _, ext = os.path.splitext(os.path.basename(path))
-            fmt = ext[1:]
+            fmt = file_suffix(path)
 
         if fmt not in self.readers:
             raise TypeError("Pelican does not know how to parse %s", path)
@@ -653,6 +676,12 @@ class Readers(FileStampDataCacher):
             source_path=path,
             context=context,
         )
+
+    def check_file(self, source_path: str) -> None:
+        """Log a warning if a file is processed by a disabled reader."""
+        reader = self.disabled_readers.get(file_suffix(source_path), None)
+        if reader:
+            logger.warning(f"{source_path}: {reader.disabled_message()}")
 
 
 def find_empty_alt(content, path):

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from pelican import readers
 from pelican.tests.support import get_settings, unittest
@@ -31,6 +31,19 @@ class ReaderTest(unittest.TestCase):
                 )
             else:
                 self.fail(f"Expected {key} to have value {value}, but was not in Dict")
+
+    def test_markdown_disabled(self):
+        with patch.object(
+            readers.MarkdownReader, "enabled", new_callable=PropertyMock
+        ) as attr_mock:
+            attr_mock.return_value = False
+            readrs = readers.Readers(settings=get_settings())
+            self.assertEqual(
+                set(readers.MarkdownReader.file_extensions),
+                readrs.disabled_readers.keys(),
+            )
+            for val in readrs.disabled_readers.values():
+                self.assertEqual(readers.MarkdownReader, val.__class__)
 
 
 class TestAssertDictHasSubset(ReaderTest):

--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -966,3 +966,10 @@ class TestMemoized(unittest.TestCase):
             container.get.cache.clear()
             self.assertEqual("bar", container.get("bar"))
             get_mock.assert_called_once_with("bar")
+
+
+class TestStringUtils(unittest.TestCase):
+    def test_file_suffix(self):
+        self.assertEqual("", utils.file_suffix(""))
+        self.assertEqual("", utils.file_suffix("foo"))
+        self.assertEqual("md", utils.file_suffix("foo.md"))

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 import dateutil.parser
+from watchfiles import Change
 
 try:
     from zoneinfo import ZoneInfo
@@ -39,7 +40,6 @@ from markupsafe import Markup
 
 if TYPE_CHECKING:
     from pelican.contents import Content
-    from pelican.readers import Readers
     from pelican.settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -797,9 +797,8 @@ def order_content(
 
 def wait_for_changes(
     settings_file: str,
-    reader_class: type[Readers],
     settings: Settings,
-):
+) -> set[tuple[Change, str]]:
     content_path = settings.get("PATH", "")
     theme_path = settings.get("THEME", "")
     ignore_files = {
@@ -924,3 +923,13 @@ def temporary_locale(
         locale.setlocale(lc_category, temp_locale)
     yield
     locale.setlocale(lc_category, orig_locale)
+
+
+def file_suffix(path: str) -> str:
+    """Return the suffix of a filename in a path."""
+    _, ext = os.path.splitext(os.path.basename(path))
+    ret = ""
+    if len(ext) > 1:
+        # drop the ".", e.g., "exe", not ".exe"
+        ret = ext[1:]
+    return ret


### PR DESCRIPTION
Resolves: 1868

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

This is a proof of concept of producing legible warning messages if markdown is not installed.

Example output:

> WARNING  ./sample.md: Could not import markdown.Markdown.  Have you installed the markdown package?                                 readers.py:688
Done: Processed 0 articles, 0 drafts, 0 hidden articles, 0 pages, 0 hidden pages and 0 draft pages in 0.07 seconds.

If this PR looks good, I can try to write at least one unit test of the new functionality.

Some downsides:
1. this is not super simple
2. it will produce one warning per file

I don't think 2 is a big deal. I think 1 is a judgment call, I'm interested in opinions.

It would probably be easier to just require the markdown package?