### PR TITLE
fix: `SUMMARY_MAX_PARAGRAPHS` not respected in some combinations with `SUMMARY_MAX_LENGTH`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,4 @@
 Release type: patch
 
-Fix SUMMARY_MAX_PARAGRAPHS not being respected in some combinations with SUMMARY_MAX_LENGTH.
+- Change ``IGNORE_FILES`` setting default to ignore all hidden files
+- Fix ``SUMMARY_MAX_PARAGRAPHS`` not being respected in some combinations with ``SUMMARY_MAX_LENGTH``

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fix SUMMARY_MAX_PARAGRAPHS not being respected in some combinations with SUMMARY_MAX_LENGTH.

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -450,7 +450,7 @@ class Content:
             return content
 
         return truncate_html_words(
-            self.content,
+            content,
             self.settings["SUMMARY_MAX_LENGTH"],
             self.settings["SUMMARY_END_SUFFIX"],
         )


### PR DESCRIPTION
When, for example, the content is 2 paragraphs, each consisting of 30 words, and `SUMMARY_MAX_PARAGRAPHS=1` and `SUMMARY_MAX_LENGTH=50`, the current behavior produces a summary with 50 words and 2 paragraphs, effectively ignoring `SUMMARY_MAX_PARAGRAPHS`.

This change inverts this behavior: the resulting summary from the above situation will consist of the entire first 30 word paragraph.

In the case where the first paragraph(s) is longer than `SUMMARY_MAX_LENGTH`, the summary will still be truncated to that length.

This change brings the actual behavior in line with the documented behavior.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] ~Updated **documentation** for changed code~ no need for documentation changes

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
