### PR TITLE
WIP - pelican-import: Support the SyntaxHighlighter plugin.

### DIFF
--- a/pelican/tools/pelican_import.py
+++ b/pelican/tools/pelican_import.py
@@ -107,6 +107,13 @@ def decode_wp_content(content, br=True):
 
         content = _multi_replace(pre_tags, content)
 
+        # SyntaxHighlighter plugin format (on WP this is quote forgiving)
+        content = re.sub(
+            r'<pre\s+class="[^>]*\bbrush\s*:\s*([\w#+-]+)[^>]*>',
+            r'<pre class="sourceCode \1">',
+            content,
+        )
+
     # convert [caption] tags into <figure>
     content = re.sub(
         r"\[caption(?:.*?)(?:caption=\"(.*?)\")?\]"


### PR DESCRIPTION
Support the SyntaxHighlighter plugin.

This was the default syntax highlighter in wordpress for about 10 years.

Currently only supports markdown output, this looks for output like: 

\`\`\` brush: python

And coverts it to:

\`\`\`python

For my personal blog this is enough to have sane output for all the included source code from the site.

Currently only supports markdown at the moment - I'm not quite sure the best way for this to support .rst as well (not sure what these look like going through .rst)

# Pull Request Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Also, please read our [contribution guide](https://docs.getpelican.com/en/latest/contribute.html#contributing-code) at least once — it will save you unnecessary review cycles! -->

- [ ] Ensured **tests pass** and (if applicable) updated functional test output
- [ ] Conformed to **code style guidelines** by running appropriate linting tools
- [ ] Added **tests** for changed code
- [ ] Updated **documentation** for changed code
