### PR TITLE
fix: Resolve `datetime` warnings

### DIFF
--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -4,7 +4,6 @@ import locale
 import logging
 import os
 import re
-from datetime import timezone
 from html import unescape
 from typing import Any, Optional
 from urllib.parse import ParseResult, unquote, urljoin, urlparse, urlunparse
@@ -593,7 +592,7 @@ class Article(Content):
             if self.date.tzinfo is None:
                 now = datetime.datetime.now()
             else:
-                now = datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
+                now = datetime.datetime.now(datetime.timezone.utc)
             if self.date > now:
                 self.status = "draft"
 


### PR DESCRIPTION
# Pull Request Checklist
This small PR resolves the `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code
