### PR TITLE
Enable `flake8-unused-arguments` Ruff rule.

### DIFF
--- a/pelican/__init__.py
+++ b/pelican/__init__.py
@@ -252,6 +252,7 @@ class Pelican:
 
 class PrintSettings(argparse.Action):
     def __call__(self, parser, namespace, values, option_string):
+        del option_string  # Unused argument
         init_logging(name=__name__)
 
         try:
@@ -287,6 +288,7 @@ class PrintSettings(argparse.Action):
 
 class ParseOverrides(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
+        del parser, option_string  # Unused arguments
         overrides = {}
         for item in values:
             try:

--- a/pelican/contents.py
+++ b/pelican/contents.py
@@ -431,7 +431,7 @@ class Content:
         return self.get_content(self.get_siteurl())
 
     @memoized
-    def get_summary(self, siteurl: str) -> str:
+    def get_summary(self, _siteurl: str) -> str:
         """Returns the summary of an article.
 
         This is based on the summary metadata if set, otherwise truncate the
@@ -552,6 +552,7 @@ class SkipStub(Content):
     def __init__(
         self, content, metadata=None, settings=None, source_path=None, context=None
     ):
+        del content, metadata, settings, context  # Unused arguments
         self.source_path = source_path
 
     def is_valid(self):

--- a/pelican/generators.py
+++ b/pelican/generators.py
@@ -296,6 +296,7 @@ class _FileLoader(BaseLoader):
         self.fullpath = os.path.join(basedir, path)
 
     def get_source(self, environment, template):
+        del environment  # Unused argument
         if template != self.path or not os.path.exists(self.fullpath):
             raise TemplateNotFound(template)
         mtime = os.path.getmtime(self.fullpath)
@@ -1022,6 +1023,7 @@ class StaticGenerator(Generator):
         signals.static_generator_finalized.send(self)
 
     def generate_output(self, writer):
+        del writer  # Unused argument
         self._copy_paths(
             self.settings["THEME_STATIC_PATHS"],
             self.theme,
@@ -1131,6 +1133,7 @@ class SourceFileGenerator(Generator):
         copy(obj.source_path, dest)
 
     def generate_output(self, writer=None):
+        del writer  # Unused argument
         logger.info("Generating source files...")
         for obj in chain(self.context["articles"], self.context["pages"]):
             self._create_source(obj)

--- a/pelican/readers.py
+++ b/pelican/readers.py
@@ -45,15 +45,15 @@ DUPLICATES_DEFINITIONS_ALLOWED = {
 
 METADATA_PROCESSORS = {
     "tags": lambda x, y: ([Tag(tag, y) for tag in ensure_metadata_list(x)] or _DISCARD),
-    "date": lambda x, y: get_date(x.replace("_", " ")),
-    "modified": lambda x, y: get_date(x),
-    "status": lambda x, y: x.strip() or _DISCARD,
+    "date": lambda x, _y: get_date(x.replace("_", " ")),
+    "modified": lambda x, _y: get_date(x),
+    "status": lambda x, _y: x.strip() or _DISCARD,
     "category": lambda x, y: _process_if_nonempty(Category, x, y),
     "author": lambda x, y: _process_if_nonempty(Author, x, y),
     "authors": lambda x, y: (
         [Author(author, y) for author in ensure_metadata_list(x)] or _DISCARD
     ),
-    "slug": lambda x, y: x.strip() or _DISCARD,
+    "slug": lambda x, _y: x.strip() or _DISCARD,
 }
 
 logger = logging.getLogger(__name__)
@@ -121,6 +121,7 @@ class BaseReader:
 
     def read(self, source_path):
         "No-op parser"
+        del source_path  # Unused argument
         content = None
         metadata = {}
         return content, metadata
@@ -165,6 +166,7 @@ class PelicanHTMLTranslator(HTMLTranslator):
         self.body.append(self.starttag(node, "abbr", "", **attrs))
 
     def depart_abbreviation(self, node):
+        del node  # Unused argument
         self.body.append("</abbr>")
 
     def visit_image(self, node):

--- a/pelican/rstdirectives.py
+++ b/pelican/rstdirectives.py
@@ -79,6 +79,7 @@ class abbreviation(nodes.Inline, nodes.TextElement):
 
 
 def abbr_role(typ, rawtext, text, lineno, inliner, options=None, content=None):
+    del typ, rawtext, lineno, inliner, options, content  # Unused arguments
     text = utils.unescape(text)
     m = _abbr_re.search(text)
     if m is None:

--- a/pelican/tests/test_contents.py
+++ b/pelican/tests/test_contents.py
@@ -333,7 +333,7 @@ class TestPage(TestBase):
         self.assertEqual("custom", custom_page.template)
 
     def test_signal(self):
-        def receiver_test_function(sender):
+        def receiver_test_function(_sender):
             receiver_test_function.has_been_called = True
 
         receiver_test_function.has_been_called = False

--- a/pelican/tests/test_importer.py
+++ b/pelican/tests/test_importer.py
@@ -552,7 +552,7 @@ class TestWordpressXMLAttachements(TestCaseWithCLocale):
 class TestTumblrImporter(TestCaseWithCLocale):
     @patch("pelican.tools.pelican_import._get_tumblr_posts")
     def test_posts(self, get):
-        def get_posts(api_key, blogname, offset=0):
+        def get_posts(_api_key, _blogname, offset=0):
             if offset > 0:
                 return []
 
@@ -603,7 +603,7 @@ class TestTumblrImporter(TestCaseWithCLocale):
 
     @patch("pelican.tools.pelican_import._get_tumblr_posts")
     def test_video_embed(self, get):
-        def get_posts(api_key, blogname, offset=0):
+        def get_posts(_api_key, _blogname, offset=0):
             if offset > 0:
                 return []
 
@@ -657,7 +657,7 @@ class TestTumblrImporter(TestCaseWithCLocale):
 
     @patch("pelican.tools.pelican_import._get_tumblr_posts")
     def test_broken_video_embed(self, get):
-        def get_posts(api_key, blogname, offset=0):
+        def get_posts(_api_key, _blogname, offset=0):
             if offset > 0:
                 return []
 

--- a/pelican/tests/test_server.py
+++ b/pelican/tests/test_server.py
@@ -8,7 +8,7 @@ from pelican.tests.support import unittest
 
 
 class MockRequest:
-    def makefile(self, *args, **kwargs):
+    def makefile(self, *_args, **_kwargs):
         return BytesIO(b"")
 
 

--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -941,7 +941,6 @@ def fields2pelican(
     strip_raw=False,
     disable_slugs=False,
     dirpage=False,
-    filename_template=None,
     filter_author=None,
     wp_custpost=False,
     wp_attach=False,

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import re
 import shutil
-import sys
 import traceback
 import unicodedata
 import urllib
@@ -215,7 +214,7 @@ def deprecated_attribute(
         _warn()
         setattr(self, new, value)
 
-    def decorator(dummy):
+    def decorator(_dummy):
         return property(fget=fget, fset=fset, doc=doc)
 
     return decorator
@@ -235,9 +234,7 @@ def get_date(string: str) -> datetime.datetime:
 
 
 @contextmanager
-def pelican_open(
-    filename: str, mode: str = "r", strip_crs: bool = (sys.platform == "win32")
-) -> Generator[str, None, None]:
+def pelican_open(filename: str, mode: str = "r") -> Generator[str, None, None]:
     """Open a file and return its content"""
 
     # utf-8-sig will clear any BOM if present
@@ -493,6 +490,7 @@ class _HTMLWordTruncator(HTMLParser):
             self.add_word(self.last_word_end)
 
     def handle_starttag(self, tag: str, attrs: Any) -> None:
+        del attrs  # Unused argument
         self.add_last_word()
         if tag not in self._singlets:
             self.open_tags.insert(0, tag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ select = [
 
     # the rest in alphabetical order:
     "A",   # flake8-builtins
-    # TODO: "ARG", # flake8-unused-arguments
+    "ARG", # flake8-unused-arguments
     "B",   # flake8-bugbear
     # TODO: "BLE", # flake8-blind-except
     # TODO: Do I want "COM", # flake8-commas


### PR DESCRIPTION
# Pull Request Checklist

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] ~Updated **documentation** for changed code~

Some points:
* Where `del` has been run on an argument, I have reason to believe the function/method _could_ be called by keyword (due to polymorphism or duck typing), so I will not rename. Alternatively, I can change this to a Ruff suppression. Considerations:
  1. Using `del` avoids the need for suppressions, thus is a long-term solution.
  2. Using Ruff suppressions (e.g. `# noqa: ARG001`) is arguably uglier and may imply that the problem still needs solving. With that said, in the future, perhaps the rule will be more particular and raise fewer false positives, in which case `RUF100` will catch the suppression and allow us to remove it easily.
* `get_summary` - I'm not sure where this is actually used, but it doesn't seem to override anything, nor does it seem to be overriden by anything, so I figured (given there is some funky caching going on with the `memoize` decorator) I would prefix the argument with `_`.
* All unused lambda arguments now have `_` prefixes. Anyone calling keyword arguments for lambda functions is already doing something wrong.
* `receiver_test_function`, `get_posts`, and `makefile` are defined within a testing context, and keyword arguments are not used on them, so safe to rename their arguments.
* `fields2pelican` genuinely doesn't seem to use it's argument `filename_template`, and it doesn't seem like Pelican users (as far as I can tell) use it either, so I've removed it.
* `decorator` does not use its argument, but it is always passed in as a positional argument, so prefixing with `_`.
* `pelican_open` does not use `strip_crs` as far as I can tell, so I've removed it.