### PR TITLE
feat: Change `IGNORE_FILES` setting default to all hidden files

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -150,12 +150,12 @@ Basic settings
 
       READERS = {'foo': FooReader}
 
-.. data:: IGNORE_FILES = ['.#*']
+.. data:: IGNORE_FILES = ['.*']
 
-   A list of glob patterns.  Files and directories matching any of these
-   patterns will be ignored by the processor. For example, the default
-   ``['.#*']`` will ignore emacs lock files, and ``['__pycache__']`` would
-   ignore Python 3's bytecode caches.
+   A list of glob patterns. Files and directories matching any of these patterns
+   will be ignored by the processor. For example, the default ``['.*']`` will
+   ignore "hidden" files and directories, and ``['__pycache__']`` would ignore
+   Python 3's bytecode caches.
 
 .. data:: MARKDOWN = {...}
 

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -157,7 +157,7 @@ DEFAULT_CONFIG = {
     "PYGMENTS_RST_OPTIONS": {},
     "TEMPLATE_PAGES": {},
     "TEMPLATE_EXTENSIONS": [".html"],
-    "IGNORE_FILES": [".#*"],
+    "IGNORE_FILES": [".*"],
     "SLUG_REGEX_SUBSTITUTIONS": [
         (r"[^\w\s-]", ""),  # remove non-alphabetical/whitespace/'-' chars
         (r"(?u)\A\s*", ""),  # strip leading whitespace


### PR DESCRIPTION
This is to avoid subtle behaviour that contributed to root cause of https://github.com/pelican-plugins/sitemap/issues/36

Specifically: if installing Pelican into a local virtualenv with the pdm or uv default name ".venv", then subdirectories of .venv will contain all of the test .rst and .md files.

If you then run Pelican in that same root directory using the default PATH value (".") then it will add those content files to the site.

# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [x] Updated **documentation** for changed code

(I haven't added a new test for the default setting, but I can if needed.)