### PR TITLE
test:  Fix `test_typogrify_ignore_tags` due to Typogrify 2.1 changes

### DIFF
--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -411,8 +411,7 @@ class RstReaderTest(ReaderTest):
 
     def test_typogrify_ignore_tags(self):
         try:
-            # typogrify should be able to ignore user specified tags,
-            # but tries to be clever with widont extension
+            # typogrify should be able to ignore user specified tags.
             page = self.read_file(
                 path="article.rst", TYPOGRIFY=True, TYPOGRIFY_IGNORE_TAGS=["p"]
             )

--- a/pelican/tests/test_readers.py
+++ b/pelican/tests/test_readers.py
@@ -417,7 +417,7 @@ class RstReaderTest(ReaderTest):
                 path="article.rst", TYPOGRIFY=True, TYPOGRIFY_IGNORE_TAGS=["p"]
             )
             expected = (
-                "<p>THIS is some content. With some stuff to&nbsp;"
+                "<p>THIS is some content. With some stuff to "
                 "&quot;typogrify&quot;...</p>\n<p>Now with added "
                 'support for <abbr title="three letter acronym">'
                 "TLA</abbr>.</p>\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev = [
     "jinja2>=3.1.2",
     "lxml>=4.9.3",
     "markdown>=3.5.1",
-    "typogrify>=2.0.7",
+    "typogrify>=2.1.0",
     "sphinx>=7.1.2",
     "sphinxext-opengraph>=0.9.0",
     "furo==2023.9.10",


### PR DESCRIPTION
Typogrify's 'widont' filter used to ignore the list of 'ignore_tags', but this will be fixed in an upcoming version of Typogrify.

The **tests will fail with Typogrify 2.0.7** but work with justinmayer/typogrify#1.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output *__⚠️ See condition above!__*
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
