### PR TITLE
Remove `ifconfig` Sphinx extension from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@ with open("../pyproject.toml", "rb") as f:
 templates_path = ["_templates"]
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.ifconfig",
     "sphinx.ext.extlinks",
     "sphinxext.opengraph",
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,6 @@
 Pelican |release|
 =================
 
-
-.. ifconfig:: release.endswith('.dev')
-
-    .. warning::
-
-        This documentation is for the version of Pelican currently under
-        development. Were you looking for version |last_stable| documentation?
-
-
 Pelican is a static site generator, written in Python_. Highlights include:
 
 * Write your content directly with your editor of choice in reStructuredText_

--- a/requirements/docs.pip
+++ b/requirements/docs.pip
@@ -2,4 +2,5 @@ sphinx
 sphinxext-opengraph
 furo==2023.9.10
 livereload
+matplotlib
 tomli;python_version<"3.11"


### PR DESCRIPTION
Originally added in #815, something about this configuration seems to be causing an [obscure ReadTheDocs build error](https://github.com/getpelican/pelican/pull/3330#issuecomment-2174347441). Plus, it seems ReadTheDocs has since added this [version-warning functionality](https://docs.readthedocs.io/en/stable/versions.html#version-warning) as a beta feature. After merging this PR, if the latter built-in beta feature proves to deliver similar functionality, we could consider removing the [`last_stable`](https://github.com/getpelican/pelican/blob/7a2c72e60473b6be0d1277ed3da60251f9a27736/docs/conf.py#L36-L38) variable and any other related changes that are no longer relevant.

This PR also adds `matplotlib` to our documentation package dependencies. Without it installed, Sphinx output says that social cards cannot be generated.