### PR TITLE
Change tuples to lists for SOCIAL and LINKS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -819,9 +819,9 @@ Time and Date
 
    .. parsed-literal::
 
-      LOCALE = ('usa', 'jpn',      # On Windows
+      LOCALE = ['usa', 'jpn',      # On Windows
                 'en_US', 'ja_JP'   # On Unix/Linux
-      )
+      ]
 
    For a list of available locales refer to `locales on Windows`_  or on
    Unix/Linux, use the ``locale -a`` command; see manpage

--- a/pelican/tests/default_conf.py
+++ b/pelican/tests/default_conf.py
@@ -12,20 +12,20 @@ DEFAULT_PAGINATION = 2
 FEED_RSS = "feeds/all.rss.xml"
 CATEGORY_FEED_RSS = "feeds/{slug}.rss.xml"
 
-LINKS = (
+LINKS = [
     ("Biologeek", "http://biologeek.org"),
     ("Filyb", "http://filyb.info/"),
     ("Libert-fr", "http://www.libert-fr.com"),
     ("N1k0", "http://prendreuncafe.com/blog/"),
     ("Tarek Ziadé", "http://ziade.org/blog"),
     ("Zubin Mithra", "http://zubin71.wordpress.com/"),
-)
+]
 
-SOCIAL = (
+SOCIAL = [
     ("twitter", "http://twitter.com/ametaireau"),
     ("lastfm", "http://lastfm.com/user/akounet"),
     ("github", "http://github.com/ametaireau"),
-)
+]
 
 # global metadata to all the contents
 DEFAULT_METADATA = {"yeah": "it is"}

--- a/pelican/tools/templates/pelicanconf.py.jinja2
+++ b/pelican/tools/templates/pelicanconf.py.jinja2
@@ -16,18 +16,18 @@ AUTHOR_FEED_ATOM = None
 AUTHOR_FEED_RSS = None
 
 # Blogroll
-LINKS = (
+LINKS = [
     ("Pelican", "https://getpelican.com/"),
     ("Python.org", "https://www.python.org/"),
     ("Jinja2", "https://palletsprojects.com/p/jinja/"),
     ("You can modify those links in your config file", "#"),
-)
+]
 
 # Social widget
-SOCIAL = (
+SOCIAL = [
     ("You can add links in your config file", "#"),
     ("Another social link", "#"),
-)
+]
 
 DEFAULT_PAGINATION = {{default_pagination}}
 

--- a/samples/pelican.conf.py
+++ b/samples/pelican.conf.py
@@ -17,20 +17,20 @@ DEFAULT_DATE = (2012, 3, 2, 14, 1, 1)
 FEED_ALL_RSS = "feeds/all.rss.xml"
 CATEGORY_FEED_RSS = "feeds/{slug}.rss.xml"
 
-LINKS = (
+LINKS = [
     ("Biologeek", "http://biologeek.org"),
     ("Filyb", "http://filyb.info/"),
     ("Libert-fr", "http://www.libert-fr.com"),
     ("N1k0", "http://prendreuncafe.com/blog/"),
     ("Tarek Ziadé", "http://ziade.org/blog"),
     ("Zubin Mithra", "http://zubin71.wordpress.com/"),
-)
+]
 
-SOCIAL = (
+SOCIAL = [
     ("twitter", "http://twitter.com/ametaireau"),
     ("lastfm", "http://lastfm.com/user/akounet"),
     ("github", "http://github.com/ametaireau"),
-)
+]
 
 # global metadata to all the contents
 DEFAULT_METADATA = {"yeah": "it is"}

--- a/samples/pelican.conf_FR.py
+++ b/samples/pelican.conf_FR.py
@@ -21,20 +21,20 @@ ARTICLE_SAVE_AS = ARTICLE_URL + "index.html"
 FEED_ALL_RSS = "feeds/all.rss.xml"
 CATEGORY_FEED_RSS = "feeds/{slug}.rss.xml"
 
-LINKS = (
+LINKS = [
     ("Biologeek", "http://biologeek.org"),
     ("Filyb", "http://filyb.info/"),
     ("Libert-fr", "http://www.libert-fr.com"),
     ("N1k0", "http://prendreuncafe.com/blog/"),
     ("Tarek Ziadé", "http://ziade.org/blog"),
     ("Zubin Mithra", "http://zubin71.wordpress.com/"),
-)
+]
 
-SOCIAL = (
+SOCIAL = [
     ("twitter", "http://twitter.com/ametaireau"),
     ("lastfm", "http://lastfm.com/user/akounet"),
     ("github", "http://github.com/ametaireau"),
-)
+]
 
 # global metadata to all the contents
 DEFAULT_METADATA = {"yeah": "it is"}


### PR DESCRIPTION
In the documentation, both `SOCIAL` and `LINKS` are described as a list of tuples, but all examples show them as tuples of tuples. It makes the most sense for them to be lists, so the examples should match the docs going forward.

Similarly, `LOCALE` is described as a list, but the examples show it as a tuple. Likewise, the examples should be lists, in line with the description.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
