### PR TITLE
Add more blocks to Simple theme's base template

### DIFF
--- a/pelican/tests/test_theme.py
+++ b/pelican/tests/test_theme.py
@@ -1,0 +1,138 @@
+import os
+import unittest
+from shutil import rmtree
+from tempfile import mkdtemp
+
+from pelican import Pelican
+from pelican.settings import read_settings
+from pelican.tests.support import LoggedTestCase, mute
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONTENT_DIR = os.path.join(CURRENT_DIR, "simple_content")
+
+
+class TestTemplateInheritance(LoggedTestCase):
+    def setUp(self):
+        super().setUp()
+        self.temp_output = mkdtemp(prefix="pelican_test_output.")
+        self.temp_theme = mkdtemp(prefix="pelican_test_theme.")
+        self.temp_cache = mkdtemp(prefix="pelican_test_cache.")
+
+        # Create test theme directory structure
+        os.makedirs(os.path.join(self.temp_theme, "templates"), exist_ok=True)
+
+        # Create base.html template that inherits from simple theme
+        template_content = """{% extends "!simple/base.html" %}
+
+{% block head %}
+{{ super() }}
+    <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/style.css" />
+{% endblock %}
+
+{% block footer %}
+    <p>New footer</p>
+{% endblock %}
+"""
+
+        with open(os.path.join(self.temp_theme, "templates", "base.html"), "w") as f:
+            f.write(template_content)
+
+    def tearDown(self):
+        """Clean up temporary directories and files"""
+        for path in [self.temp_output, self.temp_theme, self.temp_cache]:
+            if os.path.exists(path):
+                rmtree(path)
+
+        super().tearDown()
+
+    def test_simple_theme(self):
+        """Test that when a template is missing from our theme, Pelican falls back
+        to using the template from the simple theme."""
+
+        settings = read_settings(
+            path=None,
+            override={
+                "THEME": "simple",
+                "PATH": CONTENT_DIR,
+                "OUTPUT_PATH": self.temp_output,
+                "CACHE_PATH": self.temp_cache,
+                "SITEURL": "http://example.com",
+                # Disable unnecessary output that might cause failures
+                "ARCHIVES_SAVE_AS": "",
+                "CATEGORIES_SAVE_AS": "",
+                "TAGS_SAVE_AS": "",
+                "AUTHOR_SAVE_AS": "",
+                "AUTHORS_SAVE_AS": "",
+            },
+        )
+
+        pelican = Pelican(settings=settings)
+        mute(True)(pelican.run)()
+
+        output_file = os.path.join(self.temp_output, "test-md-file.html")
+        self.assertTrue(os.path.exists(output_file))
+
+        with open(output_file) as f:
+            content = f.read()
+
+        # Verify file content is present
+        self.assertIn("Test md File", content)
+
+        # Verify simple theme content is present
+        self.assertIn('<html lang="en">', content)
+        self.assertIn("Proudly powered by", content)
+
+        # Verify our custom theme additions are NOT present
+        # (since we should be using the simple theme's template directly)
+        self.assertNotIn(
+            '<link rel="stylesheet" type="text/css" href="http://example.com/theme/css/style.css"',
+            content,
+        )
+
+    def test_theme_inheritance(self):
+        """Test that theme inheritance works correctly"""
+        settings = read_settings(
+            path=None,
+            override={
+                "THEME": self.temp_theme,
+                "PATH": CONTENT_DIR,
+                "OUTPUT_PATH": self.temp_output,
+                "CACHE_PATH": self.temp_cache,
+                "SITEURL": "http://example.com",
+                # Disable unnecessary output that might cause failures
+                "ARCHIVES_SAVE_AS": "",
+                "CATEGORIES_SAVE_AS": "",
+                "TAGS_SAVE_AS": "",
+                "AUTHOR_SAVE_AS": "",
+                "AUTHORS_SAVE_AS": "",
+            },
+        )
+
+        pelican = Pelican(settings=settings)
+        # Generate the site with muted output
+        mute(True)(pelican.run)()
+
+        # Check the output file
+        output_file = os.path.join(self.temp_output, "test-md-file.html")
+        self.assertTrue(os.path.exists(output_file))
+
+        with open(output_file) as f:
+            content = f.read()
+
+        # Verify inheritance worked
+        self.assertIn('<html lang="en">', content)  # From simple theme
+
+        # Verify super() maintained original head content
+        self.assertIn('<meta charset="utf-8"', content)
+
+        # Verify our changes were included
+        self.assertIn(
+            '<link rel="stylesheet" type="text/css" href="http://example.com/theme/css/style.css"',
+            content,
+        )
+        self.assertNotIn("Proudly powered by", content)
+        self.assertIn("New footer", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -40,33 +40,41 @@
   </head>
 
   <body>
-    <header>
-      <hgroup><h1><a href="{{ SITEURL }}/">{{ SITENAME }}</a></h1>{% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}</hgroup>
-      <nav><ul>
-        {% for title, link in MENUITEMS %}
-          <li><a href="{{ link }}">{{ title }}</a></li>
-        {% endfor %}
-        {% if DISPLAY_PAGES_ON_MENU %}
-          {% for p in pages %}
-            <li><a href="{{ SITEURL }}/{{ p.url }}" {% if p==page %} aria-current="page" {% endif %}>{{ p.title }}</a></li>
-          {% endfor %}
-        {% endif %}
-        {% if DISPLAY_CATEGORIES_ON_MENU %}
-          {% for cat, null in categories %}
-            <li><a href="{{ SITEURL }}/{{ cat.url }}" {% if cat==category %} aria-current="page" {% endif %}>{{ cat}}</a></li>
-          {% endfor %}
-        {% endif %}
-      </ul></nav>
-    </header>
-    <main>
-      {% block content %}
-      {% endblock %}
-    </main>
-    <footer>
-      <address>
-        Proudly powered by <a rel="nofollow" href="https://getpelican.com/">Pelican</a>,
-        which takes great advantage of <a rel="nofollow" href="https://www.python.org/">Python</a>.
-      </address>
-    </footer>
+    {% block body %}
+      <header>
+        {% block header %}
+          <hgroup><h1><a href="{{ SITEURL }}/">{{ SITENAME }}</a></h1>{% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}</hgroup>
+        {% endblock %}
+        {% block nav %}
+          <nav><ul>
+            {% for title, link in MENUITEMS %}
+              <li><a href="{{ link }}">{{ title }}</a></li>
+            {% endfor %}
+            {% if DISPLAY_PAGES_ON_MENU %}
+              {% for p in pages %}
+                <li><a href="{{ SITEURL }}/{{ p.url }}" {% if p==page %} aria-current="page" {% endif %}>{{ p.title }}</a></li>
+              {% endfor %}
+            {% endif %}
+            {% if DISPLAY_CATEGORIES_ON_MENU %}
+              {% for cat, null in categories %}
+                <li><a href="{{ SITEURL }}/{{ cat.url }}" {% if cat==category %} aria-current="page" {% endif %}>{{ cat}}</a></li>
+              {% endfor %}
+            {% endif %}
+          </ul></nav>
+        {% endblock %}
+      </header>
+      <main>
+        {% block content %}
+        {% endblock %}
+      </main>
+      <footer>
+        {% block footer %}
+          <address>
+            Proudly powered by <a rel="nofollow" href="https://getpelican.com/">Pelican</a>,
+            which takes great advantage of <a rel="nofollow" href="https://www.python.org/">Python</a>.
+          </address>
+        {% endblock %}
+      </footer>
+    {% endblock %}
   </body>
 </html>

--- a/pelican/themes/simple/templates/base.html
+++ b/pelican/themes/simple/templates/base.html
@@ -44,7 +44,7 @@
       <header>
         {% block header %}
           <hgroup><h1><a href="{{ SITEURL }}/">{{ SITENAME }}</a></h1>{% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}</hgroup>
-        {% endblock %}
+        {% endblock header %}
         {% block nav %}
           <nav><ul>
             {% for title, link in MENUITEMS %}
@@ -61,11 +61,11 @@
               {% endfor %}
             {% endif %}
           </ul></nav>
-        {% endblock %}
+        {% endblock nav %}
       </header>
       <main>
         {% block content %}
-        {% endblock %}
+        {% endblock content %}
       </main>
       <footer>
         {% block footer %}
@@ -73,8 +73,8 @@
             Proudly powered by <a rel="nofollow" href="https://getpelican.com/">Pelican</a>,
             which takes great advantage of <a rel="nofollow" href="https://www.python.org/">Python</a>.
           </address>
-        {% endblock %}
+        {% endblock footer %}
       </footer>
-    {% endblock %}
+    {% endblock body %}
   </body>
 </html>


### PR DESCRIPTION
This change makes it easier to create new themes by inheriting from the simple theme. It allows customization of the whole body (while still making use of the theme’s head), or individual parts of the body like header, menu, or footer.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
