### PR TITLE
Don't store a RichHandler object in the `argparse` namespace (#3394)

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -310,6 +310,9 @@ class ParseOverrides(argparse.Action):
         setattr(namespace, self.dest, overrides)
 
 
+LOG_HANDLERS = {"plain": None, "rich": DEFAULT_LOG_HANDLER}
+
+
 def parse_arguments(argv=None):
     parser = argparse.ArgumentParser(
         description="A tool to generate a static blog, "
@@ -448,7 +451,6 @@ def parse_arguments(argv=None):
         ),
     )
 
-    LOG_HANDLERS = {"plain": None, "rich": DEFAULT_LOG_HANDLER}
     parser.add_argument(
         "--log-handler",
         default="rich",
@@ -512,8 +514,6 @@ def parse_arguments(argv=None):
         logger.warning("--port without --listen has no effect")
     if args.bind is not None and not args.listen:
         logger.warning("--bind without --listen has no effect")
-
-    args.log_handler = LOG_HANDLERS[args.log_handler]
 
     return args
 
@@ -637,7 +637,7 @@ def main(argv=None):
         level=args.verbosity,
         fatal=args.fatal,
         name=__name__,
-        handler=args.log_handler,
+        handler=LOG_HANDLERS[args.log_handler],
         logs_dedup_min_level=logs_dedup_min_level,
     )
 


### PR DESCRIPTION
Resolves: #3394 

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] ~Added **tests** for changed code~
- [ ] ~Updated **documentation** for changed code~

Unfortunately I can't test locally, but this patch should be harmless, at least.