### PR TITLE
Add support for Python 3.13 and drop EOL 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,6 @@ jobs:
         python: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: ubuntu
-            python: "3.8"
-          - os: ubuntu
             python: "3.9"
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: ubuntu
             python: "3.8"

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -6,7 +6,7 @@ import os
 import re
 from datetime import timezone
 from html import unescape
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Optional
 from urllib.parse import ParseResult, unquote, urljoin, urlparse, urlunparse
 
 try:
@@ -47,7 +47,7 @@ class Content:
     """
 
     default_template: Optional[str] = None
-    mandatory_properties: Tuple[str, ...] = ()
+    mandatory_properties: tuple[str, ...] = ()
 
     @deprecated_attribute(old="filename", new="source_path", since=(3, 2, 0))
     def filename():
@@ -56,10 +56,10 @@ class Content:
     def __init__(
         self,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         settings: Optional[Settings] = None,
         source_path: Optional[str] = None,
-        context: Optional[Dict[Any, Any]] = None,
+        context: Optional[dict[Any, Any]] = None,
     ):
         if metadata is None:
             metadata = {}
@@ -226,7 +226,7 @@ class Content:
         )
 
     @property
-    def url_format(self) -> Dict[str, Any]:
+    def url_format(self) -> dict[str, Any]:
         """Returns the URL, formatted with the proper values"""
         metadata = copy.copy(self.metadata)
         path = self.metadata.get("path", self.get_relative_source_path())
@@ -397,7 +397,7 @@ class Content:
         hrefs = self._get_intrasite_link_regex()
         return hrefs.sub(lambda m: self._link_replacer(siteurl, m), content)
 
-    def get_static_links(self) -> Set[str]:
+    def get_static_links(self) -> set[str]:
         static_links = set()
         hrefs = self._get_intrasite_link_regex()
         for m in hrefs.finditer(self._content):

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from functools import partial
 from itertools import chain, groupby
 from operator import attrgetter
-from typing import List, Optional, Set
+from typing import Optional
 
 from jinja2 import (
     BaseLoader,
@@ -158,8 +158,8 @@ class Generator:
         return False
 
     def get_files(
-        self, paths, exclude: Optional[List[str]] = None, extensions=None
-    ) -> Set[str]:
+        self, paths, exclude: Optional[list[str]] = None, extensions=None
+    ) -> set[str]:
         """Return a list of files to use, based on rules
 
         :param paths: the list pf paths to search (relative to self.path)
@@ -253,7 +253,7 @@ class Generator:
         # return the name of the class for logging purposes
         return self.__class__.__name__
 
-    def _check_disabled_readers(self, paths, exclude: Optional[List[str]]) -> None:
+    def _check_disabled_readers(self, paths, exclude: Optional[list[str]]) -> None:
         """Log warnings for files that would have been processed by disabled readers."""
         for fil in self.get_files(
             paths, exclude=exclude, extensions=self.readers.disabled_extensions

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -613,7 +613,7 @@ def configure_settings(settings: Settings) -> Settings:
     ]:
         if key in settings and not isinstance(settings[key], types):
             value = settings.pop(key)
-            logger.warn(
+            logger.warning(
                 "Detected misconfigured %s (%s), falling back to the default (%s)",
                 key,
                 value,

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -9,7 +9,7 @@ import sys
 from os.path import isabs
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from pelican.log import LimitFilter
 
@@ -24,7 +24,7 @@ def load_source(name: str, path: str) -> ModuleType:
 
 logger = logging.getLogger(__name__)
 
-Settings = Dict[str, Any]
+Settings = dict[str, Any]
 
 DEFAULT_THEME = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "themes", "notmyidea"

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from shutil import copy, rmtree
 from tempfile import mkdtemp
 from unittest.mock import MagicMock
@@ -1528,18 +1527,9 @@ class TestStaticGenerator(unittest.TestCase):
         self.generator.generate_context()
         self.generator.generate_output(None)
         self.assertTrue(os.path.islink(self.endfile))
-
-        # os.path.realpath is broken on Windows before python3.8 for symlinks.
-        # This is a (ugly) workaround.
-        # see: https://bugs.python.org/issue9949
-        if os.name == "nt" and sys.version_info < (3, 8):
-
-            def get_real_path(path):
-                return os.readlink(path) if os.path.islink(path) else path
-        else:
-            get_real_path = os.path.realpath
-
-        self.assertEqual(get_real_path(self.endfile), get_real_path(self.startfile))
+        self.assertEqual(
+            os.path.realpath(self.endfile), os.path.realpath(self.startfile)
+        )
 
     def test_delete_existing_file_before_mkdir(self):
         with open(self.startfile, "w") as f:

--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -3,7 +3,7 @@
 import argparse
 import locale
 import os
-from typing import Mapping
+from collections.abc import Mapping
 
 from jinja2 import Environment, FileSystemLoader
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import traceback
 import urllib
-from collections.abc import Hashable
+from collections.abc import Collection, Generator, Hashable, Iterable, Sequence
 from contextlib import contextmanager
 from functools import partial
 from html import entities
@@ -22,10 +22,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Collection,
-    Generator,
-    Iterable,
-    Sequence,
 )
 
 import dateutil.parser
@@ -133,8 +129,9 @@ class DateFormatter:
     def __call__(self, date: datetime.datetime, date_format: str) -> str:
         # on OSX, encoding from LC_CTYPE determines the unicode output in PY3
         # make sure it's same as LC_TIME
-        with temporary_locale(self.locale, locale.LC_TIME), temporary_locale(
-            self.locale, locale.LC_CTYPE
+        with (
+            temporary_locale(self.locale, locale.LC_TIME),
+            temporary_locale(self.locale, locale.LC_CTYPE),
         ):
             formatted = strftime(date, date_format)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Content Management System",
     "Topic :: Internet :: WWW/HTTP :: Site Management",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -28,7 +27,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Text Processing :: Markup :: reStructuredText",
 ]
-requires-python = ">=3.8.1,<4.0"
+requires-python = ">=3.9,<4.0"
 dependencies = [
     "blinker>=1.7.0",
     "docutils>=0.20.1",
@@ -39,7 +38,6 @@ dependencies = [
     "python-dateutil>=2.8.2",
     "rich>=13.6.0",
     "unidecode>=1.3.7",
-    "backports-zoneinfo>=0.2.1; python_version < \"3.9\"",
     "watchfiles>=0.21.0",
     "tzdata; sys_platform == 'win32'",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{3.8,3.9,3.10,3.11,3.12},docs
+envlist = py{3.8,3.9,3.10,3.11,3.12,3.13},docs
 
 [testenv]
 basepython =
@@ -8,6 +8,7 @@ basepython =
     py3.10: python3.10
     py3.11: python3.11
     py3.12: python3.12
+    py3.13: python3.13
 passenv = *
 usedevelop=True
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{3.8,3.9,3.10,3.11,3.12,3.13},docs
+envlist = py{3.9,3.10,3.11,3.12,3.13},docs
 
 [testenv]
 basepython =
-    py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
     py3.11: python3.11


### PR DESCRIPTION
# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [x] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->

Python 3.13 was released in October, and on the same day Python 3.8 reached end-of-life:

* https://devguide.python.org/versions/
