### PR TITLE
Clarify documentation for *S_SAVE_AS vs *_SAVE_AS

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+- Minor documentation improvement to clarify how to prevent listing pages from being generated.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -687,6 +687,10 @@ template.
 
    The location to save the list of all articles. The default is ``"index.html"``.
 
+Note
+
+If you do not want one or more of the list pages to be created (e.g., you are the only author on your site and thus do not need a listing of Authors), set the corresponding *_SAVE_AS setting to "" to prevent the relevant page from being generated.
+
 URLs for direct template pages are theme-dependent. Some themes use
 corresponding ``*_URL`` setting as string, while others hard-code them:
 ``"archives.html"``, ``"authors.html"``, ``"categories.html"``,

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -694,7 +694,6 @@ template.
 
    The location to save the list of all articles. The default is ``"index.html"``.
 
-
 URLs for direct template pages are theme-dependent. Some themes use
 corresponding ``*_URL`` setting as string, while others hard-code them:
 ``"archives.html"``, ``"authors.html"``, ``"categories.html"``,

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -687,7 +687,7 @@ template.
 
     If you do not want one or more of the list pages to be created (e.g.,
     you are the only author on your site and thus do not need a listing of 
-    Authors), set the corresponding `*S_SAVE_AS` setting to `""` to prevent the 
+    Authors), set the corresponding ``*S_SAVE_AS`` setting to ``""`` to prevent the 
     relevant page from being generated.
 
 .. data:: INDEX_SAVE_AS

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -683,16 +683,17 @@ template.
 
    The location to save the tag list. The default is ``"tags.html"``.
 
-.. data:: INDEX_SAVE_AS
-
-   The location to save the list of all articles. The default is ``"index.html"``.
-
 .. note::
 
     If you do not want one or more of the list pages to be created (e.g.,
     you are the only author on your site and thus do not need a listing of 
-    Authors), set the corresponding *_SAVE_AS setting to "" to prevent the 
+    Authors), set the corresponding `*S_SAVE_AS` setting to `""` to prevent the 
     relevant page from being generated.
+
+.. data:: INDEX_SAVE_AS
+
+   The location to save the list of all articles. The default is ``"index.html"``.
+
 
 URLs for direct template pages are theme-dependent. Some themes use
 corresponding ``*_URL`` setting as string, while others hard-code them:

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -687,9 +687,12 @@ template.
 
    The location to save the list of all articles. The default is ``"index.html"``.
 
-Note
+.. note::
 
-If you do not want one or more of the list pages to be created (e.g., you are the only author on your site and thus do not need a listing of Authors), set the corresponding *_SAVE_AS setting to "" to prevent the relevant page from being generated.
+    If you do not want one or more of the list pages to be created (e.g.,
+    you are the only author on your site and thus do not need a listing of 
+    Authors), set the corresponding *_SAVE_AS setting to "" to prevent the 
+    relevant page from being generated.
 
 URLs for direct template pages are theme-dependent. Some themes use
 corresponding ``*_URL`` setting as string, while others hard-code them:


### PR DESCRIPTION
When generating a simple static site, I wanted to not have the listings page, such as `authors.html` not be generated. I read through the docs and noted that `AUTHOR_SAVE_AS` would not generate an Authors page, but I couldn't stop `authors.html` from being generated. I didn't spot the difference between `AUTHOR_SAVE_AS=""` and `AUTHORS_SAVE_AS=""`.

`AUTHORS_SAVE_AS=""` is needed to stop the `authors.html` page from being generated. I couldn't spot a matching note in the docs about this, so this added in note hopefully clarifies it a bit.
