### PR TITLE
Faster cleanup of output folder (PEP-0471)

### DIFF
--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -391,19 +391,19 @@ def clean_output_dir(path: str, retention: Iterable[str]) -> None:
         return
 
     # remove existing content from output folder unless in retention list
-    for filename in os.listdir(path):
-        file = os.path.join(path, filename)
-        if any(filename == retain for retain in retention):
+    for dir_entry in os.scandir(path):
+        file = dir_entry.path
+        if any(dir_entry.name == retain for retain in retention):
             logger.debug(
-                "Skipping deletion; %s is on retention list: %s", filename, file
+                "Skipping deletion; %s is on retention list: %s", dir_entry.name, file
             )
-        elif os.path.isdir(file):
+        elif dir_entry.is_dir():
             try:
                 shutil.rmtree(file)
                 logger.debug("Deleted directory %s", file)
             except Exception as e:
                 logger.error("Unable to delete directory %s; %s", file, e)
-        elif os.path.isfile(file) or os.path.islink(file):
+        elif dir_entry.is_file(follow_symlinks=False) or dir_entry.is_symlink():
             try:
                 os.remove(file)
                 logger.debug("Deleted file/link %s", file)


### PR DESCRIPTION
Use os.scandir() instead of os.listdir()

In accordance with PEP-0471, os.listdir has been marked for discontinued sometime in the future.

https://peps.python.org/pep-0471/

# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
