### PR TITLE
Handle internal links without extensions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Allow extensionless internal links


### PR DESCRIPTION
# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

# Reason for change

Jekyll—or at least Jekyll as I've configured it—allows for internal links to files regardless of their extension. Say, for example, you have two posts: `post1.md` and `post2.html`

```markdown
Title: Post 1

This file has an internal link to post 2: [Link to Post 2]({filename}/post2)
```

I could convert-and-rename `post2.html` to `post2.md` and the internal link in `post1.md` would not need to change. (I did this a lot in my Jekyll days because the Jekyll blog had a lot of content exported from WordPerfect as HTML files.)

# Proposed implementation

In `_link_replacer()`, create a loop of Reader filename extensions to append to the end of the file path and calls `_get_linked_content()` with that extension. The first time through the loop the extension is `None` so the function behaves as it currently does. If that fails to find a path in the context, the loop tries adding extensions to the path.

# Open questions

1. How does one get a list of extensions? I could import them through, say, `YAMLMetadataReader.file_extensions`, but that seems like an unwise coupling.
