### PR TITLE
Fix `build` job failure in GitHub CI workflow

### DIFF
--- a/pelican/tests/build_test/test_build_files.py
+++ b/pelican/tests/build_test/test_build_files.py
@@ -61,6 +61,6 @@ def test_sdist_contents(pytestconfig, expected_file):
         filtered_values = [
             path
             for path in files_list
-            if match(rf"^pelican-\d\.\d\.\d/{expected_file}{dir_matcher}$", path)
+            if match(rf"^pelican-\d+\.\d+\.\d+/{expected_file}{dir_matcher}$", path)
         ]
         assert len(filtered_values) > 0


### PR DESCRIPTION
the regex, searching for the builded files was not stable to changes for two digit versions.

fixes: Build test failures in GitHub CI workflow #3393

# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

