### PR TITLE
Update Ruff to 0.12.2 and fix new complaints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,14 +16,14 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # ruff version should match the one in pyproject.toml
-    rev: v0.7.2
+    rev: v0.12.2
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/rtts/djhtml
-    rev: '3.0.7'
+    rev: '3.0.8'
     hooks:
       - id: djhtml
       - id: djcss

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ version = ".".join(release.split(".")[:1])
 last_stable = project_data.get("version")
 rst_prolog = f"""
 .. |last_stable| replace:: :pelican-doc:`{last_stable}`
-.. |min_python| replace:: {project_data.get('requires-python').split(",")[0]}
+.. |min_python| replace:: {project_data.get("requires-python").split(",")[0]}
 """
 
 extlinks = {"pelican-doc": ("https://docs.getpelican.com/en/latest/%s.html", "%s")}

--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -402,8 +402,7 @@ def parse_arguments(argv=None):
         "--autoreload",
         dest="autoreload",
         action="store_true",
-        help="Relaunch pelican each time a modification occurs"
-        " on the content files.",
+        help="Relaunch pelican each time a modification occurs on the content files.",
     )
 
     parser.add_argument(
@@ -446,8 +445,7 @@ def parse_arguments(argv=None):
         choices=("errors", "warnings"),
         default="",
         help=(
-            "Exit the program with non-zero status if any "
-            "errors/warnings encountered."
+            "Exit the program with non-zero status if any errors/warnings encountered."
         ),
     )
 

--- a/pelican/cache.py
+++ b/pelican/cache.py
@@ -1,3 +1,4 @@
+import gzip
 import hashlib
 import logging
 import os
@@ -22,8 +23,6 @@ class FileDataCacher:
         self._cache_path = os.path.join(self.settings["CACHE_PATH"], cache_name)
         self._cache_data_policy = caching_policy
         if self.settings["GZIP_CACHE"]:
-            import gzip
-
             self._cache_open = gzip.open
         else:
             self._cache_open = open

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -342,8 +342,7 @@ class Content:
                     value.geturl(),
                     extra={
                         "limit_msg": (
-                            "Other resources were not found "
-                            "and their urls not replaced"
+                            "Other resources were not found and their urls not replaced"
                         )
                     },
                 )

--- a/pelican/log.py
+++ b/pelican/log.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections import defaultdict
 
 from rich.console import Console
@@ -156,8 +157,6 @@ def init(
 
 
 def log_warnings():
-    import warnings
-
     logging.captureWarnings(True)
     warnings.simplefilter("default", DeprecationWarning)
     init(logging.DEBUG, name="py.warnings")

--- a/pelican/paginator.py
+++ b/pelican/paginator.py
@@ -53,7 +53,7 @@ class Paginator:
         "Returns the total number of pages."
         if self._num_pages is None:
             hits = max(1, self.count - self.orphans)
-            self._num_pages = int(ceil(hits / (float(self.per_page) or 1)))
+            self._num_pages = ceil(hits / (float(self.per_page) or 1))
         return self._num_pages
 
     num_pages = property(_get_num_pages)

--- a/pelican/plugins/_utils.py
+++ b/pelican/plugins/_utils.py
@@ -19,7 +19,7 @@ def iter_namespace(ns_pkg):
 
 def get_namespace_plugins(ns_pkg=None):
     if ns_pkg is None:
-        import pelican.plugins as ns_pkg
+        import pelican.plugins as ns_pkg  # noqa: PLC0415
 
     return {
         name: importlib.import_module(name)
@@ -29,7 +29,7 @@ def get_namespace_plugins(ns_pkg=None):
 
 
 def list_plugins(ns_pkg=None):
-    from pelican.log import init as init_logging
+    from pelican.log import init as init_logging  # noqa: PLC0415
 
     init_logging(logging.INFO)
     ns_plugins = get_namespace_plugins(ns_pkg)

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -630,8 +630,9 @@ class Readers(FileStampDataCacher):
 
         # eventually filter the content with typogrify if asked so
         if self.settings["TYPOGRIFY"]:
-            import smartypants
-            from typogrify.filters import typogrify
+            # typogrify is an optional feature, user may not have it installed
+            import smartypants  # noqa: PLC0415
+            from typogrify.filters import typogrify  # noqa: PLC0415
 
             typogrify_dashes = self.settings["TYPOGRIFY_DASHES"]
             if typogrify_dashes == "oldschool":
@@ -657,7 +658,7 @@ class Readers(FileStampDataCacher):
                     return typogrify(
                         text,
                         self.settings["TYPOGRIFY_IGNORE_TAGS"],
-                        **{f: False for f in self.settings["TYPOGRIFY_OMIT_FILTERS"]},
+                        **dict.fromkeys(self.settings["TYPOGRIFY_OMIT_FILTERS"], False),
                     )
                 except TypeError:
                     try:

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -12,6 +12,7 @@ from types import ModuleType
 from typing import Any, Optional
 
 from pelican.log import LimitFilter
+from pelican.paginator import PaginationRule
 
 
 def load_source(name: str, path: str) -> ModuleType:
@@ -320,8 +321,7 @@ def handle_deprecated_settings(settings: Settings) -> Settings:
     # EXTRA_TEMPLATES_PATHS -> THEME_TEMPLATES_OVERRIDES
     if "EXTRA_TEMPLATES_PATHS" in settings:
         logger.warning(
-            "EXTRA_TEMPLATES_PATHS is deprecated use "
-            "THEME_TEMPLATES_OVERRIDES instead."
+            "EXTRA_TEMPLATES_PATHS is deprecated use THEME_TEMPLATES_OVERRIDES instead."
         )
         if settings.get("THEME_TEMPLATES_OVERRIDES"):
             raise Exception(
@@ -453,8 +453,7 @@ def handle_deprecated_settings(settings: Settings) -> Settings:
                 settings[key] = _printf_s_to_format_field(settings[key], "lang")
             except ValueError:
                 logger.warning(
-                    "Failed to convert %%s to {lang} for %s. "
-                    "Falling back to default.",
+                    "Failed to convert %%s to {lang} for %s. Falling back to default.",
                     key,
                 )
                 settings[key] = DEFAULT_CONFIG[key]
@@ -476,8 +475,7 @@ def handle_deprecated_settings(settings: Settings) -> Settings:
                 settings[key] = _printf_s_to_format_field(settings[key], "slug")
             except ValueError:
                 logger.warning(
-                    "Failed to convert %%s to {slug} for %s. "
-                    "Falling back to default.",
+                    "Failed to convert %%s to {slug} for %s. Falling back to default.",
                     key,
                 )
                 settings[key] = DEFAULT_CONFIG[key]
@@ -689,8 +687,6 @@ def configure_settings(settings: Settings) -> Settings:
         )
 
     # fix up pagination rules
-    from pelican.paginator import PaginationRule
-
     pagination_rules = [
         PaginationRule(*r)
         for r in settings.get(

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -916,10 +916,7 @@ class TestArticlesGenerator(unittest.TestCase):
             "This is a super article !",
             "This is a super article !",
             "This is an article with category !",
-            (
-                "This is an article with multiple authors in lastname, "
-                "firstname format!"
-            ),
+            ("This is an article with multiple authors in lastname, firstname format!"),
             "This is an article with multiple authors in list format!",
             "This is an article with multiple authors!",
             "This is an article with multiple authors!",

--- a/pelican/tests/test_paginator.py
+++ b/pelican/tests/test_paginator.py
@@ -3,7 +3,7 @@ import locale
 from jinja2.utils import generate_lorem_ipsum
 
 from pelican.contents import Article, Author
-from pelican.paginator import Paginator
+from pelican.paginator import PaginationRule, Paginator
 from pelican.settings import DEFAULT_CONFIG
 from pelican.tests.support import get_settings, unittest
 
@@ -35,8 +35,6 @@ class TestPage(unittest.TestCase):
     def test_save_as_preservation(self):
         settings = get_settings()
         # fix up pagination rules
-        from pelican.paginator import PaginationRule
-
         pagination_rules = [
             PaginationRule(*r)
             for r in settings.get(
@@ -56,8 +54,6 @@ class TestPage(unittest.TestCase):
         self.assertEqual(page.save_as, "foobar.foo")
 
     def test_custom_pagination_pattern(self):
-        from pelican.paginator import PaginationRule
-
         settings = get_settings()
         settings["PAGINATION_PATTERNS"] = [
             PaginationRule(*r)
@@ -81,8 +77,6 @@ class TestPage(unittest.TestCase):
         self.assertEqual(page2.url, "//blog.my.site/2/")
 
     def test_custom_pagination_pattern_last_page(self):
-        from pelican.paginator import PaginationRule
-
         settings = get_settings()
         settings["PAGINATION_PATTERNS"] = [
             PaginationRule(*r)

--- a/pelican/tests/test_plugins.py
+++ b/pelican/tests/test_plugins.py
@@ -23,7 +23,7 @@ def tmp_namespace_path(path):
     """
     # This avoids calls to internal `pelican.plugins.__path__._recalculate()`
     # as it should not be necessary
-    import pelican
+    import pelican  # noqa: PLC0415
 
     old_path = pelican.__path__[:]
     try:
@@ -41,8 +41,8 @@ class PluginTest(unittest.TestCase):
     _NORMAL_PLUGIN_FOLDER = os.path.join(_PLUGIN_FOLDER, "normal_plugin")
 
     def test_namespace_path_modification(self):
-        import pelican
-        import pelican.plugins
+        import pelican  # noqa: PLC0415
+        import pelican.plugins  # noqa: PLC0415
 
         old_path = pelican.__path__[:]
 

--- a/pelican/tests/test_rstdirectives.py
+++ b/pelican/tests/test_rstdirectives.py
@@ -1,12 +1,11 @@
 from unittest.mock import Mock
 
+from pelican.rstdirectives import abbr_role
 from pelican.tests.support import unittest
 
 
 class Test_abbr_role(unittest.TestCase):
     def call_it(self, text):
-        from pelican.rstdirectives import abbr_role
-
         rawtext = text
         lineno = 42
         inliner = Mock(name="inliner")

--- a/pelican/tools/pelican_themes.py
+++ b/pelican/tools/pelican_themes.py
@@ -17,8 +17,7 @@ try:
     import pelican
 except ImportError:
     err(
-        "Cannot import pelican.\nYou must "
-        "install Pelican in order to run this script.",
+        "Cannot import pelican.\nYou must install Pelican in order to run this script.",
         -1,
     )
 

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import sys
 import traceback
+import unicodedata
 import urllib
 from collections.abc import Collection, Generator, Hashable, Iterable, Sequence
 from contextlib import contextmanager
@@ -25,6 +26,7 @@ from typing import (
 )
 
 import dateutil.parser
+import unidecode
 from watchfiles import Change
 
 try:
@@ -259,10 +261,6 @@ def slugify(
     For a set of sensible default regex substitutions to pass to regex_subs
     look into pelican.settings.DEFAULT_CONFIG['SLUG_REGEX_SUBSTITUTIONS'].
     """
-
-    import unicodedata
-
-    import unidecode
 
     def normalize_unicode(text: str) -> str:
         # normalize text by compatibility composition
@@ -796,8 +794,7 @@ def order_content(
                                 content.get_relative_source_path(),
                                 extra={
                                     "limit_msg": (
-                                        "More files are missing "
-                                        "the needed attribute."
+                                        "More files are missing the needed attribute."
                                     )
                                 },
                             )

--- a/pelican/writers.py
+++ b/pelican/writers.py
@@ -261,8 +261,7 @@ class Writer:
             # generated pages, and write
             for page_num in range(next(iter(paginators.values())).num_pages):
                 paginated_kwargs = kwargs.copy()
-                for key in paginators.keys():
-                    paginator = paginators[key]
+                for key, paginator in paginators.items():
                     previous_page = paginator.page(page_num) if page_num > 0 else None
                     page = paginator.page(page_num + 1)
                     next_page = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     "tox>=4.11.3",
     "invoke>=2.2.0",
     # ruff version should match the one in .pre-commit-config.yaml
-    "ruff==0.7.2",
+    "ruff==0.12.2",
     "tomli>=2.0.1; python_version < \"3.11\"",
 ]
 
@@ -111,7 +111,6 @@ source-includes = [
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
-
 
 [tool.ruff.lint]
 # see https://docs.astral.sh/ruff/configuration/#using-pyprojecttoml

--- a/tasks.py
+++ b/tasks.py
@@ -3,10 +3,11 @@ from pathlib import Path
 from shutil import which
 
 from invoke import task
+from livereload import Server
 
 PKG_NAME = "pelican"
 PKG_PATH = Path(PKG_NAME)
-DOCS_PORT = os.environ.get("DOCS_PORT", 8000)
+DOCS_PORT = int(os.environ.get("DOCS_PORT", "8000"))
 BIN_DIR = "bin" if os.name != "nt" else "Scripts"
 PTY = os.name != "nt"
 ACTIVE_VENV = os.environ.get("VIRTUAL_ENV", None)
@@ -29,8 +30,6 @@ def docbuild(c):
 @task(docbuild)
 def docserve(c):
     """Serve docs at http://localhost:$DOCS_PORT/ (default port is 8000)"""
-    from livereload import Server
-
     server = Server()
     server.watch("docs/conf.py", lambda: docbuild(c))
     server.watch("CONTRIBUTING.rst", lambda: docbuild(c))


### PR DESCRIPTION
~~Also: announce target-version="py39" in pyproject.toml to be explicit.~~ _JM: Reverted, as this is unnecessary._

Some changes were automatic (from ruff), mostly formatting, but a number of changes are manual, most notably moving imports to the top of the file unless there seemed some reason not to.

- [X] Ensured **tests pass** and (if applicable) updated functional test output
- [X] Conformed to **code style guidelines** by running appropriate linting tools
