### PR TITLE
Add Dependabot checking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See https://docs.github.com/en/free-pro-team@latest/
+#  github/administering-a-repository/enabling-and-disabling-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
I think I also had to enable dependabot in the github interface. See [here](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository).

I wasn't sure if dependabot was even running, because everything is silent, but [this run](https://github.com/boxydog/pelican/actions/runs/9352026556/job/25739167659) shows dependabot checking. It is not clear what file it is checking, but for example I see "Checking if feedgenerator  needs updating", which is only in pyproject.toml, so it looks to me like it is doing the right thing.