### PR TITLE
Clarify meaning of “replacement indicator” in warning

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -358,8 +358,9 @@ class Content:
             origin = joiner(siteurl, Author(path, self.settings).url)
         else:
             logger.warning(
-                "Replacement Indicator '%s' not recognized, skipping replacement",
+                "Replacement Indicator %r not recognized in %r, skipping replacement",
                 what,
+                origin,
             )
 
         # keep all other parts, such as query, fragment, etc.

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -1036,7 +1036,7 @@ class TestStatic(LoggedTestCase):
         self.assertEqual(content, html)
         self.assertLogCountEqual(
             count=1,
-            msg="Replacement Indicator 'unknown' not recognized, "
+            msg="Replacement Indicator 'unknown' not recognized in '{unknown}foo', "
             "skipping replacement",
             level=logging.WARNING,
         )


### PR DESCRIPTION
Not always clear what was the issue with only the keyword.

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

After writing a long article, I got this warning message but I had to look in the code to understand what was wrong (used `{content}` while I wanted `{filename}`). Not really clear what we meant by "Replacement Indicator".

Before this commit:
```
$ make devserver
…
Serving site at: http://127.0.0.1:8000 - Tap CTRL-C to stop
[14:46:30] WARNING  Replacement Indicator 'content' not recognized, skipping replacement                                                                                                           contents.py:360
Done: Processed 210 articles, 24 drafts, 0 hidden articles, 1 page, 1 hidden page and 0 draft pages in 3.53 seconds.
```

After this commit
```
$ make devserver
…
Serving site at: http://127.0.0.1:8000 - Tap CTRL-C to stop
[14:45:47] WARNING  Replacement Indicator 'content' not recognized in '{content}/2024/my-shinny-article.md', skipping replacement                                           contents.py:360
Done: Processed 210 articles, 24 drafts, 0 hidden articles, 1 page, 1 hidden page and 0 draft pages in 3.05 seconds.
```

An alternative patch could be simply:
```diff
- "Replacement Indicator '%s' not recognized, skipping replacement"
+ "Replacement Indicator '{%s}' not recognized, skipping replacement"
```
I guess I would have understood as well. Let me know what you prefer.