### PR TITLE
Change order of SUFFIXES so index.html is served first

### DIFF
--- a/pelican/server.py
+++ b/pelican/server.py
@@ -49,7 +49,7 @@ def parse_arguments():
 
 
 class ComplexHTTPRequestHandler(server.SimpleHTTPRequestHandler):
-    SUFFIXES = [".html", "/index.html", "/", ""]
+    SUFFIXES = ["/index.html",".html", "/", ""]
 
     extensions_map = {
         **server.SimpleHTTPRequestHandler.extensions_map,


### PR DESCRIPTION
A file named .html should not exist in the output directory. 

Somehow I ended up with one, and it was difficult to debug. Changing the order of the SUFFIXES allows the index.html file to be served before checking for .html.

