### PR TITLE
Exclude Apple debugging artifacts from package builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,9 @@ source-includes = [
     "docs/changelog.rst",
     "samples/",
 ]
-# Don't include Apple debugging symbols
-excludes = ["pelican/build/*"]
+excludes = [
+    "pelican/build/"
+]
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
c.f. https://backend.pdm-project.org/build_config/#include-or-exclude-files

Resolves: #3517
