### PR TITLE
Update image URLs for GitHub ribbons

### DIFF
--- a/pelican/tests/output/custom/a-markdown-powered-article.html
+++ b/pelican/tests/output/custom/a-markdown-powered-article.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/archives.html
+++ b/pelican/tests/output/custom/archives.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/article-1.html
+++ b/pelican/tests/output/custom/article-1.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/article-2.html
+++ b/pelican/tests/output/custom/article-2.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/article-3.html
+++ b/pelican/tests/output/custom/article-3.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau2.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom/author/alexis-metaireau3.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/authors.html
+++ b/pelican/tests/output/custom/authors.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/categories.html
+++ b/pelican/tests/output/custom/categories.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/category/bar.html
+++ b/pelican/tests/output/custom/category/bar.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/category/cat1.html
+++ b/pelican/tests/output/custom/category/cat1.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/category/misc.html
+++ b/pelican/tests/output/custom/category/misc.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/category/yeah.html
+++ b/pelican/tests/output/custom/category/yeah.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/drafts/a-draft-article-without-date.html
+++ b/pelican/tests/output/custom/drafts/a-draft-article-without-date.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom/drafts/a-draft-article.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/filename_metadata-example.html
+++ b/pelican/tests/output/custom/filename_metadata-example.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/index.html
+++ b/pelican/tests/output/custom/index.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/index2.html
+++ b/pelican/tests/output/custom/index2.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/index3.html
+++ b/pelican/tests/output/custom/index3.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/jinja2_template.html
+++ b/pelican/tests/output/custom/jinja2_template.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/oh-yeah-fr.html
+++ b/pelican/tests/output/custom/oh-yeah-fr.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/oh-yeah.html
+++ b/pelican/tests/output/custom/oh-yeah.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/override/index.html
+++ b/pelican/tests/output/custom/override/index.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-hidden-page.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom/pages/this-is-a-test-page.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/second-article-fr.html
+++ b/pelican/tests/output/custom/second-article-fr.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/second-article.html
+++ b/pelican/tests/output/custom/second-article.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tag/bar.html
+++ b/pelican/tests/output/custom/tag/bar.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tag/baz.html
+++ b/pelican/tests/output/custom/tag/baz.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tag/foo.html
+++ b/pelican/tests/output/custom/tag/foo.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tag/foobar.html
+++ b/pelican/tests/output/custom/tag/foobar.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tag/oh.html
+++ b/pelican/tests/output/custom/tag/oh.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tag/yeah.html
+++ b/pelican/tests/output/custom/tag/yeah.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/tags.html
+++ b/pelican/tests/output/custom/tags.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/this-is-a-super-article.html
+++ b/pelican/tests/output/custom/this-is-a-super-article.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom/unbelievable.html
+++ b/pelican/tests/output/custom/unbelievable.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log <strong>A personal blog.</strong></a></h1>

--- a/pelican/tests/output/custom_locale/archives.html
+++ b/pelican/tests/output/custom_locale/archives.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau2.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
+++ b/pelican/tests/output/custom_locale/author/alexis-metaireau3.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/authors.html
+++ b/pelican/tests/output/custom_locale/authors.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/categories.html
+++ b/pelican/tests/output/custom_locale/categories.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/category/bar.html
+++ b/pelican/tests/output/custom_locale/category/bar.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/category/cat1.html
+++ b/pelican/tests/output/custom_locale/category/cat1.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/category/misc.html
+++ b/pelican/tests/output/custom_locale/category/misc.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/category/yeah.html
+++ b/pelican/tests/output/custom_locale/category/yeah.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/drafts/a-draft-article-without-date.html
+++ b/pelican/tests/output/custom_locale/drafts/a-draft-article-without-date.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/drafts/a-draft-article.html
+++ b/pelican/tests/output/custom_locale/drafts/a-draft-article.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/index.html
+++ b/pelican/tests/output/custom_locale/index.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/index2.html
+++ b/pelican/tests/output/custom_locale/index2.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/index3.html
+++ b/pelican/tests/output/custom_locale/index3.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/jinja2_template.html
+++ b/pelican/tests/output/custom_locale/jinja2_template.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/oh-yeah-fr.html
+++ b/pelican/tests/output/custom_locale/oh-yeah-fr.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/override/index.html
+++ b/pelican/tests/output/custom_locale/override/index.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-hidden-page.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
+++ b/pelican/tests/output/custom_locale/pages/this-is-a-test-page.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/décembre/02/this-is-a-super-article/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/15/unbelievable/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
+++ b/pelican/tests/output/custom_locale/posts/2010/octobre/20/oh-yeah/index.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/avril/20/a-markdown-powered-article/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-1/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-2/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
+++ b/pelican/tests/output/custom_locale/posts/2011/février/17/article-3/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/février/29/second-article/index.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
+++ b/pelican/tests/output/custom_locale/posts/2012/novembre/30/filename_metadata-example/index.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../../../../../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/second-article-fr.html
+++ b/pelican/tests/output/custom_locale/second-article-fr.html
@@ -15,7 +15,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tag/bar.html
+++ b/pelican/tests/output/custom_locale/tag/bar.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tag/baz.html
+++ b/pelican/tests/output/custom_locale/tag/baz.html
@@ -13,7 +13,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tag/foo.html
+++ b/pelican/tests/output/custom_locale/tag/foo.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tag/foobar.html
+++ b/pelican/tests/output/custom_locale/tag/foobar.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tag/oh.html
+++ b/pelican/tests/output/custom_locale/tag/oh.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tag/yeah.html
+++ b/pelican/tests/output/custom_locale/tag/yeah.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="../">Alexis' log</a></h1>

--- a/pelican/tests/output/custom_locale/tags.html
+++ b/pelican/tests/output/custom_locale/tags.html
@@ -12,7 +12,7 @@
 
         <body id="index" class="home">
                 <a href="http://github.com/ametaireau/">
-                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+                        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
                 </a>
                 <header id="banner" class="body">
                         <h1><a href="./">Alexis' log</a></h1>

--- a/pelican/themes/notmyidea/templates/github.html
+++ b/pelican/themes/notmyidea/templates/github.html
@@ -1,9 +1,9 @@
 {% if GITHUB_URL %}
     <a href="{{ GITHUB_URL }}">
         {% if GITHUB_POSITION != "left" %}
-            <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
+            <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub" />
         {% else %}
-            <img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_white_ffffff.png" alt="Fork me on GitHub" />
+            <img style="position: absolute; top: 0; left: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_left_white_ffffff.png" alt="Fork me on GitHub" />
         {% endif %}
     </a>
 {% endif %}


### PR DESCRIPTION
Old URLs are no longer active with the following error:

```xml
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
<RequestId>V7X07P83V1ASMXZV</RequestId>
<HostId>aloi/lC8shId9O5ftSA4RZqqtsX6pcKWcWnkJ9yAc4aPLoKna6EeSDSNijWuBeLg6qxyyZm0EC4=</HostId>
</Error>
```

This results in missing images in the generated site.

New URLs for ribbons were taken from the article on GitHub blog:
https://github.blog/2008-12-19-github-ribbons/

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
