### PR TITLE
docs: Fix default `SLUG_REGEX_SUBSTITUTIONS`

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -715,10 +715,10 @@ corresponding ``*_URL`` setting as string, while others hard-code them:
    backward compatibility with existing URLs. The default is::
 
        [
-           (r'[^\\w\\s-]', ''),   # remove non-alphabetical/whitespace/'-' chars
-           (r'(?u)\\A\\s*', ''),  # strip leading whitespace
-           (r'(?u)\\s*\\Z', ''),  # strip trailing whitespace
-           (r'[-\\s]+', '-'),     # reduce multiple whitespace or '-' to single '-'
+           (r'[^\w\s-]', ''),   # remove non-alphabetical/whitespace/'-' chars
+           (r'(?u)\A\s*', ''),  # strip leading whitespace
+           (r'(?u)\s*\Z', ''),  # strip trailing whitespace
+           (r'[-\s]+', '-'),     # reduce multiple whitespace or '-' to single '-'
        ]
 
 .. data:: AUTHOR_REGEX_SUBSTITUTIONS


### PR DESCRIPTION
Backslashes should not have been doubled, given the defaults are raw strings.

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
