### PR TITLE
Secure jinja scaping characters

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Set `autoescape=True` for jinja2

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -86,6 +86,7 @@ class Generator:
                     ),  # explicit ones
                 ]
             ),
+            autoescape=True,
             **self.settings["JINJA_ENVIRONMENT"],
         )
 

--- a/pelican/tools/pelican_quickstart.py
+++ b/pelican/tools/pelican_quickstart.py
@@ -45,6 +45,7 @@ _jinja_env = Environment(
     loader=FileSystemLoader(_TEMPLATES_DIR),
     trim_blocks=True,
     keep_trailing_newline=True,
+    autoescape=True,
 )
 
 


### PR DESCRIPTION
This PR enhances the security of the Pelican static site generator by setting `autoescape=True` in the Jinja2 Environment initialization. This change ensures that the Jinja2 template engine automatically escapes variables in templates, preventing potential Cross-Site Scripting (XSS) vulnerabilities. The update is applied to two files:

- pelican/generators.py
- pelican/tools/pelican_quickstart.py

This update improves the safety of the generated static content by mitigating risks associated with improperly escaped HTML.

Tests: Ran `black` against changed files.

# Pull Request Checklist

Resolves: 

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [X] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
