### PR TITLE
Match actual version instead of regex in `build` CI job

### DIFF
--- a/pelican/tests/build_test/test_build_files.py
+++ b/pelican/tests/build_test/test_build_files.py
@@ -1,9 +1,12 @@
+import importlib.metadata
 import tarfile
 from pathlib import Path
 from re import match
 from zipfile import ZipFile
 
 import pytest
+
+version = importlib.metadata.version("pelican")
 
 
 @pytest.mark.skipif(
@@ -16,7 +19,7 @@ def test_wheel_contents(pytestconfig):
     that everything that is needed is included in the final build
     """
     dist_folder = pytestconfig.getoption("--check-build")
-    wheels = Path(dist_folder).rglob("*.whl")
+    wheels = Path(dist_folder).rglob(f"pelican-{version}-py3-none-any.whl")
     for wheel_file in wheels:
         files_list = ZipFile(wheel_file).namelist()
         # Check if theme files are copied to wheel
@@ -52,7 +55,7 @@ def test_sdist_contents(pytestconfig, expected_file):
     that everything that is needed is included in the final build.
     """
     dist_folder = pytestconfig.getoption("--check-build")
-    sdist_files = Path(dist_folder).rglob("*.tar.gz")
+    sdist_files = Path(dist_folder).rglob(f"pelican-{version}.tar.gz")
     for dist in sdist_files:
         files_list = tarfile.open(dist, "r:gz").getnames()
         dir_matcher = ""
@@ -61,6 +64,6 @@ def test_sdist_contents(pytestconfig, expected_file):
         filtered_values = [
             path
             for path in files_list
-            if match(rf"^pelican-\d\.\d\.\d/{expected_file}{dir_matcher}$", path)
+            if match(rf"^pelican-{version}/{expected_file}{dir_matcher}$", path)
         ]
         assert len(filtered_values) > 0


### PR DESCRIPTION
This is an alternative approach to #3395 

- get version from package
- files need to start with `pelican-`

fixes #3393 



# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
