### PR TITLE
Improve test coverage, docs, and `.gitignore`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [report]
-omit = pelican/tests/*
+omit =
+       pelican/tests/*
+       pelican/signals.py

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ samples/output
 *.lock
 .pdm-python
 .venv
+
+# direnv
+.envrc
+
+# pycharm
+.idea

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -64,6 +64,20 @@ your bug fix or feature::
 Now you can make changes to Pelican, its documentation, and/or other aspects of
 the project.
 
+Setting up git blame
+--------------------
+
+``git blame`` annotates lines from a file with information about the pull request
+that last modified it.  Sweeping shallow changes (like formatting) can make that
+information less useful, so we keep a list of such changes to be ignored.  To set
+that up in your repository::
+
+    git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+For more information, see here_.
+
+.. _here: https://www.michaelheap.com/git-ignore-rev/
+
 Running the test suite
 ----------------------
 
@@ -107,6 +121,20 @@ Tox_ is a useful tool to automate running tests inside ``virtualenv``
 environments.
 
 .. _Tox: https://tox.readthedocs.io/en/latest/
+
+Running a code coverage report
+------------------------------
+
+The code is more likely to stay robust if it is tested.
+coverage_ is a library that measures how much of the code is tested.
+To run it::
+
+    invoke coverage
+    open htmlcov/index.html
+
+The HTML will show overall coverage, coverage per file, and even line-by-line coverage.
+
+.. _coverage: https://github.com/nedbat/coveragepy
 
 Building the docs
 -----------------

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -64,19 +64,26 @@ your bug fix or feature::
 Now you can make changes to Pelican, its documentation, and/or other aspects of
 the project.
 
-Setting up git blame
---------------------
+Setting up ``git blame`` (optional)
+-----------------------------------
 
-``git blame`` annotates lines from a file with information about the pull request
-that last modified it.  Sweeping shallow changes (like formatting) can make that
-information less useful, so we keep a list of such changes to be ignored.  To set
-that up in your repository::
+``git blame`` annotates lines in a file with information about the pull request
+that last modified it. Sweeping shallow changes (like formatting) can make that
+information less useful, so we keep a list of such changes to be ignored. Run the
+following command to set this up in your repository, adding ``--global`` if you
+want this setting to apply to all repositories::
 
     git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-For more information, see here_.
+As noted in a `useful article`_ about ``git blame``, there are other related
+settings you may find to be beneficial::
 
-.. _here: https://www.michaelheap.com/git-ignore-rev/
+    # Add `?` to any lines that have had a commit skipped using --ignore-rev
+    git config --global blame.markIgnoredLines true
+    # Add `*` to any lines that were added in a skipped commit and can not be attributed
+    git config --global blame.markUnblamableLines true
+
+.. _useful article: https://www.michaelheap.com/git-ignore-rev/
 
 Running the test suite
 ----------------------
@@ -125,16 +132,17 @@ environments.
 Running a code coverage report
 ------------------------------
 
-The code is more likely to stay robust if it is tested.
-coverage_ is a library that measures how much of the code is tested.
-To run it::
+Code is more likely to stay robust if it is tested. Coverage_ is a library that
+measures how much of the code is tested. To run it::
 
     invoke coverage
+
+This will show overall coverage, coverage per file, and even line-by-line coverage.
+There is also an HTML report available::
+
     open htmlcov/index.html
 
-The HTML will show overall coverage, coverage per file, and even line-by-line coverage.
-
-.. _coverage: https://github.com/nedbat/coveragepy
+.. _Coverage: https://github.com/nedbat/coveragepy
 
 Building the docs
 -----------------

--- a/pelican/tests/simple_content/article_with_md_extension.md
+++ b/pelican/tests/simple_content/article_with_md_extension.md
@@ -1,0 +1,1 @@
+../content/article_with_md_extension.md

--- a/pelican/tests/test_pelican.py
+++ b/pelican/tests/test_pelican.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import locale
 import logging
 import os
@@ -6,9 +8,12 @@ import sys
 import unittest
 from collections.abc import Sequence
 from shutil import rmtree
-from tempfile import mkdtemp
+from tempfile import TemporaryDirectory, mkdtemp
+from unittest.mock import patch
 
-from pelican import Pelican
+from rich.console import Console
+
+from pelican import Pelican, __version__, main
 from pelican.generators import StaticGenerator
 from pelican.settings import read_settings
 from pelican.tests.support import (
@@ -271,3 +276,31 @@ class TestPelican(LoggedTestCase):
             [sys.executable, "-m", "pelican", "--help"]
         ).decode("ascii", "replace")
         assert "usage:" in output
+
+    def test_main_version(self):
+        """Run main --version."""
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                main(["--version"])
+            self.assertEqual(f"{__version__}\n", out.getvalue())
+
+    def test_main_help(self):
+        """Run main --help."""
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            with self.assertRaises(SystemExit):
+                main(["--help"])
+            self.assertIn("A tool to generate a static blog", out.getvalue())
+
+    def test_main_on_content(self):
+        """Invoke main on simple_content directory."""
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            with TemporaryDirectory() as temp_dir:
+                # Don't highlight anything.
+                # See https://rich.readthedocs.io/en/stable/highlighting.html
+                with patch("pelican.console", new=Console(highlight=False)):
+                    main(["-o", temp_dir, "pelican/tests/simple_content"])
+            self.assertIn("Processed 1 article", out.getvalue())
+            self.assertEqual("", err.getvalue())

--- a/tasks.py
+++ b/tasks.py
@@ -47,7 +47,11 @@ def tests(c):
 @task
 def coverage(c):
     """Generate code coverage of running the test suite."""
-    c.run(f"{VENV_BIN}/pytest --cov=pelican", pty=PTY)
+    c.run(
+        f"{VENV_BIN}/pytest --cov=pelican --cov-report term-missing "
+        "--cov-fail-under 74.8",
+        pty=PTY,
+    )
     c.run(f"{VENV_BIN}/coverage html", pty=PTY)
 
 


### PR DESCRIPTION
- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools

I wanted to see if I could improve test coverage. `__init__.py` was a file with a big coverage gap, so I wrote some tests to invoke `main` (not previously invoked). If this is acceptable, we can invoke main with different arguments to cover different pieces.

I must admit, I'm a bit disappointed to only cover 24 additional lines, but they are probably important lines (making sure main still runs). See coverage below.

As I was working, I also wrote a bit in the docs, and excluded `signals.py` from test coverage, since it's deprecated.

* BEFORE:

```
Name                                  Stmts   Miss  Cover
---------------------------------------------------------
pelican/__init__.py                     301    142    53%
pelican/__main__.py                       3      0   100%
pelican/cache.py                         68     13    81%
pelican/contents.py                     345     15    96%
pelican/generators.py                   491     33    93%
pelican/log.py                           84     13    85%
pelican/paginator.py                     92     13    86%
pelican/plugins/_utils.py                79     16    80%
pelican/plugins/signals.py               31      0   100%
pelican/readers.py                      409     17    96%
pelican/rstdirectives.py                 47      3    94%
pelican/server.py                        92     39    58%
pelican/settings.py                     248     54    78%
pelican/signals.py                        1      1     0%
pelican/tools/__init__.py                 0      0   100%
pelican/tools/pelican_import.py         636    232    64%
pelican/tools/pelican_quickstart.py     180    180     0%
pelican/tools/pelican_themes.py         154    154     0%
pelican/urlwrappers.py                   89      9    90%
pelican/utils.py                        445     68    85%
pelican/writers.py                      124      6    95%
---------------------------------------------------------
TOTAL                                  3919   1008    74%
```

* AFTER:

```
Name                                  Stmts   Miss  Cover
---------------------------------------------------------
pelican/__init__.py                     301    120    60%
pelican/__main__.py                       3      0   100%
pelican/cache.py                         68     13    81%
pelican/contents.py                     345     15    96%
pelican/generators.py                   491     33    93%
pelican/log.py                           84     12    86%
pelican/paginator.py                     92     13    86%
pelican/plugins/_utils.py                79     16    80%
pelican/plugins/signals.py               31      0   100%
pelican/readers.py                      409     17    96%
pelican/rstdirectives.py                 47      3    94%
pelican/server.py                        92     39    58%
pelican/settings.py                     248     54    78%
pelican/tools/__init__.py                 0      0   100%
pelican/tools/pelican_import.py         636    232    64%
pelican/tools/pelican_quickstart.py     180    180     0%
pelican/tools/pelican_themes.py         154    154     0%
pelican/urlwrappers.py                   89      9    90%
pelican/utils.py                        445     68    85%
pelican/writers.py                      124      6    95%
---------------------------------------------------------
TOTAL                                  3918    984    75%
```
