### PR TITLE
Add `page_content` block for better template inheritance

### DIFF
--- a/pelican/themes/simple/templates/page.html
+++ b/pelican/themes/simple/templates/page.html
@@ -20,7 +20,7 @@
     {% import 'translations.html' as translations with context %}
     {{ translations.translations_for(page) }}
 
-    {% block page_content %}{{ page.content }}{% endblock %}
+    {% block page_content %}{{ page.content }}{% endblock page_content %}
 
     {% if page.modified %}
       <footer>


### PR DESCRIPTION
This adds a `page_content` block that can be replaced in a child template.

As an example, our use case is to extract a list of links from the metadata and add them to the top of the content. Currently we need to copy most of this template to achieve that.