### PR TITLE
Limit Dependabot scope to GitHub Actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,8 @@
 # See https://docs.github.com/en/free-pro-team@latest/
 #  github/administering-a-repository/enabling-and-disabling-version-updates
-
+---
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Sometimes we intentionally pin versions for specific packages that can affect Pelican’s functional test output — such as Pygments, Jinja2, and Markdown — and thus automated Dependabot PRs for those packages are spurious and unwanted.

Meanwhile, [Dependabot will happily (and unhelpfully) generate a PR to update the Pygments version](https://github.com/getpelican/pelican/pull/3481), even though Pygments is [clearly and explicitly pinned in `pyproject.toml`](https://github.com/getpelican/pelican/blob/9e3e1325c0cdcabd7d0a99c78b7eadc170656f22/pyproject.toml#L37).

To resolve this, this pull request removes the portion of Dependabot’s configuration that generates PRs for Python package version updates, regulating Dependabot to only updating GitHub Actions version numbers in workflows.

------------------------

*Original commit that added the configuration that is removed herein:* https://github.com/getpelican/pelican/commit/8c7c29e4f2a35124f2bfe7905fd0a5a334f7e056