### PR TITLE
Make build reproducible by reading envvar `SOURCE_DATE_EPOCH` if set

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,8 @@ extensions = [
 source_suffix = ".rst"
 master_doc = "index"
 project = project_data.get("name").upper()
-year = datetime.datetime.utcfromtimestamp(
-    int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+year = datetime.datetime.fromtimestamp(
+    int(os.environ.get("SOURCE_DATE_EPOCH", time.time())), datetime.timezone.utc
 ).year
 copyright = f"2010–{year}"  # noqa: RUF001
 exclude_patterns = ["_build"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 import datetime
 import os
-import time
 import sys
+import time
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -31,7 +31,9 @@ extensions = [
 source_suffix = ".rst"
 master_doc = "index"
 project = project_data.get("name").upper()
-year = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))).year
+year = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))
+).year
 copyright = f"2010–{year}"  # noqa: RUF001
 exclude_patterns = ["_build"]
 release = project_data.get("version")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import time
 import sys
 
 if sys.version_info >= (3, 11):
@@ -30,7 +31,7 @@ extensions = [
 source_suffix = ".rst"
 master_doc = "index"
 project = project_data.get("name").upper()
-year = datetime.datetime.now().date().year
+year = datetime.datetime.utcfromtimestamp(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))).year
 copyright = f"2010–{year}"  # noqa: RUF001
 exclude_patterns = ["_build"]
 release = project_data.get("version")


### PR DESCRIPTION
As part of the ongoing [Reproducible Builds](https://reproducible-builds.org/) project, packages in Debian/Ubuntu are routinely scanned and tested for build reproducibility. [A bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056571) was filed against the `pelican` package in Debian, so I'm just forwarding the patch that we've applied there to make it build reproducibly, i.e. by attempting to get the current datetime from a standard envvar, [SOURCE_DATE_EPOCH](https://reproducible-builds.org/docs/source-date-epoch/), if it's available. Thanks for considering this change!