### PR TITLE
docs: Use raw string for the `PATH_METADATA` setting

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -118,7 +118,7 @@ How do I make my output folder structure identical to my content hierarchy?
 Try these settings::
 
     USE_FOLDER_AS_CATEGORY = False
-    PATH_METADATA = "(?P<path_no_ext>.*)\..*"
+    PATH_METADATA = r"(?P<path_no_ext>.*)\..*"
     ARTICLE_URL = ARTICLE_SAVE_AS = PAGE_URL = PAGE_SAVE_AS = "{path_no_ext}.html"
 
 How do I assign custom templates on a per-page basis?

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -458,7 +458,7 @@ If you don't want that flexibility and instead prefer that your generated
 output paths mirror your source content's filesystem path hierarchy, try the
 following settings::
 
-    PATH_METADATA = '(?P<path_no_ext>.*)\..*'
+    PATH_METADATA = r'(?P<path_no_ext>.*)\..*'
     ARTICLE_URL = ARTICLE_SAVE_AS = PAGE_URL = PAGE_SAVE_AS = '{path_no_ext}.html'
 
 Otherwise, you can use a variety of file metadata attributes within URL-related

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -144,7 +144,7 @@ DEFAULT_CONFIG = {
     "DEFAULT_ORPHANS": 0,
     "DEFAULT_METADATA": {},
     "FILENAME_METADATA": r"(?P<date>\d{4}-\d{2}-\d{2}).*",
-    "PATH_METADATA": "",
+    "PATH_METADATA": r"",
     "EXTRA_PATH_METADATA": {},
     "ARTICLE_PERMALINK_STRUCTURE": "",
     "TYPOGRIFY": False,


### PR DESCRIPTION
### 1. Summary

Currently, the Pelican documentation 2 times proposes this syntax:

```python
PATH_METADATA = "(?P<path_no_ext>.*)\..*"
```

It’s not a valid Python syntax. I fixed typos.

### 2. Style

I prefer raw strings to escaping backslashes due to the [**rule WPS342**](https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/consistency.html#wemake_python_styleguide.violations.consistency.ImplicitRawStringViolation) of wemake-python-styleguide:

> It is hard to read escape sequences inside regular strings, because they use `\\` double backslash for a single character escape.
>
> Use raw strings `r''` to rewrite the escape sequence with a `\` single backslash.

### 3. USE_FOLDER_AS_CATEGORY

I don’t understand why [**Pelican FAQ also recommends using `USE_FOLDER_AS_CATEGORY = False`**](https://docs.getpelican.com/en/latest/faq.html#how-do-i-make-my-output-folder-structure-identical-to-my-content-hierarchy) with the option `PATH_METADATA`.

If `USE_FOLDER_AS_CATEGORY = True`, Pelican still save the folder structure identical to the content hierarchy. `USE_FOLDER_AS_CATEGORY` is a stylistic (and in my opinion a useful) option. I propose removing `USE_FOLDER_AS_CATEGORY = False` from FAQ or explain in FAQ why this option is required.

Thanks.