### PR TITLE
Fix symbolic link handling in `pelican-themes -s/-c`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: minor
-
-Fix symlink handling in `pelican-themes`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Fix symlink handling in `pelican-themes`.

--- a/pelican/tools/pelican_themes.py
+++ b/pelican/tools/pelican_themes.py
@@ -249,6 +249,7 @@ def install(path, v=False, u=False):
 
 def symlink(path, v=False):
     """Symbolically link a theme"""
+    path = os.path.realpath(path)
     if not os.path.exists(path):
         err(path + " : no such file or directory")
     elif not os.path.isdir(path):
@@ -269,7 +270,7 @@ def symlink(path, v=False):
 
 def is_broken_link(path):
     """Returns True if the path given as is a broken symlink"""
-    path = os.readlink(path)
+    path = os.path.realpath(path)
     return not os.path.exists(path)
 
 


### PR DESCRIPTION
# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

# Description

Symlinks with relative paths were not handled properly by `pelican-themes`.

Example:

The pelican theme to be installed is in a sibling directory to the project directory. Running

```bash
pelican-themes -s ../my-theme
```

creates a symlink `../my-theme` in pelican’s theme folder. This link is broken, since the relative path in the symlink will now be resolved from pelican’s theme folder.

When running `pelican-themes -c` from the project folder, it will not detect the broken symlink, since the relative path will actually resolve from the current directory (just not from pelican’s theme folder).

This pull request fixes this by running `os.path.realpath` on the passed path both when creating symlinks and when checking symlinks. This will make sure that always the absolute paths are linked/checked.