### PR TITLE
refactor: Use specific exceptions instead of bare `Exception`

### DIFF
--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -324,7 +324,7 @@ def handle_deprecated_settings(settings: Settings) -> Settings:
             "EXTRA_TEMPLATES_PATHS is deprecated use THEME_TEMPLATES_OVERRIDES instead."
         )
         if settings.get("THEME_TEMPLATES_OVERRIDES"):
-            raise Exception(
+            raise ValueError(
                 "Setting both EXTRA_TEMPLATES_PATHS and "
                 "THEME_TEMPLATES_OVERRIDES is not permitted. Please move to "
                 "only setting THEME_TEMPLATES_OVERRIDES."
@@ -392,7 +392,7 @@ def handle_deprecated_settings(settings: Settings) -> Settings:
         if f + "_REGEX_SUBSTITUTIONS" in settings
     }
     if old_values and new_values:
-        raise Exception(
+        raise ValueError(
             "Setting both {new_key} and {old_key} (or variants thereof) is "
             "not permitted. Please move to only setting {new_key}.".format(
                 old_key="SLUG_SUBSTITUTIONS", new_key="SLUG_REGEX_SUBSTITUTIONS"
@@ -573,7 +573,7 @@ def configure_settings(settings: Settings) -> Settings:
     Also, specify the log messages to be ignored.
     """
     if "PATH" not in settings or not os.path.isdir(settings["PATH"]):
-        raise Exception(
+        raise ValueError(
             "You need to specify a path containing the content"
             " (see pelican --help for more information)"
         )
@@ -590,7 +590,7 @@ def configure_settings(settings: Settings) -> Settings:
         if os.path.exists(theme_path):
             settings["THEME"] = theme_path
         else:
-            raise Exception("Could not find the theme {}".format(settings["THEME"]))
+            raise ValueError("Could not find the theme {}".format(settings["THEME"]))
 
     # Clear CSS_FILE if the file doesn't exist in the theme
     css_file = settings.get("CSS_FILE")

--- a/pelican/tests/test_generators.py
+++ b/pelican/tests/test_generators.py
@@ -788,7 +788,9 @@ class TestArticlesGenerator(unittest.TestCase):
             theme=settings["THEME"],
             output_path=None,
         )
-        self.assertRaises(Exception, generator.get_template, "not_a_template")
+        self.assertRaises(
+            PelicanTemplateNotFound, generator.get_template, "not_a_template"
+        )
 
     def test_generate_authors(self):
         """Check authors generation."""

--- a/pelican/tests/test_settings.py
+++ b/pelican/tests/test_settings.py
@@ -153,7 +153,7 @@ class TestSettingsConfiguration(unittest.TestCase):
 
         # Check that non-existent theme raises exception
         settings["THEME"] = "foo"
-        self.assertRaises(Exception, configure_settings, settings)
+        self.assertRaises(ValueError, configure_settings, settings)
 
     def test_deprecated_dir_setting(self):
         settings = self.settings
@@ -190,17 +190,17 @@ class TestSettingsConfiguration(unittest.TestCase):
         # test that 'PATH' is set
         settings = {}
 
-        self.assertRaises(Exception, configure_settings, settings)
+        self.assertRaises(ValueError, configure_settings, settings)
 
         # Test that 'PATH' is valid
         settings["PATH"] = ""
-        self.assertRaises(Exception, configure_settings, settings)
+        self.assertRaises(ValueError, configure_settings, settings)
 
         # Test nonexistent THEME
         settings["PATH"] = os.curdir
         settings["THEME"] = "foo"
 
-        self.assertRaises(Exception, configure_settings, settings)
+        self.assertRaises(ValueError, configure_settings, settings)
 
     def test__printf_s_to_format_field(self):
         for s in ("%s", "{%s}", "{%s"):
@@ -253,14 +253,14 @@ class TestSettingsConfiguration(unittest.TestCase):
         settings["EXTRA_TEMPLATES_PATHS"] = ["/ha"]
         settings["THEME_TEMPLATES_OVERRIDES"] = ["/foo/bar"]
 
-        self.assertRaises(Exception, handle_deprecated_settings, settings)
+        self.assertRaises(ValueError, handle_deprecated_settings, settings)
 
     def test_slug_and_slug_regex_substitutions_exception(self):
         settings = {}
         settings["SLUG_REGEX_SUBSTITUTIONS"] = [("C++", "cpp")]
         settings["TAG_SUBSTITUTIONS"] = [("C#", "csharp")]
 
-        self.assertRaises(Exception, handle_deprecated_settings, settings)
+        self.assertRaises(ValueError, handle_deprecated_settings, settings)
 
     def test_deprecated_slug_substitutions(self):
         default_slug_regex_subs = self.settings["SLUG_REGEX_SUBSTITUTIONS"]

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -384,7 +384,7 @@ def clean_output_dir(path: str, retention: Iterable[str]) -> None:
     if not os.path.isdir(path):
         try:
             os.remove(path)
-        except Exception:
+        except OSError:
             logger.exception("Unable to delete file %s", path)
         return
 
@@ -399,13 +399,13 @@ def clean_output_dir(path: str, retention: Iterable[str]) -> None:
             try:
                 shutil.rmtree(file)
                 logger.debug("Deleted directory %s", file)
-            except Exception:
+            except OSError:
                 logger.exception("Unable to delete directory %s", file)
         elif os.path.isfile(file) or os.path.islink(file):
             try:
                 os.remove(file)
                 logger.debug("Deleted file/link %s", file)
-            except Exception:
+            except OSError:
                 logger.exception("Unable to delete file %s", file)
         else:
             logger.error("Unable to delete %s, file type unknown", file)


### PR DESCRIPTION
There are numerous instances in Pelican using bare Exception even in situations where something more specific exception could (and thus should) be used. This PR tries to eliminate the most egregious ones.