### PR TITLE
fix: Fix typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ ignore = [
     "PLR2004"
 ]
 
-"pelican/tools/*.py}" = [
+"pelican/tools/*.py" = [
     # this is a command-line utility, prints are fine
     "T201"
 ]


### PR DESCRIPTION
This is just a typo fix