### PR TITLE
Optimize imports in `tasks.py.jinja2`

### DIFF
--- a/pelican/tools/templates/tasks.py.jinja2
+++ b/pelican/tools/templates/tasks.py.jinja2
@@ -2,11 +2,15 @@ import os
 import shlex
 import shutil
 import sys
+{% if github %}
 import datetime
+{% endif %}
 
 from invoke import task
 from invoke.main import program
+{% if cloudfiles %}
 from invoke.util import cd
+{% endif %}
 from pelican import main as pelican_main
 from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
 from pelican.settings import DEFAULT_CONFIG, get_settings_from_file


### PR DESCRIPTION
When opening the generated tasks.py file with a Python linter enabled, some imports will be marked as unecessary depending on the options passed to pelican-quickstart.

Add if statements around the optional imports so they are used only when necessary.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
