### PR TITLE
Support copying files to a directory

### DIFF
--- a/pelican/tests/test_utils.py
+++ b/pelican/tests/test_utils.py
@@ -868,6 +868,18 @@ class TestCopy(unittest.TestCase):
         self._exist_dir("b0", "b1", "b2", "b3", "b")
         self._exist_file("b0", "b1", "b2", "b3", "b", "a.txt")
 
+    def test_copy_file_to_existing_dir(self):
+        self._create_dir("a")
+        self._create_file("a", "a.txt")
+        self._create_dir("b0", "b1")
+        utils.copy(
+            os.path.join(self.root_dir, "a", "a.txt"),
+            os.path.join(self.root_dir, "b0", "b1"),
+        )
+        self._exist_dir("b0")
+        self._exist_dir("b0", "b1")
+        self._exist_file("b0", "b1", "a.txt")
+
 
 class TestDateFormatter(unittest.TestCase):
     """Tests that the output of DateFormatter jinja filter is same as

--- a/pelican/utils.py
+++ b/pelican/utils.py
@@ -366,6 +366,9 @@ def copy(source: str, destination: str, ignores: Iterable[str] | None = None) ->
 
 def copy_file(source: str, destination: str) -> None:
     """Copy a file"""
+    if os.path.isdir(destination):
+        destination = os.path.join(destination, os.path.basename(source))
+
     try:
         shutil.copyfile(source, destination)
     except OSError as e:


### PR DESCRIPTION
This restores the ability for the `copy()` function to copy files to a directory. The changes are essentially the same as what is used in the [Python standard library](https://github.com/python/cpython/blob/d12f86092476dd1ed93f2de78989b1871a606c0a/Lib/shutil.py#L487).

# Pull Request Checklist

Resolves: #3442

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [x] Ensured **tests pass** and (if applicable) updated functional test output
- [x] Conformed to **code style guidelines** by running appropriate linting tools
- [x] Added **tests** for changed code
- [ ] Updated **documentation** for changed code

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing! -->
