### PR TITLE
fix: Move `livereload` import inside `docserve()` task

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Move livereload import inside docserve() to fix invoke setup in fresh environments

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-Release type: patch
-
-Move livereload import inside docserve() to fix invoke setup in fresh environments

--- a/tasks.py
+++ b/tasks.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from shutil import which
 
 from invoke import task
-from livereload import Server
 
 PKG_NAME = "pelican"
 PKG_PATH = Path(PKG_NAME)
@@ -30,6 +29,8 @@ def docbuild(c):
 @task(docbuild)
 def docserve(c):
     """Serve docs at http://localhost:$DOCS_PORT/ (default port is 8000)"""
+    from livereload import Server  # noqa: PLC0415
+
     server = Server()
     server.watch("docs/conf.py", lambda: docbuild(c))
     server.watch("CONTRIBUTING.rst", lambda: docbuild(c))


### PR DESCRIPTION
This fixes 'invoke setup' failing in fresh virtual environments. The top-level import of livereload caused tasks.py to fail on import before any task could execute, since livereload is a dev dependency only installed by pdm during the setup process.

# Pull Request Checklist

Resolves: #issue-number-here <!-- Only if related issue *already* exists — otherwise remove this line -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
