### PR TITLE
Ensure `URLWrapper.__str__()` returns a string

### DIFF
--- a/pelican/urlwrappers.py
+++ b/pelican/urlwrappers.py
@@ -95,7 +95,7 @@ class URLWrapper:
         return False
 
     def __str__(self):
-        return self.name
+        return self.name or ""
 
     def __repr__(self):
         return f"<{type(self).__name__} {self._name!r}>"


### PR DESCRIPTION
This could otherwise cause an error if a setting, such as `AUTHOR`, was set to `None`:

```
CRITICAL TypeError: __str__ returned non-string (type NoneType)  __init__.py:683

Traceback (most recent call last):
    File "pelican/pelican/__init__.py", line 679, in main
    pelican.run()
    File "pelican/pelican/__init__.py", line 143, in run
    p.generate_output(writer)
    File "pelican/pelican/generators.py", line 842, in
generate_output
    self.generate_feeds(writer)
    File "pelican/pelican/generators.py", line 371, in
generate_feeds
    writer.write_feed(
    File "pelican/pelican/writers.py", line 158, in write_feed
    self._add_item_to_the_feed(feed, element)
    File "pelican/pelican/writers.py", line 86, in
_add_item_to_the_feed
    feed.add_item(
    File "~/.virtualenvs/pelican/lib/python3.11/site-packages/feedgenerator/django/utils/feedgenerator.py", line 203, in add_item
    "author_name": to_str(author_name),
                    ^^^^^^^^^^^^^^^^^^^
    File "~/.virtualenvs/pelican/lib/python3.11/site-packages/feedgenerator/django/utils/feedgenerator.py", line 193, in to_str
    return str(s) if s is not None else s
            ^^^^^^
TypeError: __str__ returned non-string (type NoneType)
```